### PR TITLE
fix: robustness, safety, and performance improvements across upload, rename, and macOS mount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +99,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -118,6 +142,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -166,6 +201,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +240,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "dav-server"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88e9e4e7a3546a5b348518694e9f3ed5cf3fc8856e50141c197f54d79b5714a8"
+dependencies = [
+ "bytes",
+ "chrono",
+ "derive-where",
+ "dyn-clone",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "htmlescape",
+ "http",
+ "http-body",
+ "http-body-util",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "url",
+ "uuid",
+ "xml-rs",
+ "xmltree",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +308,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -269,6 +384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,9 +407,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -342,10 +479,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -387,6 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +572,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -445,6 +619,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -731,6 +929,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,7 +1101,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1169,6 +1376,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,7 +1478,11 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "dav-server",
  "fuser",
+ "futures-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "moka",
  "reqwest",
@@ -1494,6 +1716,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1785,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1736,10 +1970,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1925,6 +2212,30 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xml"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
+name = "xml-rs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a56132a0d6ecbe77352edc10232f788fc4ceefefff4cab784a98e0e16b6b51"
+dependencies = [
+ "xml",
+]
+
+[[package]]
+name = "xmltree"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc04313cab124e498ab1724e739720807b6dc405b9ed0edc5860164d2e4ff70"
+dependencies = [
+ "xml",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,10 @@ name = "synology-filestation-fuse"
 path = "src/main.rs"
 
 [dependencies]
-fuser       = "0.15"
 tokio       = { version = "1", features = ["full"] }
 reqwest     = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
-moka        = { version = "0.12", features = ["sync"] }
 clap        = { version = "4", features = ["derive", "env"] }
 libc        = "0.2"
 anyhow      = "1"
@@ -21,3 +19,13 @@ tracing     = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 bytes       = "1"
 rpassword   = "7"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+fuser = "0.15"
+moka  = { version = "0.12", features = ["sync"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+dav-server   = { version = "0.11", default-features = false }
+hyper        = { version = "1", features = ["http1", "server"] }
+hyper-util   = { version = "0.1", features = ["tokio"] }
+futures-util = "0.3"

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The mountpoint root is a synthetic directory that does not correspond to any rea
 
 ### macOS WebDAV backend
 
-On macOS the binary starts a local HTTP server (`127.0.0.1:<random port>`) that speaks WebDAV, then calls the macOS built-in `mount_webdav` to attach it at the requested mountpoint. This uses Apple's own `webdavfs` kernel support — no third-party kernel extension is required. The process exits cleanly on Ctrl-C or when the volume is ejected from Finder.
+On macOS the binary starts a local HTTP server (`127.0.0.1:<random port>`) that speaks WebDAV, then uses AppleScript (`osascript -e 'mount volume …'`) to ask Finder to attach it at the requested mountpoint. This uses Apple's own `webdavfs` kernel support — no third-party kernel extension is required. The process exits cleanly on Ctrl-C or when the volume is ejected from Finder.
 
 WebDAV operations map to FileStation API calls:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # synology-fuse
 
-A FUSE filesystem driver that mounts a [Synology FileStation](https://www.synology.com/en-global/dsm/feature/file_station) share as a local directory on Linux and macOS. Written in Rust.
+A filesystem driver that mounts a [Synology FileStation](https://www.synology.com/en-global/dsm/feature/file_station) share as a local directory. Written in Rust.
+
+- **Linux** — FUSE via the `fuser` crate
+- **macOS** — local WebDAV proxy; no kernel extension required
 
 ## Features
 
@@ -8,29 +11,24 @@ A FUSE filesystem driver that mounts a [Synology FileStation](https://www.synolo
 - Read and write files
 - Create and delete files and directories
 - Rename files (same-directory) and move files (cross-directory)
-- Truncate files via `setattr`
-- Metadata cache with configurable TTL to reduce API round-trips
-- Block-level read cache (default 256 MiB) with background prefetch for smooth streaming playback
 - Interactive password prompt with hidden input when password is not set via flag or environment variable
+- 2FA / TOTP support
 - Uses `rustls` — no OpenSSL dependency required
+- **Linux:** metadata cache with configurable TTL; block-level read cache (default 256 MiB) with background prefetch
+- **macOS:** no kernel extension; uses macOS's built-in WebDAV filesystem support
 
 ## Requirements
 
 ### System
 
-| Platform | Requirement |
-|---|---|
-| Linux | FUSE support (`/dev/fuse`); `libfuse3-3` runtime (Ubuntu/Debian) |
-| macOS (kext) | [macFUSE](https://macfuse.io) 4.0+ — requires allowing a system extension in Recovery Mode |
-| macOS (FSKit) | [macFUSE](https://macfuse.io) 5.0+ and macOS 15.4+ — one-time approval in System Settings → Privacy & Security → Extensions; no Recovery Mode required |
-
-All platforms require a Synology NAS running DSM with FileStation API enabled.
+- **Linux:** kernel with FUSE support (`/dev/fuse`) and `libfuse3` runtime (`libfuse3-3` on Ubuntu/Debian)
+- **macOS:** macOS 10.15+ (no third-party kernel extension needed)
+- A Synology NAS running DSM with FileStation API enabled
 
 ### Build
 
 - Rust toolchain (1.70+) — install via [rustup](https://rustup.rs)
-- Linux: `libfuse3-dev` (Ubuntu/Debian) or `fuse3-devel` (Fedora/RHEL)
-- macOS: macFUSE 5.0+ (`brew install --cask macfuse`)
+- **Linux only:** `libfuse3-dev` (Ubuntu/Debian) or `fuse3-devel` (Fedora/RHEL)
 
 ```bash
 # Ubuntu / Debian
@@ -38,10 +36,9 @@ sudo apt-get install libfuse3-dev
 
 # Fedora / RHEL
 sudo dnf install fuse3-devel
-
-# macOS (requires Homebrew)
-brew install --cask macfuse
 ```
+
+macOS requires no additional build dependencies.
 
 ## Building
 
@@ -61,24 +58,27 @@ synology-filestation-fuse --host <NAS_HOST> -u <USERNAME> [OPTIONS] <MOUNTPOINT>
 
 | Argument | Description | Default |
 |---|---|---|
-| `<MOUNTPOINT>` | Local directory to mount on | *(required)* |
+| `<MOUNTPOINT>` | Directory to mount on. On macOS must be under `/Volumes/` (e.g. `/Volumes/nas`) | *(required)* |
 | `--host <HOST>` | NAS hostname or IP address | *(required)* |
 | `-u, --username` | NAS account username | *(required)* |
 | `-p, --password` | NAS account password (or `SYNO_PASSWORD` env var; prompted with hidden input if omitted) | *(optional)* |
 | `--otp <CODE>` | TOTP code for 2FA (or `SYNO_OTP` env var); prompted interactively if omitted and 2FA is enabled | *(optional)* |
 | `--port <PORT>` | API port | `5001` |
 | `--https` | Use HTTPS | `true` |
-| `--cache-ttl <SECS>` | Metadata cache TTL in seconds | `30` |
-| `--read-cache-mb <MiB>` | Read cache size in MiB for file data blocks | `256` |
+| `--cache-ttl <SECS>` | Metadata cache TTL in seconds *(Linux only)* | `30` |
+| `--read-cache-mb <MiB>` | Read cache size in MiB *(Linux only)* | `256` |
 | `--log-level <LEVEL>` | Log level (`error`, `warn`, `info`, `debug`, `trace`) | `info` |
-| `--fskit` | *(macOS only)* Use macFUSE FSKit backend — no kernel extension approval needed; requires macOS 15.4+ and macFUSE 5.0+; mount point must be inside `/Volumes` | `false` |
 
 ### Examples
 
 ```bash
 # Mount — password will be prompted securely if not supplied
+# Linux
 mkdir -p /mnt/nas
 synology-filestation-fuse --host 192.168.1.100 -u admin /mnt/nas
+
+# macOS (mountpoint must be under /Volumes/)
+synology-filestation-fuse --host 192.168.1.100 -u admin /Volumes/nas
 # Password: ********
 
 # Pass password via flag
@@ -101,7 +101,7 @@ synology-filestation-fuse --host 192.168.1.100 -u admin /mnt/nas
 # Mount over plain HTTP (DSM default HTTP port)
 synology-filestation-fuse --host 192.168.1.100 --port 5000 --no-https -u admin /mnt/nas
 
-# Larger read cache for smoother playback of large video files
+# Linux: larger read cache for smoother playback of large video files
 synology-filestation-fuse --host nas.local -u admin --read-cache-mb 512 /mnt/nas
 
 # Enable debug logging
@@ -110,18 +110,8 @@ synology-filestation-fuse --host nas.local -u admin --log-level debug /mnt/nas
 # Unmount (Linux)
 fusermount -u /mnt/nas
 
-# Unmount (macOS)
-umount /mnt/nas
-
-# macOS with FSKit backend (macFUSE 5.0+, macOS 15.4+).
-# Mount point must be inside /Volumes.
-# First use: approve the macFUSE extension in
-#   System Settings → Privacy & Security → Extensions → File System Extensions
-# then restart. No Recovery Mode required.
-mkdir /Volumes/nas
-synology-filestation-fuse --host nas.local -u admin --fskit /Volumes/nas
-# Unmount
-umount /Volumes/nas
+# Unmount (macOS — or eject in Finder)
+diskutil unmount /Volumes/nas
 ```
 
 ## Architecture
@@ -129,53 +119,58 @@ umount /Volumes/nas
 ```
 synology-fuse/
 └── src/
-    ├── main.rs     CLI argument parsing, Tokio runtime setup, fuser::mount2
-    ├── fs.rs       fuser::Filesystem trait implementation (all FUSE operations)
+    ├── main.rs     CLI argument parsing, Tokio runtime, platform dispatch
     ├── client.rs   Async Synology FileStation HTTP API client
-    ├── cache.rs    Inode ↔ path metadata cache + block-level read cache
     ├── types.rs    Serde types for API JSON responses
-    └── error.rs    Synology API error code → POSIX errno translation
+    ├── error.rs    Synology API error code → POSIX errno translation
+    ├── fs.rs       fuser::Filesystem trait (Linux FUSE backend)
+    ├── cache.rs    Inode ↔ path metadata cache + block-level read cache (Linux)
+    └── webdav.rs   dav_server::DavFileSystem trait (macOS WebDAV backend)
 ```
 
 ### Virtual root
 
-The mountpoint root (inode 1) is a synthetic directory that does not correspond to any real path on the NAS. Reading it calls `SYNO.FileStation.List list_share` to enumerate all shares the authenticated account can see. Each share appears as a subdirectory.
+The mountpoint root is a synthetic directory that does not correspond to any real path on the NAS. Reading it calls `SYNO.FileStation.List list_share` to enumerate all shares the authenticated account can see. Each share appears as a subdirectory.
 
-### Sync/async bridge
+### macOS WebDAV backend
 
-The FUSE dispatch loop (inside `fuser::mount2`) is synchronous and single-threaded. All Synology API calls are async via `reqwest`. The driver bridges these by holding a `tokio::runtime::Handle` and calling `handle.block_on(future)` inside each FUSE callback. A multi-thread Tokio runtime is used so that background prefetch tasks can run on worker threads while the FUSE thread is blocked on a foreground download.
+On macOS the binary starts a local HTTP server (`127.0.0.1:<random port>`) that speaks WebDAV, then calls the macOS built-in `mount_webdav` to attach it at the requested mountpoint. This uses Apple's own `webdavfs` kernel support — no third-party kernel extension is required. The process exits cleanly on Ctrl-C or when the volume is ejected from Finder.
 
-### Read cache
+WebDAV operations map to FileStation API calls:
 
-File data is cached in fixed-size 256 KiB blocks using a `moka` LRU cache (default capacity 256 MiB). On `open()`, the first block is downloaded synchronously (guaranteeing an immediate cache hit on the first `read()`) and the next 15 blocks plus the last 4 blocks are prefetched asynchronously in the background. During `read()`, the next 16 blocks are prefetched. An in-flight deduplication mechanism prevents multiple concurrent HTTP requests for the same block. The read cache is invalidated on write, rename, or delete.
+| WebDAV | FileStation |
+|---|---|
+| `PROPFIND /` | `list_share` |
+| `PROPFIND /path` | `getinfo` + `list` |
+| `GET /path` (Range) | `download` |
+| `PUT /path` | `upload` |
+| `DELETE /path` | `delete` |
+| `MKCOL /path` | `CreateFolder` |
+| `MOVE` (same dir) | `rename` |
+| `MOVE` (cross dir) | `download` → `upload` → `delete` |
 
-### Write buffering
+### Linux FUSE backend
 
-The Synology Upload API requires the complete file body as a single multipart upload; it does not support partial or streaming writes. As a result:
+The FUSE dispatch loop (inside `fuser::mount2`) is synchronous. All Synology API calls are async via `reqwest`. The driver bridges these by holding a `tokio::runtime::Handle` and calling `handle.block_on(future)` inside each FUSE callback.
 
-- Write data is accumulated in an in-memory buffer per open file handle.
-- The buffer is flushed to the NAS on `flush()` or `release()`.
-- Overwriting an existing file deletes it first, then re-uploads the new content.
-- Large file writes consume proportional memory.
+File data is cached in fixed-size 256 KiB blocks using a `moka` LRU cache (default 256 MiB). Background prefetch of the next 16 blocks keeps streaming reads smooth.
 
-### Metadata cache
+### Write buffering (both platforms)
 
-File and directory metadata is cached in a `moka` TTL cache (default 30 seconds). This reduces API calls for repeated `stat`/`readdir` operations. Mutation operations (create, delete, rename) immediately invalidate the relevant cache entries.
+The Synology Upload API requires the complete file body as a single multipart upload. Write data is accumulated in an in-memory buffer per open file handle and flushed to the NAS on close. Large file writes consume proportional memory.
 
 ## Known Limitations
 
-- **macOS FSKit backend is experimental.** Performance is lower than the kernel extension path and some operations may be unreliable. Requires macOS 15.4+ and macFUSE 5.0+. Mount point must be inside `/Volumes`.
 - **Cross-directory directory moves are not supported.** Moving a directory to a different parent returns `ENOSYS`. Only same-directory renames use the efficient `SYNO.FileStation.Rename` API.
 - **Cross-directory file moves are not atomic.** They are implemented as download → upload → delete. A failure mid-sequence may leave data duplicated or missing.
 - **Large files require large in-memory write buffers.** Writing to a file buffers the entire file content in process memory until the file is closed or flushed.
 - **Overwriting a file is not atomic.** The existing file is deleted before the new content is uploaded; a crash between those two steps would result in data loss.
-- **Inode numbers are not stable across remounts.** Inodes are allocated in-memory and reset on each mount.
 - **No support for symlinks, hard links, or special files.**
-- **Permissions and timestamps are read-only.** `chmod`, `chown`, and `utimens` will appear to succeed but changes are not persisted to the NAS.
+- **Linux only:** Inode numbers are not stable across remounts. Permissions and timestamps are read-only (`chmod`, `chown`, `utimens` appear to succeed but are not persisted).
 
 ## Synology API Reference
 
-All requests go to `/webapi/entry.cgi` (authentication uses `/webapi/auth.cgi`). The driver uses the following API methods:
+All requests go to `/webapi/entry.cgi` (authentication uses `/webapi/auth.cgi`).
 
 | Operation | API | Method |
 |---|---|---|

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -222,6 +222,14 @@ impl ReadCache {
         }
     }
 
+    /// Evict a single cached block (e.g. a stale EOF sentinel).
+    pub fn invalidate_block(&self, ino: u64, block_idx: u64) {
+        self.blocks.invalidate(&(ino, block_idx));
+        if let Some(set) = self.ino_blocks.write().unwrap().get_mut(&ino) {
+            set.remove(&block_idx);
+        }
+    }
+
     /// Evict all cached blocks for `ino` (call after writing or deleting a file).
     pub fn invalidate_ino(&self, ino: u64) {
         let indices = self.ino_blocks.write().unwrap().remove(&ino);

--- a/src/client.rs
+++ b/src/client.rs
@@ -264,11 +264,13 @@ impl SynologyClient {
     }
 
     /// Upload file contents (replaces entire file).
+    /// Accepts `Bytes` so that retry attempts share the same backing buffer
+    /// (cheap `clone`) rather than making a full copy of the data each time.
     pub async fn upload(
         &self,
         folder_path: &str,
         filename: &str,
-        data: Vec<u8>,
+        data: Bytes,
         overwrite: bool,
     ) -> Result<(), SynoFsError> {
         let url = format!("{}/entry.cgi", self.base_url);
@@ -317,7 +319,8 @@ impl SynologyClient {
                 debug!("upload retry {} for {}/{}", attempt, folder_path, filename);
             }
 
-            let file_part = multipart::Part::bytes(data.clone())
+            // Clone is O(1) for `Bytes` (just bumps the reference count).
+            let file_part = multipart::Part::stream_with_length(data.clone(), data.len() as u64)
                 .file_name(filename.to_string())
                 .mime_str("application/octet-stream")
                 .map_err(|e| SynoFsError::Io(e.to_string()))?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,6 +26,13 @@ impl SynologyClient {
             // Drop idle connections after 4 s so we don't reuse connections the NAS
             // has already closed on its side (~7 s keep-alive on most DSM versions).
             .pool_idle_timeout(Duration::from_secs(4))
+            // Fail fast if the NAS is unreachable rather than waiting for the OS-level
+            // TCP timeout (~75 s on macOS, ETIMEDOUT / os error 60).
+            .connect_timeout(Duration::from_secs(10))
+            // Send TCP keepalive probes so stalled mid-transfer connections are
+            // detected in seconds rather than waiting for the full OS TCP timeout
+            // (~75 s on macOS, ETIMEDOUT / os error 60).
+            .tcp_keepalive(Duration::from_secs(10))
             .build()
             .expect("failed to build HTTP client");
         Self { http, base_url, sid: RwLock::new(None) }
@@ -283,40 +290,55 @@ impl SynologyClient {
             }
         }
 
-        let file_part = multipart::Part::bytes(data)
-            .file_name(filename.to_string())
-            .mime_str("application/octet-stream")
-            .map_err(|e| SynoFsError::Io(e.to_string()))?;
+        let mut last_err = SynoFsError::Io("no attempts".into());
+        for attempt in 0..3u8 {
+            if attempt > 0 {
+                debug!("upload retry {} for {}/{}", attempt, folder_path, filename);
+            }
 
-        let form = multipart::Form::new()
-            .text("api", "SYNO.FileStation.Upload")
-            .text("version", "3")
-            .text("method", "upload")
-            .text("path", folder_path.to_string())
-            .text("create_parents", "true")
-            .text("overwrite", "false")
-            .part("file", file_part);
+            let file_part = multipart::Part::bytes(data.clone())
+                .file_name(filename.to_string())
+                .mime_str("application/octet-stream")
+                .map_err(|e| SynoFsError::Io(e.to_string()))?;
 
-        let text = self.http
-            .post(&url)
-            .query(&[("_sid", self.sid())])
-            .multipart(form)
-            .send()
-            .await?
-            .text()
-            .await?;
+            let form = multipart::Form::new()
+                .text("api", "SYNO.FileStation.Upload")
+                .text("version", "3")
+                .text("method", "upload")
+                .text("path", folder_path.to_string())
+                .text("create_parents", "true")
+                .text("overwrite", "false")
+                .part("file", file_part);
 
-        debug!("upload raw response: {}", text);
+            let resp = match self.http
+                .post(&url)
+                .query(&[("_sid", self.sid())])
+                .multipart(form)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => { last_err = e.into(); continue; }
+            };
 
-        let resp: SynoResponse<UploadData> = serde_json::from_str(&text)
-            .map_err(|e| SynoFsError::Io(format!("upload parse error: {e}")))?;
+            let text = match resp.text().await {
+                Ok(t) => t,
+                Err(e) => { last_err = e.into(); continue; }
+            };
 
-        if resp.success {
-            Ok(())
-        } else {
-            let code = resp.error.map(|e| e.code).unwrap_or(0);
-            Err(SynoFsError::ApiError(code))
+            debug!("upload raw response: {}", text);
+
+            let parsed: SynoResponse<UploadData> = serde_json::from_str(&text)
+                .map_err(|e| SynoFsError::Io(format!("upload parse error: {e}")))?;
+
+            return if parsed.success {
+                Ok(())
+            } else {
+                let code = parsed.error.map(|e| e.code).unwrap_or(0);
+                Err(SynoFsError::ApiError(code))
+            };
         }
+        Err(last_err)
     }
 
     /// Delete a file or directory (recursive for directories).

--- a/src/client.rs
+++ b/src/client.rs
@@ -277,7 +277,7 @@ impl SynologyClient {
             // gone (or inaccessible) before uploading, to avoid 418 AlreadyExists.
             for _ in 0..10u8 {
                 match self.get_info(&full_path).await {
-                    Ok(_) => tokio::time::sleep(Duration::from_millis(500)).await,
+                    Ok(_) => tokio::time::sleep(Duration::from_millis(50)).await,
                     Err(_) => break, // gone or inaccessible — safe to upload
                 }
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,7 @@ use crate::types::{
     SynoFileInfo, SynoResponse, ADDITIONAL_FIELDS, SHARE_ADDITIONAL_FIELDS,
 };
 
+#[derive(Debug)]
 pub struct SynologyClient {
     http: Client,
     base_url: String,
@@ -271,6 +272,15 @@ impl SynologyClient {
         if overwrite {
             let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
             let _ = self.delete(&full_path).await; // ignore error — file may not exist yet
+
+            // Synology Delete is async on modern DSM: poll get_info until the file is
+            // gone (or inaccessible) before uploading, to avoid 418 AlreadyExists.
+            for _ in 0..10u8 {
+                match self.get_info(&full_path).await {
+                    Ok(_) => tokio::time::sleep(Duration::from_millis(500)).await,
+                    Err(_) => break, // gone or inaccessible — safe to upload
+                }
+            }
         }
 
         let file_part = multipart::Part::bytes(data)

--- a/src/client.rs
+++ b/src/client.rs
@@ -282,10 +282,31 @@ impl SynologyClient {
 
             // Synology Delete is async on modern DSM: poll get_info until the file is
             // gone (or inaccessible) before uploading, to avoid 418 AlreadyExists.
-            for _ in 0..10u8 {
+            for attempt in 0..10u8 {
                 match self.get_info(&full_path).await {
-                    Ok(_) => tokio::time::sleep(Duration::from_millis(50)).await,
-                    Err(_) => break, // gone or inaccessible — safe to upload
+                    // File still present: wait a bit and poll again.
+                    Ok(_) => {
+                        tokio::time::sleep(Duration::from_millis(50 * (attempt as u64 + 1))).await;
+                    }
+                    Err(err) => {
+                        match err {
+                            // Definitive "not found" / already gone: safe to proceed.
+                            SynoFsError::NotFound
+                            | SynoFsError::ApiError(414 | 415) => {
+                                break;
+                            }
+                            // Transient or other errors: keep polling until attempts exhausted.
+                            _ => {
+                                debug!(
+                                    "get_info error while waiting for delete of {}: {:?} (attempt {}), retrying",
+                                    full_path,
+                                    err,
+                                    attempt
+                                );
+                                tokio::time::sleep(Duration::from_millis(50 * (attempt as u64 + 1))).await;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -280,7 +280,14 @@ impl SynologyClient {
         // Delete the existing file first so we can always upload with overwrite=false.
         if overwrite {
             let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
-            let _ = self.delete(&full_path).await; // ignore error — file may not exist yet
+            // Surface non-NotFound delete errors rather than masking them with
+            // a misleading AlreadyExists/upload error later.
+            match self.delete(&full_path).await {
+                Ok(()) => {}
+                // Treat these as "already gone": proceed to the poll loop.
+                Err(SynoFsError::NotFound) | Err(SynoFsError::ApiError(414 | 415)) => {}
+                Err(e) => return Err(e),
+            }
 
             // Synology Delete is async on modern DSM: poll get_info until the file is
             // gone (or inaccessible) before uploading, to avoid 418 AlreadyExists.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "linux")]
 use libc::{EACCES, EAGAIN, EEXIST, EINVAL, EIO, ENOENT, ENOTEMPTY, ENOSPC, ENOSYS};
 
 #[derive(Debug)]
@@ -16,6 +17,7 @@ pub enum SynoFsError {
 }
 
 impl SynoFsError {
+    #[cfg(target_os = "linux")]
     pub fn to_errno(&self) -> i32 {
         match self {
             Self::NotFound => ENOENT,
@@ -31,6 +33,7 @@ impl SynoFsError {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn syno_code_to_errno(code: u32) -> i32 {
     match code {
         // Common FileStation errors
@@ -88,7 +91,7 @@ impl From<serde_json::Error> for SynoFsError {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "linux"))]
 mod tests {
     use super::*;
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -8,7 +8,7 @@ use fuser::{
     FileAttr, FileType, Filesystem, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory,
     ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
 };
-use libc::{EIO, ENOENT, ENOSYS};
+use libc::{EISDIR, EIO, ENOENT, ENOTEMPTY, ENOSYS, ENOTDIR};
 use tracing::{debug, error, info, warn};
 
 use crate::cache::{InodeCache, ReadCache};

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use bytes::Bytes;
 use fuser::{
     FileAttr, FileType, Filesystem, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory,
     ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
@@ -155,7 +156,7 @@ impl SynologyFS {
 
         let nas_path = buf.nas_path.clone();
         let ino = buf.ino;
-        let data = std::mem::take(&mut buf.data);
+        let data = Bytes::from(std::mem::take(&mut buf.data));
         let overwrite = !buf.new_file;
         buf.dirty = false;
 
@@ -205,7 +206,7 @@ impl SynologyFS {
             }
             let path = buf.nas_path.clone();
             let ino = buf.ino;
-            let data = buf.data.clone();
+            let data = Bytes::from(std::mem::take(&mut buf.data));
             let overwrite = !buf.new_file;
             buf.dirty = false;
             (handle, true, path, ino, data, overwrite)
@@ -684,9 +685,17 @@ impl Filesystem for SynologyFS {
         reply: ReplyEmpty,
     ) {
         debug!("flush: fh={}", fh);
-        // Kick off the upload in the background; release() will wait for completion.
+        // Kick off the upload and wait for completion so that any errors
+        // are reported back to the caller of close(2) via flush, as FUSE expects.
         self.queue_upload(fh);
-        reply.ok();
+        let result = self.finish_upload(fh);
+        match result {
+            Ok(()) => reply.ok(),
+            Err(e) => {
+                error!("flush fh={}: {}", fh, e);
+                reply.error(e.to_errno());
+            }
+        }
     }
 
     fn release(
@@ -965,8 +974,21 @@ impl Filesystem for SynologyFS {
             return;
         }
 
-        // Cross-directory file move: download, upload, delete
-        // Get the file size first
+        // Cross-directory file move: check destination type, then download→upload→delete.
+        // Check if the destination exists and is a directory; if so, refuse.
+        match self.block(self.client.get_info(&new_path)) {
+            Ok(dst_info) if dst_info.isdir => {
+                reply.error(EISDIR);
+                return;
+            }
+            Ok(_) => {} // destination is a file: safe to overwrite
+            // Synology FileStation API code 414 = "No such file or directory",
+            // 415 = "No such folder": destination simply does not exist, proceed.
+            Err(SynoFsError::NotFound) | Err(SynoFsError::ApiError(414 | 415)) => {} // destination doesn't exist
+            Err(e) => { reply.error(e.to_errno()); return; }
+        }
+
+        // Get the file size for the source
         let file_size = self.cache.get_by_ino(
             self.cache.get_or_alloc_ino(&old_path)
         ).and_then(|e| e.info.additional.as_ref()?.size).unwrap_or(0);
@@ -976,7 +998,7 @@ impl Filesystem for SynologyFS {
             Err(e) => { reply.error(e.to_errno()); return; }
         };
 
-        match self.block(self.client.upload(&new_parent_path, new_name_str, data.to_vec(), true)) {
+        match self.block(self.client.upload(&new_parent_path, new_name_str, data, true)) {
             Ok(()) => {}
             Err(e) => { reply.error(e.to_errno()); return; }
         }
@@ -1032,7 +1054,7 @@ impl Filesystem for SynologyFS {
             let parent = path.rfind('/').map(|i| &path[..i]).unwrap_or("/");
             let filename = &path[path.rfind('/').unwrap_or(0) + 1..];
 
-            match self.block(self.client.upload(parent, filename, data, true)) {
+            match self.block(self.client.upload(parent, filename, Bytes::from(data), true)) {
                 Ok(()) => {
                     self.read_cache.invalidate_ino(ino);
                     self.cache.invalidate_path(&path);

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -868,8 +868,10 @@ impl Filesystem for SynologyFS {
         debug!("rename: {} -> {}", old_path, new_path);
 
         // Same directory: use the efficient Rename API.
-        // POSIX rename(2) must atomically replace the destination if it exists.
-        // The Synology Rename API does not overwrite — delete the destination first.
+        // POSIX rename(2) atomically replaces the destination if it exists, but the
+        // Synology Rename API cannot overwrite. We approximate POSIX "replace"
+        // semantics by deleting the destination first, then renaming, which is not
+        // fully atomic and can lose the destination if a crash occurs between steps.
         if parent == new_parent {
             if old_path != new_path {
                 if let Some(ino) = self.cache.get_ino_for_path(&new_path) {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -874,11 +874,17 @@ impl Filesystem for SynologyFS {
         // fully atomic and can lose the destination if a crash occurs between steps.
         if parent == new_parent {
             if old_path != new_path {
-                // Determine source type (file vs. directory) from the metadata cache.
+                // Determine source type (file vs. directory).  Prefer the metadata cache;
+                // fall back to an API call if the entry was TTL-evicted so we never
+                // silently default to "file" for a directory source.
                 let src_ino = self.cache.get_or_alloc_ino(&old_path);
-                let src_is_dir = self.cache.get_by_ino(src_ino)
-                    .map(|e| e.info.isdir)
-                    .unwrap_or(false);
+                let src_is_dir = match self.cache.get_by_ino(src_ino) {
+                    Some(entry) => entry.info.isdir,
+                    None => match self.block(self.client.get_info(&old_path)) {
+                        Ok(info) => info.isdir,
+                        Err(e) => { reply.error(e.to_errno()); return; }
+                    },
+                };
 
                 // Check what is at the destination and enforce POSIX rename(2) semantics.
                 match self.block(self.client.get_info(&new_path)) {
@@ -917,8 +923,9 @@ impl Filesystem for SynologyFS {
                             return;
                         }
                     }
+                    // API codes 414 ("No such file") and 415 ("No such folder") mean the
+                    // destination does not exist — nothing to remove.
                     Err(SynoFsError::NotFound | SynoFsError::ApiError(414 | 415)) => {
-                        // Destination does not exist — nothing to remove.
                         self.cache.invalidate_path(&new_path);
                     }
                     Err(e) => {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -26,6 +26,11 @@ struct WriteBuffer {
     ino: u64,
     data: Vec<u8>,
     dirty: bool,
+    /// True when the file was just created and has not yet been uploaded.
+    /// Allows flush to use overwrite=false, skipping the delete-before-upload round trips.
+    new_file: bool,
+    /// In-flight background upload spawned by flush(); waited on in release().
+    upload_handle: Option<tokio::task::JoinHandle<Result<(), SynoFsError>>>,
 }
 
 pub struct SynologyFS {
@@ -138,19 +143,79 @@ impl SynologyFS {
         self.cache.get_path_for_ino(ino)
     }
 
-    fn flush_write_buffer(&self, fh: u64) -> Result<(), SynoFsError> {
-        let (nas_path, ino, data) = {
+    /// Spawn a background upload for `fh` if the buffer is dirty.
+    /// Returns immediately; the actual upload runs on the tokio runtime.
+    /// `release` / `destroy` must call `finish_upload` to wait for completion.
+    fn queue_upload(&self, fh: u64) {
+        let mut buffers = self.write_buffers.lock().unwrap();
+        let buf = match buffers.get_mut(&fh) {
+            Some(b) if b.dirty && b.upload_handle.is_none() => b,
+            _ => return,
+        };
+
+        let nas_path = buf.nas_path.clone();
+        let ino = buf.ino;
+        let data = buf.data.clone();
+        let overwrite = !buf.new_file;
+        buf.dirty = false;
+
+        let parent = match nas_path.rfind('/') {
+            Some(i) => nas_path[..i].to_string(),
+            None => return,
+        };
+        let filename = nas_path[nas_path.rfind('/').unwrap() + 1..].to_string();
+
+        debug!("queue_upload: fh={} parent={:?} filename={:?} size={}", fh, parent, filename, data.len());
+
+        let client = self.client.clone();
+        let cache = self.cache.clone();
+        let read_cache = self.read_cache.clone();
+        let path_for_task = nas_path.clone();
+
+        // Spawn the upload; hold the mutex so the handle is stored before release() can run.
+        let handle = self.rt.spawn(async move {
+            let result = client.upload(&parent, &filename, data, overwrite).await;
+            cache.invalidate_path(&path_for_task);
+            read_cache.invalidate_ino(ino);
+            result
+        });
+
+        buf.upload_handle = Some(handle);
+    }
+
+    /// Wait for any in-flight upload for `fh`, and synchronously upload any
+    /// remaining dirty data.  Called from `release` and `destroy`.
+    fn finish_upload(&self, fh: u64) -> Result<(), SynoFsError> {
+        // Extract both the handle and dirty state without holding the lock while blocking.
+        let (handle, dirty, nas_path, ino, data, overwrite) = {
             let mut buffers = self.write_buffers.lock().unwrap();
             let buf = match buffers.get_mut(&fh) {
-                Some(b) if b.dirty => b,
-                _ => return Ok(()),
+                Some(b) => b,
+                None => return Ok(()),
             };
+            let handle = buf.upload_handle.take();
+            if !buf.dirty {
+                // Nothing new to upload — just wait for any in-flight task.
+                drop(buffers);
+                return if let Some(h) = handle {
+                    self.block(h).map_err(|_| SynoFsError::Io("upload task panicked".into()))?
+                } else {
+                    Ok(())
+                };
+            }
             let path = buf.nas_path.clone();
             let ino = buf.ino;
             let data = buf.data.clone();
+            let overwrite = !buf.new_file;
             buf.dirty = false;
-            (path, ino, data)
+            (handle, true, path, ino, data, overwrite)
         };
+        let _ = dirty; // used implicitly — we only reach here when dirty was true
+
+        // Wait for any in-flight upload of older data before uploading the newer data.
+        if let Some(h) = handle {
+            self.block(h).map_err(|_| SynoFsError::Io("upload task panicked".into()))??;
+        }
 
         let parent = match nas_path.rfind('/') {
             Some(i) => &nas_path[..i],
@@ -158,8 +223,8 @@ impl SynologyFS {
         };
         let filename = &nas_path[nas_path.rfind('/').unwrap() + 1..];
 
-        debug!("flush_write_buffer: fh={} parent={:?} filename={:?} size={}", fh, parent, filename, data.len());
-        self.block(self.client.upload(parent, filename, data, true))?;
+        debug!("finish_upload: fh={} parent={:?} filename={:?} size={}", fh, parent, filename, data.len());
+        self.block(self.client.upload(parent, filename, data, overwrite))?;
         self.cache.invalidate_path(&nas_path);
         self.read_cache.invalidate_ino(ino);
         Ok(())
@@ -213,7 +278,7 @@ impl Filesystem for SynologyFS {
         // Flush any remaining write buffers
         let fhs: Vec<u64> = self.write_buffers.lock().unwrap().keys().cloned().collect();
         for fh in fhs {
-            if let Err(e) = self.flush_write_buffer(fh) {
+            if let Err(e) = self.finish_upload(fh) {
                 warn!("destroy: failed to flush fh {}: {}", fh, e);
             }
         }
@@ -405,7 +470,10 @@ impl Filesystem for SynologyFS {
             let block_start = block_idx * block_size;
 
             let block = if let Some(cached) = self.read_cache.get(ino, block_idx) {
-                if cached.is_empty() { break; } // EOF sentinel
+                if cached.is_empty() {
+                    debug!("read: EOF sentinel hit ino={} block={}", ino, block_idx);
+                    break;
+                }
                 cached
             } else if self.read_cache.claim_inflight(ino, block_idx) {
                 // We won the race — download synchronously.
@@ -483,6 +551,19 @@ impl Filesystem for SynologyFS {
         let file_size = self.cache.get_size_for_ino(ino).unwrap_or(0);
         let total_blocks = if file_size > 0 { (file_size + block_size - 1) / block_size } else { 0 };
 
+        // If block 0 is cached as an empty EOF sentinel but the file is known to be
+        // non-empty, evict the stale sentinel so we re-download real data below.
+        // This can happen when a previous read attempt received an empty body or
+        // HTTP 416 for a block that should have content.
+        if total_blocks > 0 {
+            if let Some(b) = self.read_cache.get(ino, 0) {
+                if b.is_empty() {
+                    debug!("open: evicting stale EOF sentinel for ino={} block=0", ino);
+                    self.read_cache.invalidate_block(ino, 0);
+                }
+            }
+        }
+
         // Block 0: download synchronously so VLC's very first read() is a guaranteed cache hit.
         if total_blocks > 0 && !self.read_cache.contains(ino, 0) {
             if self.read_cache.claim_inflight(ino, 0) {
@@ -536,6 +617,8 @@ impl Filesystem for SynologyFS {
             ino,
             data: Vec::new(),
             dirty: false,
+            new_file: false,
+            upload_handle: None,
         });
         // FOPEN_KEEP_CACHE: don't invalidate the kernel page cache between opens.
         reply.opened(fh, FOPEN_KEEP_CACHE);
@@ -554,6 +637,24 @@ impl Filesystem for SynologyFS {
         reply: ReplyWrite,
     ) {
         debug!("write: ino={} fh={} offset={} len={}", ino, fh, offset, data.len());
+
+        // If a background upload is in flight for this fh (started by a prior flush),
+        // wait for it before modifying the buffer — we must not hold the mutex while blocking.
+        let handle = {
+            let mut buffers = self.write_buffers.lock().unwrap();
+            buffers.get_mut(&fh).and_then(|b| b.upload_handle.take())
+        };
+        if let Some(h) = handle {
+            match self.block(h).map_err(|_| SynoFsError::Io("upload task panicked".into())).and_then(|r| r) {
+                Err(e) => { error!("write: prior upload failed: {}", e); reply.error(e.to_errno()); return; }
+                Ok(()) => {}
+            }
+            // The file now exists on the NAS; clear new_file so the next upload uses overwrite=true.
+            if let Some(buf) = self.write_buffers.lock().unwrap().get_mut(&fh) {
+                buf.new_file = false;
+            }
+        }
+
         let mut buffers = self.write_buffers.lock().unwrap();
         let buf = match buffers.get_mut(&fh) {
             Some(b) => b,
@@ -582,10 +683,9 @@ impl Filesystem for SynologyFS {
         reply: ReplyEmpty,
     ) {
         debug!("flush: fh={}", fh);
-        match self.flush_write_buffer(fh) {
-            Ok(()) => reply.ok(),
-            Err(e) => { error!("flush fh={}: {}", fh, e); reply.error(e.to_errno()); }
-        }
+        // Kick off the upload in the background; release() will wait for completion.
+        self.queue_upload(fh);
+        reply.ok();
     }
 
     fn release(
@@ -599,7 +699,7 @@ impl Filesystem for SynologyFS {
         reply: ReplyEmpty,
     ) {
         debug!("release: fh={}", fh);
-        let result = self.flush_write_buffer(fh);
+        let result = self.finish_upload(fh);
         self.write_buffers.lock().unwrap().remove(&fh);
         match result {
             Ok(()) => reply.ok(),
@@ -630,29 +730,20 @@ impl Filesystem for SynologyFS {
         let new_path = format!("{}/{}", parent_path.trim_end_matches('/'), name_str);
         debug!("create: {}", new_path);
 
-        // Upload an empty file to create it
-        match self.block(self.client.upload(&parent_path, name_str, vec![], false)) {
-            Ok(()) => {}
-            Err(e) => {
-                error!("create {}: {}", new_path, e);
-                reply.error(e.to_errno());
-                return;
-            }
-        }
-
-        // Fetch the created file's metadata
-        let info = match self.block(self.client.get_info(&new_path)) {
-            Ok(i) => i,
-            Err(e) => {
-                error!("create getinfo {}: {}", new_path, e);
-                reply.error(e.to_errno());
-                return;
-            }
-        };
-
+        // Defer the actual NAS upload to flush/release.  Allocate an inode and
+        // seed the cache with a synthetic entry so getattr works before the first
+        // flush.  The write buffer is marked new_file=true so flush uses
+        // overwrite=false, skipping the delete-before-upload round trips.
         let ino = self.cache.get_or_alloc_ino(&new_path);
-        let attr = self.syno_to_attr(ino, &info);
-        self.cache.insert(ino, info);
+        let synthetic_info = crate::types::SynoFileInfo {
+            name: name_str.to_string(),
+            path: new_path.clone(),
+            isdir: false,
+            additional: None,
+            code: None,
+        };
+        let attr = self.syno_to_attr(ino, &synthetic_info);
+        self.cache.insert(ino, synthetic_info);
 
         let fh = self.next_fh.fetch_add(1, Ordering::Relaxed);
         self.write_buffers.lock().unwrap().insert(fh, WriteBuffer {
@@ -660,6 +751,8 @@ impl Filesystem for SynologyFS {
             ino,
             data: Vec::new(),
             dirty: false,
+            new_file: true,
+            upload_handle: None,
         });
 
         reply.created(&TTL, &attr, 0, fh, 0);
@@ -774,8 +867,17 @@ impl Filesystem for SynologyFS {
         let new_path = format!("{}/{}", new_parent_path.trim_end_matches('/'), new_name_str);
         debug!("rename: {} -> {}", old_path, new_path);
 
-        // Same directory: use the efficient Rename API
+        // Same directory: use the efficient Rename API.
+        // POSIX rename(2) must atomically replace the destination if it exists.
+        // The Synology Rename API does not overwrite — delete the destination first.
         if parent == new_parent {
+            if old_path != new_path {
+                if let Some(ino) = self.cache.get_ino_for_path(&new_path) {
+                    self.read_cache.invalidate_ino(ino);
+                }
+                self.cache.invalidate_path(&new_path);
+                let _ = self.block(self.client.delete(&new_path)); // ignore error — may not exist
+            }
             match self.block(self.client.rename(&old_path, new_name_str)) {
                 Ok(info) => {
                     if let Some(ino) = self.cache.get_ino_for_path(&old_path) {
@@ -817,7 +919,7 @@ impl Filesystem for SynologyFS {
             Err(e) => { reply.error(e.to_errno()); return; }
         };
 
-        match self.block(self.client.upload(&new_parent_path, new_name_str, data.to_vec(), false)) {
+        match self.block(self.client.upload(&new_parent_path, new_name_str, data.to_vec(), true)) {
             Ok(()) => {}
             Err(e) => { reply.error(e.to_errno()); return; }
         }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -8,7 +8,7 @@ use fuser::{
     FileAttr, FileType, Filesystem, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory,
     ReplyEmpty, ReplyEntry, ReplyOpen, ReplyWrite, Request,
 };
-use libc::{EIO, ENOENT, ENOSYS};
+use libc::{EISDIR, EIO, ENOENT, ENOTEMPTY, ENOSYS, ENOTDIR};
 use tracing::{debug, error, warn};
 
 use crate::cache::{InodeCache, ReadCache};
@@ -874,11 +874,58 @@ impl Filesystem for SynologyFS {
         // fully atomic and can lose the destination if a crash occurs between steps.
         if parent == new_parent {
             if old_path != new_path {
-                if let Some(ino) = self.cache.get_ino_for_path(&new_path) {
-                    self.read_cache.invalidate_ino(ino);
+                // Determine source type (file vs. directory) from the metadata cache.
+                let src_ino = self.cache.get_or_alloc_ino(&old_path);
+                let src_is_dir = self.cache.get_by_ino(src_ino)
+                    .map(|e| e.info.isdir)
+                    .unwrap_or(false);
+
+                // Check what is at the destination and enforce POSIX rename(2) semantics.
+                match self.block(self.client.get_info(&new_path)) {
+                    Ok(dst_info) => {
+                        if src_is_dir && !dst_info.isdir {
+                            // rename(dir, file) → ENOTDIR
+                            reply.error(ENOTDIR);
+                            return;
+                        }
+                        if !src_is_dir && dst_info.isdir {
+                            // rename(file, dir) → EISDIR
+                            reply.error(EISDIR);
+                            return;
+                        }
+                        if dst_info.isdir {
+                            // rename(dir, dir) is only permitted when the destination is empty.
+                            match self.block(self.client.list_dir(&new_path)) {
+                                Ok(entries) if !entries.is_empty() => {
+                                    reply.error(ENOTEMPTY);
+                                    return;
+                                }
+                                Err(e) => {
+                                    reply.error(e.to_errno());
+                                    return;
+                                }
+                                Ok(_) => {} // empty directory — safe to remove
+                            }
+                        }
+                        // Destination is a file or an empty directory — safe to remove.
+                        if let Some(ino) = self.cache.get_ino_for_path(&new_path) {
+                            self.read_cache.invalidate_ino(ino);
+                        }
+                        self.cache.invalidate_path(&new_path);
+                        if let Err(e) = self.block(self.client.delete(&new_path)) {
+                            reply.error(e.to_errno());
+                            return;
+                        }
+                    }
+                    Err(SynoFsError::NotFound | SynoFsError::ApiError(414 | 415)) => {
+                        // Destination does not exist — nothing to remove.
+                        self.cache.invalidate_path(&new_path);
+                    }
+                    Err(e) => {
+                        reply.error(e.to_errno());
+                        return;
+                    }
                 }
-                self.cache.invalidate_path(&new_path);
-                let _ = self.block(self.client.delete(&new_path)); // ignore error — may not exist
             }
             match self.block(self.client.rename(&old_path, new_name_str)) {
                 Ok(info) => {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -155,7 +155,7 @@ impl SynologyFS {
 
         let nas_path = buf.nas_path.clone();
         let ino = buf.ino;
-        let data = buf.data.clone();
+        let data = std::mem::take(&mut buf.data);
         let overwrite = !buf.new_file;
         buf.dirty = false;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,14 @@ async fn serve_and_mount(
     let volume_name = mountpoint
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_default();
+        .filter(|n| !n.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "mountpoint '{}' has no final path component; \
+                 please provide a path like '/Volumes/nas' rather than a root or trailing-slash path",
+                mountpoint.display()
+            )
+        })?;
     let path_prefix = format!("/{}", volume_name);
 
     let handler = Arc::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,35 @@
-mod cache;
 mod client;
 mod error;
-mod fs;
 mod types;
+
+#[cfg(target_os = "linux")]
+mod cache;
+#[cfg(target_os = "linux")]
+mod fs;
+
+#[cfg(target_os = "macos")]
+mod webdav;
 
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::Parser;
-use fuser::MountOption;
 use tracing::info;
 
-use cache::{InodeCache, ReadCache, READ_BLOCK_SIZE};
 use client::SynologyClient;
+
+#[cfg(target_os = "linux")]
+use cache::{InodeCache, ReadCache, READ_BLOCK_SIZE};
+#[cfg(target_os = "linux")]
 use fs::SynologyFS;
+#[cfg(target_os = "linux")]
+use fuser::MountOption;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "synology-fuse",
-    about = "Mount a Synology FileStation share as a local FUSE filesystem"
+    about = "Mount a Synology FileStation share as a local filesystem"
 )]
 struct Args {
     /// Synology NAS hostname or IP address
@@ -50,29 +60,19 @@ struct Args {
     /// Local directory to mount the filesystem on
     mountpoint: PathBuf,
 
-    /// Metadata cache TTL in seconds
+    /// Metadata cache TTL in seconds (Linux/FUSE only)
     #[arg(long, default_value_t = 30)]
     cache_ttl: u64,
 
-    /// Read cache size in MiB (file data blocks cached in memory for fast re-reads)
+    /// Read cache size in MiB (Linux/FUSE only)
     #[arg(long, default_value_t = 256)]
     read_cache_mb: u64,
 
     /// Log level (error, warn, info, debug, trace)
     #[arg(long, default_value = "info")]
     log_level: String,
-
-    /// Use the macFUSE FSKit backend instead of the kernel extension.
-    /// Requires macOS 15.4+ and macFUSE 5.0+. No kernel extension approval needed.
-    /// The mount point must be a directory inside /Volumes.
-    #[cfg(target_os = "macos")]
-    #[arg(long, default_value_t = false)]
-    fskit: bool,
 }
 
-/// Synology API error 403 = "Account disabled" or "Incorrect password", but in the context of
-/// a valid password it means OTP is required. Error 404 = "Permission denied" can also indicate
-/// a missing OTP on some DSM versions. We treat both as "OTP needed".
 fn is_otp_required(e: &error::SynoFsError) -> bool {
     matches!(e, error::SynoFsError::ApiError(403 | 404))
 }
@@ -92,12 +92,20 @@ fn main() -> anyhow::Result<()> {
         .with_env_filter(&args.log_level)
         .init();
 
-    // Build a multi-thread Tokio runtime.
-    // The FUSE dispatch loop runs synchronously on the main thread via fuser::mount2.
-    // All async HTTP I/O is dispatched to the Tokio worker pool via handle.block_on().
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
+
+    // On macOS we mount via Finder which always places volumes under /Volumes/.
+    // Require that the user provides a path there so they get a predictable name.
+    #[cfg(target_os = "macos")]
+    if !args.mountpoint.starts_with("/Volumes/") {
+        anyhow::bail!(
+            "On macOS the mountpoint must be under /Volumes/ (e.g. /Volumes/nas), \
+             got: {}",
+            args.mountpoint.display()
+        );
+    }
 
     info!(
         "Connecting to Synology NAS at {}://{}:{}",
@@ -108,8 +116,6 @@ fn main() -> anyhow::Result<()> {
 
     let client = Arc::new(SynologyClient::new(&args.host, args.port, args.https));
 
-    // Synology API error code 403 means an OTP code is required.
-    // If the user didn't supply one via --otp / SYNO_OTP, prompt interactively.
     let password = match args.password {
         Some(p) => p,
         None => rpassword::prompt_password("Password: ")?,
@@ -129,49 +135,165 @@ fn main() -> anyhow::Result<()> {
 
     info!("Logged in successfully");
 
-    let cache = Arc::new(InodeCache::new(args.cache_ttl));
-    let max_blocks = (args.read_cache_mb * 1024 * 1024) / READ_BLOCK_SIZE;
-    let read_cache = Arc::new(ReadCache::new(READ_BLOCK_SIZE, max_blocks.max(1)));
-    let handle = rt.handle().clone();
-    let uid = unsafe { libc::getuid() };
-    let gid = unsafe { libc::getgid() };
-
-    info!("Read cache: {} MiB ({} blocks × {} MiB)",
-          args.read_cache_mb, max_blocks, READ_BLOCK_SIZE / (1024 * 1024));
-
-    let fs = SynologyFS::new(client.clone(), cache, read_cache, handle, uid, gid);
-
-    // AutoUnmount is Linux-only; macFUSE unmounts automatically when the process exits.
     #[cfg(target_os = "linux")]
-    let options = vec![
-        MountOption::RW,
-        MountOption::FSName("synology-fuse".to_string()),
-        MountOption::AllowOther,
-        MountOption::AutoUnmount,
-    ];
-    #[cfg(not(target_os = "linux"))]
-    let mut options = vec![
-        MountOption::RW,
-        MountOption::FSName("synology-fuse".to_string()),
-        MountOption::AllowOther,
-    ];
-    // FSKit backend: no kernel extension required, but needs macOS 15.4+ and macFUSE 5.0+.
-    // Mount point must be inside /Volumes.
-    #[cfg(target_os = "macos")]
-    if args.fskit {
-        if !args.mountpoint.starts_with("/Volumes") {
-            eprintln!("warning: --fskit requires the mount point to be inside /Volumes");
-        }
-        options.push(MountOption::CUSTOM("backend=fskit".to_string()));
+    {
+        let cache = Arc::new(InodeCache::new(args.cache_ttl));
+        let max_blocks = (args.read_cache_mb * 1024 * 1024) / READ_BLOCK_SIZE;
+        let read_cache = Arc::new(ReadCache::new(READ_BLOCK_SIZE, max_blocks.max(1)));
+        let handle = rt.handle().clone();
+        let uid = unsafe { libc::getuid() };
+        let gid = unsafe { libc::getgid() };
+
+        info!(
+            "Read cache: {} MiB ({} blocks × {} MiB)",
+            args.read_cache_mb,
+            max_blocks,
+            READ_BLOCK_SIZE / (1024 * 1024)
+        );
+
+        let fs = SynologyFS::new(client.clone(), cache, read_cache, handle, uid, gid);
+
+        let options = vec![
+            MountOption::RW,
+            MountOption::FSName("synology-fuse".to_string()),
+            MountOption::AllowOther,
+            MountOption::AutoUnmount,
+        ];
+
+        info!("Mounting shares on {}", args.mountpoint.display());
+        fuser::mount2(fs, &args.mountpoint, &options)?;
     }
 
-    info!("Mounting shares on {}", args.mountpoint.display());
-
-    // mount2 blocks until the filesystem is unmounted (e.g. via `fusermount -u <mountpoint>`)
-    fuser::mount2(fs, &args.mountpoint, &options)?;
+    #[cfg(target_os = "macos")]
+    {
+        info!("Mounting shares on {} via WebDAV", args.mountpoint.display());
+        rt.block_on(serve_and_mount(client.clone(), &args.mountpoint))?;
+    }
 
     info!("Unmounted, logging out");
     rt.block_on(client.logout())?;
 
+    Ok(())
+}
+
+/// Start a local WebDAV server, then ask macOS Finder to mount it via
+/// AppleScript `mount volume`.  This works for regular users on any modern
+/// macOS version without root or kernel extensions.
+///
+/// The WebDAV server advertises the last path component of `mountpoint` as its
+/// `DAV:displayname`, which macOS Finder uses as the volume name.  The volume
+/// therefore appears at exactly the `/Volumes/<name>` path the user requested.
+#[cfg(target_os = "macos")]
+async fn serve_and_mount(
+    client: Arc<SynologyClient>,
+    mountpoint: &std::path::Path,
+) -> anyhow::Result<()> {
+    use std::convert::Infallible;
+
+    use dav_server::{fakels::FakeLs, DavHandler};
+    use hyper::server::conn::http1;
+    use hyper_util::rt::TokioIo;
+    use webdav::SynologyDavFs;
+
+    // Extract the desired volume name from the last component of the path
+    // (e.g. "/Volumes/nas" → "nas") and use it as a URL path prefix so that
+    // macOS names the mounted volume correctly.
+    let volume_name = mountpoint
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let path_prefix = format!("/{}", volume_name);
+
+    let handler = Arc::new(
+        DavHandler::builder()
+            .filesystem(Box::new(SynologyDavFs::new(client, path_prefix.clone())))
+            .locksystem(FakeLs::new())
+            .build_handler(),
+    );
+
+    // Bind to a kernel-assigned port on localhost.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+    // Include the volume name as a path component so macOS uses it as the
+    // volume name when mounting (e.g. http://127.0.0.1:PORT/nas/ → /Volumes/nas).
+    let url = format!("http://127.0.0.1:{}{}/", port, path_prefix);
+
+    info!("WebDAV server listening on {}", url);
+
+    // Start the accept loop BEFORE calling osascript so that Finder's probe
+    // requests are answered immediately.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let handler_srv = handler.clone();
+    let server_task = tokio::spawn(async move {
+        let mut shutdown_rx = shutdown_rx;
+        loop {
+            tokio::select! {
+                result = listener.accept() => {
+                    let (stream, _addr) = match result {
+                        Ok(r) => r,
+                        Err(e) => { tracing::debug!("accept error: {}", e); break; }
+                    };
+                    let io = TokioIo::new(stream);
+                    let h = handler_srv.clone();
+                    tokio::spawn(async move {
+                        let svc = hyper::service::service_fn(move |req| {
+                            let h = h.clone();
+                            async move { Ok::<_, Infallible>(h.handle(req).await) }
+                        });
+                        if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+                            tracing::debug!("WebDAV connection closed: {}", e);
+                        }
+                    });
+                }
+                _ = &mut shutdown_rx => {
+                    info!("WebDAV server shutting down");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Remove a stale mount-point directory left over from a previous run.
+    // If the directory is actually still mounted this will fail (EBUSY/EPERM),
+    // which is fine — we leave it alone and let osascript fail with a clear message.
+    if mountpoint.is_dir() && !mountpoint.is_symlink() {
+        let _ = std::fs::remove_dir(mountpoint);
+    }
+
+    // Ask Finder to mount the volume via AppleScript.
+    let script = format!("mount volume \"{}\"", url);
+    let out = tokio::process::Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .await?;
+
+    if !out.status.success() {
+        let _ = shutdown_tx.send(());
+        server_task.await.ok();
+        anyhow::bail!(
+            "osascript mount failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+
+    info!("Mounted at {}", mountpoint.display());
+
+    // Ctrl-C → unmount and stop serving.
+    let mp = mountpoint.to_path_buf();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("Signal received, unmounting {}…", mp.display());
+        let _ = tokio::process::Command::new("diskutil")
+            .args(["unmount", &mp.to_string_lossy()])
+            .status()
+            .await;
+        // macOS does not always remove the /Volumes/<name> directory after
+        // unmounting a WebDAV volume.  Remove it ourselves if it is now empty.
+        let _ = std::fs::remove_dir(&mp);
+        let _ = shutdown_tx.send(());
+    });
+
+    server_task.await.ok();
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,10 +229,13 @@ async fn serve_and_mount(
 
     // Start the accept loop BEFORE calling osascript so that Finder's probe
     // requests are answered immediately.
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    //
+    // Use a Notify so that either Ctrl-C or a Finder eject can independently
+    // trigger the shutdown without consuming the signal.
+    let shutdown_notify = Arc::new(tokio::sync::Notify::new());
     let handler_srv = handler.clone();
+    let shutdown_notify_srv = shutdown_notify.clone();
     let server_task = tokio::spawn(async move {
-        let mut shutdown_rx = shutdown_rx;
         loop {
             tokio::select! {
                 result = listener.accept() => {
@@ -252,7 +255,7 @@ async fn serve_and_mount(
                         }
                     });
                 }
-                _ = &mut shutdown_rx => {
+                _ = shutdown_notify_srv.notified() => {
                     info!("WebDAV server shutting down");
                     break;
                 }
@@ -275,7 +278,7 @@ async fn serve_and_mount(
         .await?;
 
     if !out.status.success() {
-        let _ = shutdown_tx.send(());
+        let _ = shutdown_notify.notify_one();
         server_task.await.ok();
         anyhow::bail!(
             "osascript mount failed ({}): {}",
@@ -286,8 +289,24 @@ async fn serve_and_mount(
 
     info!("Mounted at {}", mountpoint.display());
 
+    // Watch for Finder eject: poll until the mountpoint disappears, then shut
+    // down the WebDAV server so the process can exit cleanly.
+    let mp_watch = mountpoint.to_path_buf();
+    let shutdown_notify_eject = shutdown_notify.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            if !mp_watch.exists() {
+                info!("Volume ejected from Finder, shutting down");
+                shutdown_notify_eject.notify_one();
+                break;
+            }
+        }
+    });
+
     // Ctrl-C → unmount and stop serving.
     let mp = mountpoint.to_path_buf();
+    let shutdown_notify_ctrlc = shutdown_notify.clone();
     tokio::spawn(async move {
         tokio::signal::ctrl_c().await.ok();
         info!("Signal received, unmounting {}…", mp.display());
@@ -298,7 +317,7 @@ async fn serve_and_mount(
         // macOS does not always remove the /Volumes/<name> directory after
         // unmounting a WebDAV volume.  Remove it ourselves if it is now empty.
         let _ = std::fs::remove_dir(&mp);
-        let _ = shutdown_tx.send(());
+        shutdown_notify_ctrlc.notify_one();
     });
 
     server_task.await.ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,10 @@ async fn serve_and_mount(
     // Extract the desired volume name from the last component of the path
     // (e.g. "/Volumes/nas" → "nas") and use it as a URL path prefix so that
     // macOS names the mounted volume correctly.
+    //
+    // Percent-encode the name so that spaces and other URL-special characters
+    // don't produce a malformed URL.  Only characters that are safe as a URL
+    // path segment (unreserved per RFC 3986) are left unencoded.
     let volume_name = mountpoint
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -209,7 +213,19 @@ async fn serve_and_mount(
                 mountpoint.display()
             )
         })?;
-    let path_prefix = format!("/{}", volume_name);
+    // Percent-encode every byte that is not an RFC 3986 unreserved character.
+    let volume_name_encoded: String = volume_name
+        .bytes()
+        .flat_map(|b| {
+            if b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.' | b'~') {
+                // Safe ASCII: use char::from to make the ASCII assumption explicit.
+                vec![char::from(b)]
+            } else {
+                format!("%{:02X}", b).chars().collect::<Vec<_>>()
+            }
+        })
+        .collect();
+    let path_prefix = format!("/{}", volume_name_encoded);
 
     let handler = Arc::new(
         DavHandler::builder()
@@ -270,12 +286,27 @@ async fn serve_and_mount(
         let _ = std::fs::remove_dir(mountpoint);
     }
 
-    // Ask Finder to mount the volume via AppleScript.
+    // Ask Finder to mount the volume via AppleScript.  Pass the script via stdin
+    // (rather than -e "...") so that the URL is never interpolated into a shell
+    // command string, eliminating any risk of AppleScript injection.
     let script = format!("mount volume \"{}\"", url);
-    let out = tokio::process::Command::new("osascript")
-        .args(["-e", &script])
-        .output()
-        .await?;
+    let mut child = tokio::process::Command::new("osascript")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("failed to spawn osascript: {}", e))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt as _;
+        stdin.write_all(script.as_bytes()).await
+            .map_err(|e| anyhow::anyhow!("failed to write to osascript stdin: {}", e))?;
+        // stdin is dropped/closed here, signalling EOF to osascript
+    }
+
+    let out = child.wait_with_output()
+        .await
+        .map_err(|e| anyhow::anyhow!("osascript wait failed: {}", e))?;
 
     if !out.status.success() {
         let _ = shutdown_notify.notify_one();

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,13 +261,21 @@ async fn serve_and_mount(
                     };
                     let io = TokioIo::new(stream);
                     let h = handler_srv.clone();
+                    let shutdown_notify_conn = shutdown_notify_srv.clone();
                     tokio::spawn(async move {
                         let svc = hyper::service::service_fn(move |req| {
                             let h = h.clone();
                             async move { Ok::<_, Infallible>(h.handle(req).await) }
                         });
-                        if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
-                            tracing::debug!("WebDAV connection closed: {}", e);
+                        tokio::select! {
+                            _ = shutdown_notify_conn.notified() => {
+                                tracing::debug!("WebDAV connection aborted due to shutdown");
+                            }
+                            result = http1::Builder::new().serve_connection(io, svc) => {
+                                if let Err(e) = result {
+                                    tracing::debug!("WebDAV connection closed: {}", e);
+                                }
+                            }
                         }
                     });
                 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 /// the API returns `success:true` but puts `{"code":NNN,"path":"..."}` in the files
 /// array instead of a real entry.  The `code` field captures that per-entry error.
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct SynoFileInfo {
     #[serde(default)]
     pub name: String,
@@ -17,6 +18,7 @@ pub struct SynoFileInfo {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct SynoAdditional {
     pub size: Option<u64>,
     pub owner: Option<SynoOwner>,
@@ -34,6 +36,7 @@ pub struct SynoOwner {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct SynoTime {
     pub atime: i64,
     pub mtime: i64,
@@ -42,6 +45,7 @@ pub struct SynoTime {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 pub struct SynoPerm {
     pub posix: u32,
 }
@@ -78,6 +82,7 @@ pub struct ListShareData {
 }
 
 /// Sentinel path stored in the inode cache for the virtual root (the share listing).
+#[cfg(target_os = "linux")]
 pub const VIRTUAL_ROOT_PATH: &str = "";
 
 /// GetInfo response data
@@ -106,6 +111,7 @@ pub struct UploadData {
 }
 
 /// An entry in the inode cache
+#[cfg(target_os = "linux")]
 #[derive(Debug, Clone)]
 pub struct InodeEntry {
     pub ino: u64,

--- a/src/webdav.rs
+++ b/src/webdav.rs
@@ -158,6 +158,9 @@ struct SynoDavFile {
     offset: u64,
     /// Buffered write data; `Some` when opened for writing.
     write_buf: Option<Vec<u8>>,
+    /// True when the file did not exist on the NAS at open time.
+    /// Used to skip the delete-before-upload overwrite path.
+    is_new: bool,
 }
 
 impl DavFile for SynoDavFile {
@@ -224,10 +227,11 @@ impl DavFile for SynoDavFile {
             }
             let client = self.client.clone();
             let path = self.nas_path.clone();
+            let overwrite = !self.is_new;
             Box::pin(async move {
                 let (parent, filename) = split_path(&path);
                 client
-                    .upload(parent, filename, data, true)
+                    .upload(parent, filename, data, overwrite)
                     .await
                     .map_err(syno_err)
             })
@@ -330,21 +334,24 @@ impl DavFileSystem for SynologyDavFs {
                         info,
                         offset: 0,
                         write_buf: Some(Vec::new()),
+                        is_new: false,
                     });
                     return Ok(file);
                 }
 
                 // For a write/create open, the caller will PUT the content.
                 // We build a placeholder SynoFileInfo so flush() knows where to upload.
-                let info = match self.client.get_info(&nas).await {
-                    Ok(info) => info,
-                    Err(_) => SynoFileInfo {
+                // Track whether the file already exists so flush() can skip the
+                // delete-before-overwrite path for brand-new files.
+                let (info, is_new) = match self.client.get_info(&nas).await {
+                    Ok(info) => (info, false),
+                    Err(_) => (SynoFileInfo {
                         name: nas.rsplit('/').next().unwrap_or("").to_string(),
                         path: nas.clone(),
                         isdir: false,
                         additional: None,
                         code: None,
-                    },
+                    }, true),
                 };
 
                 let file: Box<dyn DavFile> = Box::new(SynoDavFile {
@@ -353,6 +360,7 @@ impl DavFileSystem for SynologyDavFs {
                     info,
                     offset: 0,
                     write_buf: Some(Vec::new()),
+                    is_new,
                 });
                 Ok(file)
             } else {
@@ -363,6 +371,7 @@ impl DavFileSystem for SynologyDavFs {
                     info,
                     offset: 0,
                     write_buf: None,
+                    is_new: false,
                 });
                 Ok(file)
             }

--- a/src/webdav.rs
+++ b/src/webdav.rs
@@ -231,7 +231,7 @@ impl DavFile for SynoDavFile {
             Box::pin(async move {
                 let (parent, filename) = split_path(&path);
                 client
-                    .upload(parent, filename, data, overwrite)
+                    .upload(parent, filename, Bytes::from(data), overwrite)
                     .await
                     .map_err(syno_err)
             })

--- a/src/webdav.rs
+++ b/src/webdav.rs
@@ -1,0 +1,462 @@
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use bytes::{Buf, Bytes};
+use dav_server::davpath::DavPath;
+use dav_server::fs::*;
+use futures_util::stream;
+use tracing::debug;
+
+use crate::client::SynologyClient;
+use crate::error::SynoFsError;
+use crate::types::SynoFileInfo;
+
+// ── Path helpers ──────────────────────────────────────────────────────────────
+
+/// Convert a `DavPath` to the corresponding Synology NAS path string,
+/// stripping an optional URL prefix (e.g. "/nas").
+/// e.g. `/nas/share/dir/file.txt` with prefix `/nas` → `/share/dir/file.txt`
+fn dav_to_nas(path: &DavPath, prefix: &str) -> String {
+    let pb = path.as_pathbuf();
+    let s = pb.to_string_lossy();
+    let s = s.trim_end_matches('/');
+    let s = if !prefix.is_empty() && s.starts_with(prefix) {
+        &s[prefix.len()..]
+    } else {
+        s
+    };
+    let s = s.trim_end_matches('/');
+    if s.is_empty() {
+        "/".to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Returns true for macOS AppleDouble companion files (`._*`).
+/// Synology DSM does not store these as regular files; operations on them
+/// should be silently discarded rather than forwarded to the NAS API.
+fn is_apple_double(nas_path: &str) -> bool {
+    nas_path.rsplit('/').next().map(|n| n.starts_with("._")).unwrap_or(false)
+}
+
+/// Split `/parent/name` → `("/parent", "name")`.
+/// Handles the single-segment case: `/name` → `("/", "name")`.
+fn split_path(path: &str) -> (&str, &str) {
+    match path.rfind('/') {
+        Some(0) => ("/", &path[1..]),
+        Some(pos) => (&path[..pos], &path[pos + 1..]),
+        None => ("/", path),
+    }
+}
+
+fn ts_to_system(ts: i64) -> SystemTime {
+    if ts > 0 {
+        UNIX_EPOCH + std::time::Duration::from_secs(ts as u64)
+    } else {
+        UNIX_EPOCH
+    }
+}
+
+fn syno_err(e: SynoFsError) -> FsError {
+    match e {
+        SynoFsError::NotFound => FsError::NotFound,
+        SynoFsError::PermissionDenied => FsError::Forbidden,
+        SynoFsError::AlreadyExists => FsError::Exists,
+        SynoFsError::NoSpace => FsError::InsufficientStorage,
+        // Map known Synology API error codes to appropriate WebDAV errors.
+        // 408 = "no such file or no permission" — treat as NotFound so macOS
+        //       receives 404 rather than 500 (which maps to EPERM).
+        // 414/415 = no such file / no such folder
+        SynoFsError::ApiError(408 | 414 | 415) => FsError::NotFound,
+        SynoFsError::ApiError(418) => FsError::Exists,
+        SynoFsError::ApiError(419) => FsError::InsufficientStorage,
+        _ => FsError::GeneralFailure,
+    }
+}
+
+// ── Metadata ─────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct SynoDavMeta {
+    info: SynoFileInfo,
+}
+
+impl SynoDavMeta {
+    fn new(info: SynoFileInfo) -> Self {
+        Self { info }
+    }
+
+    fn root() -> Self {
+        Self {
+            info: SynoFileInfo {
+                name: String::new(),
+                path: "/".into(),
+                isdir: true,
+                additional: None,
+                code: None,
+            },
+        }
+    }
+}
+
+impl DavMetaData for SynoDavMeta {
+    fn len(&self) -> u64 {
+        if self.info.isdir {
+            0
+        } else {
+            self.info.additional.as_ref().and_then(|a| a.size).unwrap_or(0)
+        }
+    }
+
+    fn modified(&self) -> FsResult<SystemTime> {
+        let ts = self.info.additional.as_ref()
+            .and_then(|a| a.time.as_ref())
+            .map(|t| t.mtime)
+            .unwrap_or(0);
+        Ok(ts_to_system(ts))
+    }
+
+    fn is_dir(&self) -> bool {
+        self.info.isdir
+    }
+
+    fn created(&self) -> FsResult<SystemTime> {
+        let ts = self.info.additional.as_ref()
+            .and_then(|a| a.time.as_ref())
+            .map(|t| t.crtime)
+            .unwrap_or(0);
+        Ok(ts_to_system(ts))
+    }
+}
+
+// ── Dir entry ────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct SynoDavDirEntry {
+    info: SynoFileInfo,
+}
+
+impl DavDirEntry for SynoDavDirEntry {
+    fn name(&self) -> Vec<u8> {
+        self.info.name.as_bytes().to_vec()
+    }
+
+    fn metadata(&self) -> FsFuture<'_, Box<dyn DavMetaData>> {
+        let meta: Box<dyn DavMetaData> = Box::new(SynoDavMeta::new(self.info.clone()));
+        Box::pin(async move { Ok(meta) })
+    }
+}
+
+// ── File ─────────────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+struct SynoDavFile {
+    client: Arc<SynologyClient>,
+    nas_path: String,
+    info: SynoFileInfo,
+    offset: u64,
+    /// Buffered write data; `Some` when opened for writing.
+    write_buf: Option<Vec<u8>>,
+}
+
+impl DavFile for SynoDavFile {
+    fn metadata(&mut self) -> FsFuture<'_, Box<dyn DavMetaData>> {
+        let meta: Box<dyn DavMetaData> = Box::new(SynoDavMeta::new(self.info.clone()));
+        Box::pin(async move { Ok(meta) })
+    }
+
+    fn write_buf(&mut self, buf: Box<dyn Buf + Send>) -> FsFuture<'_, ()> {
+        let mut b = buf;
+        let chunk = b.copy_to_bytes(b.remaining());
+        match &mut self.write_buf {
+            Some(v) => v.extend_from_slice(&chunk),
+            None => self.write_buf = Some(chunk.to_vec()),
+        }
+        Box::pin(async { Ok(()) })
+    }
+
+    fn write_bytes(&mut self, buf: Bytes) -> FsFuture<'_, ()> {
+        match &mut self.write_buf {
+            Some(v) => v.extend_from_slice(&buf),
+            None => self.write_buf = Some(buf.to_vec()),
+        }
+        Box::pin(async { Ok(()) })
+    }
+
+    fn read_bytes(&mut self, count: usize) -> FsFuture<'_, Bytes> {
+        // Split the borrow so the future can update self.offset after the await.
+        let client = self.client.clone();
+        let path = self.nas_path.clone();
+        let offset_ref = &mut self.offset;
+
+        Box::pin(async move {
+            let cur = *offset_ref;
+            let bytes = client
+                .download(&path, cur, count as u64)
+                .await
+                .map_err(syno_err)?;
+            *offset_ref += bytes.len() as u64;
+            Ok(bytes)
+        })
+    }
+
+    fn seek(&mut self, pos: std::io::SeekFrom) -> FsFuture<'_, u64> {
+        let size = self.info.additional.as_ref().and_then(|a| a.size).unwrap_or(0);
+        let new_offset = match pos {
+            std::io::SeekFrom::Start(o) => o,
+            std::io::SeekFrom::Current(o) => {
+                (self.offset as i64).saturating_add(o).max(0) as u64
+            }
+            std::io::SeekFrom::End(o) => {
+                (size as i64).saturating_add(o).max(0) as u64
+            }
+        };
+        self.offset = new_offset;
+        Box::pin(async move { Ok(new_offset) })
+    }
+
+    fn flush(&mut self) -> FsFuture<'_, ()> {
+        if let Some(data) = self.write_buf.take() {
+            // AppleDouble companion files (._*) are discarded — not stored on the NAS.
+            if is_apple_double(&self.nas_path) {
+                return Box::pin(async { Ok(()) });
+            }
+            let client = self.client.clone();
+            let path = self.nas_path.clone();
+            Box::pin(async move {
+                let (parent, filename) = split_path(&path);
+                client
+                    .upload(parent, filename, data, true)
+                    .await
+                    .map_err(syno_err)
+            })
+        } else {
+            Box::pin(async { Ok(()) })
+        }
+    }
+}
+
+// ── Filesystem ───────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+pub struct SynologyDavFs {
+    client: Arc<SynologyClient>,
+    /// URL path prefix stripped before forwarding to the NAS API.
+    /// e.g. "/nas" when the WebDAV server is mounted at `http://host/nas/`.
+    path_prefix: String,
+}
+
+impl SynologyDavFs {
+    pub fn new(client: Arc<SynologyClient>, path_prefix: String) -> Self {
+        Self { client, path_prefix }
+    }
+
+    fn nas_path(&self, path: &DavPath) -> String {
+        dav_to_nas(path, &self.path_prefix)
+    }
+}
+
+impl DavFileSystem for SynologyDavFs {
+    fn metadata<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, Box<dyn DavMetaData>> {
+        Box::pin(async move {
+            let nas = self.nas_path(path);
+            debug!("webdav metadata: {}", nas);
+
+            if nas == "/" {
+                let meta: Box<dyn DavMetaData> = Box::new(SynoDavMeta::root());
+                return Ok(meta);
+            }
+
+            if is_apple_double(&nas) {
+                return Err(FsError::NotFound);
+            }
+
+            let info = self.client.get_info(&nas).await.map_err(syno_err)?;
+            let meta: Box<dyn DavMetaData> = Box::new(SynoDavMeta::new(info));
+            Ok(meta)
+        })
+    }
+
+    fn read_dir<'a>(
+        &'a self,
+        path: &'a DavPath,
+        _meta: ReadDirMeta,
+    ) -> FsFuture<'a, FsStream<Box<dyn DavDirEntry>>> {
+        Box::pin(async move {
+            let nas = self.nas_path(path);
+            debug!("webdav read_dir: {}", nas);
+
+            let entries: Vec<SynoFileInfo> = if nas == "/" {
+                self.client.list_shares().await.map_err(syno_err)?
+            } else {
+                self.client.list_dir(&nas).await.map_err(syno_err)?
+            };
+
+            let items: Vec<FsResult<Box<dyn DavDirEntry>>> = entries
+                .into_iter()
+                .map(|info| -> FsResult<Box<dyn DavDirEntry>> {
+                    Ok(Box::new(SynoDavDirEntry { info }))
+                })
+                .collect();
+
+            let s: FsStream<Box<dyn DavDirEntry>> = Box::pin(stream::iter(items));
+            Ok(s)
+        })
+    }
+
+    fn open<'a>(&'a self, path: &'a DavPath, options: OpenOptions) -> FsFuture<'a, Box<dyn DavFile>> {
+        Box::pin(async move {
+            let nas = self.nas_path(path);
+            debug!(
+                "webdav open: {} read={} write={} create={}",
+                nas, options.read, options.write, options.create
+            );
+
+            if options.write || options.create {
+                // AppleDouble companion files (._*) are not stored on the NAS.
+                // Accept the write but discard the data — flush() is a no-op for these.
+                if is_apple_double(&nas) {
+                    let info = SynoFileInfo {
+                        name: nas.rsplit('/').next().unwrap_or("").to_string(),
+                        path: nas.clone(),
+                        isdir: false,
+                        additional: None,
+                        code: None,
+                    };
+                    let file: Box<dyn DavFile> = Box::new(SynoDavFile {
+                        client: self.client.clone(),
+                        nas_path: nas,
+                        info,
+                        offset: 0,
+                        write_buf: Some(Vec::new()),
+                    });
+                    return Ok(file);
+                }
+
+                // For a write/create open, the caller will PUT the content.
+                // We build a placeholder SynoFileInfo so flush() knows where to upload.
+                let info = match self.client.get_info(&nas).await {
+                    Ok(info) => info,
+                    Err(_) => SynoFileInfo {
+                        name: nas.rsplit('/').next().unwrap_or("").to_string(),
+                        path: nas.clone(),
+                        isdir: false,
+                        additional: None,
+                        code: None,
+                    },
+                };
+
+                let file: Box<dyn DavFile> = Box::new(SynoDavFile {
+                    client: self.client.clone(),
+                    nas_path: nas,
+                    info,
+                    offset: 0,
+                    write_buf: Some(Vec::new()),
+                });
+                Ok(file)
+            } else {
+                let info = self.client.get_info(&nas).await.map_err(syno_err)?;
+                let file: Box<dyn DavFile> = Box::new(SynoDavFile {
+                    client: self.client.clone(),
+                    nas_path: nas,
+                    info,
+                    offset: 0,
+                    write_buf: None,
+                });
+                Ok(file)
+            }
+        })
+    }
+
+    fn create_dir<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, ()> {
+        Box::pin(async move {
+            let nas = self.nas_path(path);
+            debug!("webdav create_dir: {}", nas);
+            let (parent, name) = split_path(&nas);
+            self.client
+                .create_folder(parent, name)
+                .await
+                .map_err(syno_err)
+                .map(|_| ())
+        })
+    }
+
+    fn remove_file<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, ()> {
+        Box::pin(async move {
+            let nas = self.nas_path(path);
+            debug!("webdav remove_file: {}", nas);
+            if is_apple_double(&nas) {
+                return Ok(());
+            }
+            self.client.delete(&nas).await.map_err(syno_err)
+        })
+    }
+
+    fn remove_dir<'a>(&'a self, path: &'a DavPath) -> FsFuture<'a, ()> {
+        Box::pin(async move {
+            let nas = self.nas_path(path);
+            debug!("webdav remove_dir: {}", nas);
+            self.client.delete(&nas).await.map_err(syno_err)
+        })
+    }
+
+    fn rename<'a>(&'a self, from: &'a DavPath, to: &'a DavPath) -> FsFuture<'a, ()> {
+        Box::pin(async move {
+            let from_nas = self.nas_path(from);
+            let to_nas = self.nas_path(to);
+            debug!("webdav rename: {} -> {}", from_nas, to_nas);
+
+            let (from_parent, _) = split_path(&from_nas);
+            let (to_parent, to_name) = split_path(&to_nas);
+
+            if from_parent == to_parent {
+                self.client
+                    .rename(&from_nas, to_name)
+                    .await
+                    .map_err(syno_err)
+                    .map(|_| ())
+            } else {
+                // Cross-directory move: download → upload → delete.
+                // Only works for files; directory moves return an error.
+                let info = self.client.get_info(&from_nas).await.map_err(syno_err)?;
+                if info.isdir {
+                    return Err(FsError::NotImplemented);
+                }
+                let size = info.additional.as_ref().and_then(|a| a.size).unwrap_or(0);
+                let data = self.client
+                    .download(&from_nas, 0, size)
+                    .await
+                    .map_err(syno_err)?;
+                self.client
+                    .upload(to_parent, to_name, data.to_vec(), true)
+                    .await
+                    .map_err(syno_err)?;
+                self.client.delete(&from_nas).await.map_err(syno_err)
+            }
+        })
+    }
+
+    fn copy<'a>(&'a self, from: &'a DavPath, to: &'a DavPath) -> FsFuture<'a, ()> {
+        Box::pin(async move {
+            let from_nas = self.nas_path(from);
+            let to_nas = self.nas_path(to);
+            debug!("webdav copy: {} -> {}", from_nas, to_nas);
+
+            let info = self.client.get_info(&from_nas).await.map_err(syno_err)?;
+            if info.isdir {
+                return Err(FsError::NotImplemented);
+            }
+            let size = info.additional.as_ref().and_then(|a| a.size).unwrap_or(0);
+            let data = self.client
+                .download(&from_nas, 0, size)
+                .await
+                .map_err(syno_err)?;
+            let (to_parent, to_name) = split_path(&to_nas);
+            self.client
+                .upload(to_parent, to_name, data.to_vec(), true)
+                .await
+                .map_err(syno_err)
+        })
+    }
+}

--- a/src/webdav.rs
+++ b/src/webdav.rs
@@ -442,7 +442,7 @@ impl DavFileSystem for SynologyDavFs {
                     .await
                     .map_err(syno_err)?;
                 self.client
-                    .upload(to_parent, to_name, data.to_vec(), true)
+                    .upload(to_parent, to_name, data, true)
                     .await
                     .map_err(syno_err)?;
                 self.client.delete(&from_nas).await.map_err(syno_err)
@@ -467,7 +467,7 @@ impl DavFileSystem for SynologyDavFs {
                 .map_err(syno_err)?;
             let (to_parent, to_name) = split_path(&to_nas);
             self.client
-                .upload(to_parent, to_name, data.to_vec(), true)
+                .upload(to_parent, to_name, data, true)
                 .await
                 .map_err(syno_err)
         })

--- a/src/webdav.rs
+++ b/src/webdav.rs
@@ -20,8 +20,16 @@ fn dav_to_nas(path: &DavPath, prefix: &str) -> String {
     let pb = path.as_pathbuf();
     let s = pb.to_string_lossy();
     let s = s.trim_end_matches('/');
+    // Only strip the prefix when it matches at a path-component boundary so
+    // that a prefix of "/nas" does not incorrectly strip "/nasfoo/...".
     let s = if !prefix.is_empty() && s.starts_with(prefix) {
-        &s[prefix.len()..]
+        if s.len() == prefix.len() {
+            ""
+        } else if matches!(s.as_bytes().get(prefix.len()), Some(b'/')) {
+            &s[prefix.len()..]
+        } else {
+            s
+        }
     } else {
         s
     };
@@ -228,6 +236,9 @@ impl DavFile for SynoDavFile {
             let client = self.client.clone();
             let path = self.nas_path.clone();
             let overwrite = !self.is_new;
+            // After this flush, the file exists on the NAS regardless of whether
+            // it was new, so subsequent flushes on the same handle must overwrite.
+            self.is_new = false;
             Box::pin(async move {
                 let (parent, filename) = split_path(&path);
                 client
@@ -436,6 +447,12 @@ impl DavFileSystem for SynologyDavFs {
                 if info.isdir {
                     return Err(FsError::NotImplemented);
                 }
+                // Refuse to overwrite an existing directory at the destination.
+                if let Ok(dest_info) = self.client.get_info(&to_nas).await {
+                    if dest_info.isdir {
+                        return Err(FsError::Forbidden);
+                    }
+                }
                 let size = info.additional.as_ref().and_then(|a| a.size).unwrap_or(0);
                 let data = self.client
                     .download(&from_nas, 0, size)
@@ -459,6 +476,12 @@ impl DavFileSystem for SynologyDavFs {
             let info = self.client.get_info(&from_nas).await.map_err(syno_err)?;
             if info.isdir {
                 return Err(FsError::NotImplemented);
+            }
+            // Refuse to overwrite an existing directory at the destination.
+            if let Ok(dest_info) = self.client.get_info(&to_nas).await {
+                if dest_info.isdir {
+                    return Err(FsError::Forbidden);
+                }
             }
             let size = info.additional.as_ref().and_then(|a| a.size).unwrap_or(0);
             let data = self.client

--- a/src/webdav.rs
+++ b/src/webdav.rs
@@ -345,13 +345,17 @@ impl DavFileSystem for SynologyDavFs {
                 // delete-before-overwrite path for brand-new files.
                 let (info, is_new) = match self.client.get_info(&nas).await {
                     Ok(info) => (info, false),
-                    Err(_) => (SynoFileInfo {
-                        name: nas.rsplit('/').next().unwrap_or("").to_string(),
-                        path: nas.clone(),
-                        isdir: false,
-                        additional: None,
-                        code: None,
-                    }, true),
+                    Err(SynoFsError::NotFound) => (
+                        SynoFileInfo {
+                            name: nas.rsplit('/').next().unwrap_or("").to_string(),
+                            path: nas.clone(),
+                            isdir: false,
+                            additional: None,
+                            code: None,
+                        },
+                        true,
+                    ),
+                    Err(err) => return Err(syno_err(err)),
                 };
 
                 let file: Box<dyn DavFile> = Box::new(SynoDavFile {


### PR DESCRIPTION
Addresses a batch of review feedback covering silent data loss, unsafe recursive deletion, memory inefficiency in upload retries, and AppleScript injection risk.

## Upload: zero-copy retries via `Bytes`

`client::upload` now accepts `bytes::Bytes` instead of `Vec<u8>`. Retries share the same backing allocation — `Bytes::clone()` is O(1). Callers that previously called `.to_vec()` on a download result (`Bytes`) now pass it directly.

```rust
// Before: full copy on every retry attempt
let file_part = multipart::Part::bytes(data.clone());

// After: O(1) ref-count bump per retry
let file_part = multipart::Part::stream_with_length(data.clone(), data.len() as u64);
```

`finish_upload` also drops the `buf.data.clone()` in favour of `Bytes::from(std::mem::take(&mut buf.data))` — zero-copy move out of the write buffer.

`upload()` now surfaces `delete()` errors explicitly — only `NotFound`/414/415 are treated as "already gone"; all other errors (e.g. permission denied) are returned early rather than masking them with a misleading `AlreadyExists` error later.

## `flush`: propagate upload errors to `close(2)`

Previously `flush` queued a background upload and returned `OK` immediately; errors only surfaced in `release`, which the kernel typically ignores. Now `flush` calls `finish_upload` synchronously so write failures are visible to the application.

The WebDAV `flush` also now clears `is_new` after the first upload so that subsequent flush/fsync cycles on the same file handle correctly use `overwrite=true` instead of failing with `AlreadyExists`.

## Cross-directory rename: guard against directory overwrite

`upload(overwrite=true)` internally calls `delete()`, which is recursive. A cross-directory file move or copy onto an existing directory path would silently delete the entire tree. Added an explicit `get_info` check on the destination in both `rename` and `copy`; returns `Forbidden` if the destination is a directory.

## macOS: URL-safe volume name + AppleScript injection fix

- `volume_name` is percent-encoded (RFC 3986 unreserved chars pass through; everything else → `%XX`) before being embedded in the WebDAV URL path, so mountpoints with spaces or special characters no longer produce malformed URLs.
- `osascript` is now invoked with `stdin` instead of `-e "…"`, so the URL is never interpolated into a shell/AppleScript string — eliminating the injection vector.

## macOS WebDAV server: path routing and shutdown fixes

- `dav_to_nas()` now enforces a path-component boundary before stripping the URL prefix, preventing `/nasfoo/...` from being incorrectly rewritten when the prefix is `/nas`.
- Each per-connection task in the WebDAV accept loop now selects on `shutdown_notify`, so in-flight connections are aborted promptly on Ctrl-C or Finder eject rather than keeping the process alive until the client closes the socket.