### PR TITLE
fix(release-please): attribute SynologyFuse/* commits to the fuse package

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,15 @@
       "package-name": "synology-filestation-fuse",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "include-paths": [
+        "rust/synology-filestation-fuse",
+        "SynologyFuse.Gui",
+        "SynologyFuse.Tests",
+        "SynologyFuse.MacInstaller",
+        "SynologyFuse.DebInstaller",
+        "SynologyFuse.Installer",
+        "SynologyFuse.sln"
+      ],
       "extra-files": [
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

Adds `include-paths` to the `synology-filestation-fuse` package in [release-please-config.json](release-please-config.json) so commits to the .NET GUI, the test project, and the platform installer subprojects get attributed to the FUSE package's changelog.

## Why

When the repo became a Cargo workspace (#40), each release-please package's "claim" on commits became its directory key — `rust/synology-filestation-fuse`, `rust/synology-filestation-core`, `python/synology_filestation`. The .NET GUI and installers all live at the repo root (`SynologyFuse.Gui/`, `SynologyFuse.Tests/`, `SynologyFuse.{Mac,Deb,}Installer/`), so commits that touch only those paths are "homeless" — not attributed to any package, and therefore omitted from every changelog.

## Concrete miss this fixes

[f540739](https://github.com/UCSD-E4E/synology-filestation/commit/f540739) — "fix: UI should have icon when running on ubuntu" — touched `SynologyFuse.Gui/` only and is **missing** from #41's `rust/synology-filestation-fuse/CHANGELOG.md`. After this change, release-please will re-evaluate on the next regeneration and add the entry.

## Test plan

- [x] `python3 -m json.tool release-please-config.json` parses cleanly
- [ ] After merge, observe release-please bot regenerate #41 (or a new release PR if #41 was already merged) with the `f540739` icon-fix entry under the FUSE package's changelog
- [ ] Land a future commit that touches only `SynologyFuse.Gui/` and confirm it appears in the next FUSE changelog

## Suggested merge order

1. Merge **this PR** first
2. Wait for the release-please bot to regenerate #41 with the corrected FUSE changelog
3. Merge #41 (releases 0.1.17 across all three packages with the icon fix included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)