### PR TITLE
docs: update README for the Cargo workspace + Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ sudo apt-get install dpkg-dev
 # Produces: SynologyFuse.DebInstaller/synologyfuse-0.1.2_amd64.deb
 ```
 
-Pass `--build` to compile the Rust CLI and publish the .NET GUI automatically. Omit it if you have already run `cargo build --release` and `dotnet publish` yourself. Use `--arch arm64` to target 64-bit ARM instead of x86-64 (default: `amd64`).
+Pass `--build` to compile the Rust CLI and publish the .NET GUI automatically. Omit it if you have already run `cargo build --release -p synology-filestation-fuse` and `dotnet publish` yourself. Use `--arch arm64` to target 64-bit ARM instead of x86-64 (default: `amd64`).
 
 The package installs:
 
@@ -214,7 +214,7 @@ xcode-select --install   # provides pkgbuild, productbuild, iconutil
 # Produces: SynologyFuse.MacInstaller/SynologyFuse-0.1.2.pkg
 ```
 
-Pass `--build` to compile the Rust CLI and publish the .NET GUI automatically. Omit it if you have already run `cargo build --release` and `dotnet publish` yourself. Use `--arch x86_64` to target Intel Macs instead of Apple Silicon (default: `arm64`).
+Pass `--build` to compile the Rust CLI and publish the .NET GUI automatically. Omit it if you have already run `cargo build --release -p synology-filestation-fuse` and `dotnet publish` yourself. Use `--arch x86_64` to target Intel Macs instead of Apple Silicon (default: `arm64`).
 
 #### Windows
 
@@ -237,7 +237,7 @@ wix extension add WixToolset.Util.wixext
 
 ```powershell
 # From repo root — build Rust CLI and .NET GUI first
-cargo build -r
+cargo build -r -p synology-filestation-fuse
 dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
 
 msbuild SynologyFuse.Installer\SynologyFuse.Installer.wixproj

--- a/README.md
+++ b/README.md
@@ -142,10 +142,12 @@ After saving the file, remount and all users will be able to access the share.
 ### CLI (all platforms)
 
 ```bash
-cargo build --release
+cargo build --release -p synology-filestation-fuse
 ```
 
 The binary will be at `target/release/synology-filestation-fuse`.
+
+The repo is a Cargo workspace; `-p synology-filestation-fuse` keeps the build scoped to the FUSE binary and its `synology-filestation-core` library dependency. Building the whole workspace also pulls in [`python/synology_filestation/`](python/synology_filestation/), which requires Python development headers — see [the Python package's README](python/synology_filestation/README.md) for that.
 
 ### GUI (all platforms)
 
@@ -328,22 +330,33 @@ diskutil unmount /Volumes/nas
 
 ## Architecture
 
+The repo is a Cargo workspace with three Rust crates plus the .NET desktop GUI and platform installers:
+
 ```
-synology-fuse/
-├── src/
-│   ├── main.rs          CLI argument parsing, Tokio runtime, platform dispatch
-│   ├── client.rs        Async Synology FileStation HTTP API client
-│   ├── types.rs         Serde types for API JSON responses
-│   ├── error.rs         Synology API error code → POSIX errno / NTSTATUS translation
-│   ├── fs.rs            fuser::Filesystem trait (Linux FUSE backend)
-│   ├── cache.rs         Inode ↔ path metadata cache + block-level read cache (Linux)
-│   ├── webdav.rs        dav_server::DavFileSystem trait (macOS WebDAV backend)
-│   └── winfs.rs         winfsp::FileSystemContext trait (Windows WinFsp backend)
-├── SynologyFuse.Gui/         Cross-platform desktop GUI (Avalonia / .NET 10)
-├── SynologyFuse.DebInstaller/ Linux .deb package (dpkg-deb)
-├── SynologyFuse.MacInstaller/ macOS .pkg installer (pkgbuild / productbuild)
-├── SynologyFuse.Installer/   Windows MSI + bundle installer (WiX 6)
-└── SynologyFuse.Tests/       xUnit tests for the GUI project
+synology-filestation/
+├── rust/
+│   ├── synology-filestation-core/   Pure async HTTP client (no platform deps)
+│   │   └── src/
+│   │       ├── client.rs            FileStation API; auto-relogin; atomic download_to_path
+│   │       ├── types.rs             Serde types for API JSON responses
+│   │       └── error.rs             SynoFsError + Linux errno mapping
+│   └── synology-filestation-fuse/   CLI + FUSE / WebDAV / WinFsp backends
+│       └── src/
+│           ├── main.rs              CLI argument parsing, Tokio runtime, platform dispatch
+│           ├── fs.rs                fuser::Filesystem trait (Linux FUSE backend)
+│           ├── cache.rs             Inode ↔ path cache + block-level read cache (Linux)
+│           ├── webdav.rs            dav_server::DavFileSystem trait (macOS WebDAV backend)
+│           └── winfs.rs             winfsp::FileSystemContext trait (Windows WinFsp backend)
+├── python/
+│   └── synology_filestation/        PyO3 + maturin Python bindings (synofs fsspec)
+│       ├── src/lib.rs               PyO3 _native module: Client, AsyncClient, exceptions
+│       ├── synology_filestation/    Importable Python package (re-exports + fsspec.py)
+│       └── tests/                   pytest + pytest-httpserver
+├── SynologyFuse.Gui/                Cross-platform desktop GUI (Avalonia / .NET 10)
+├── SynologyFuse.DebInstaller/       Linux .deb package (dpkg-deb)
+├── SynologyFuse.MacInstaller/       macOS .pkg installer (pkgbuild / productbuild)
+├── SynologyFuse.Installer/          Windows MSI + bundle installer (WiX 6)
+└── SynologyFuse.Tests/              xUnit tests for the GUI project
 ```
 
 ### GUI

--- a/SynologyFuse.DebInstaller/Build-Package.sh
+++ b/SynologyFuse.DebInstaller/Build-Package.sh
@@ -20,7 +20,7 @@
 #     # Rust toolchain and .NET 10 SDK must also be installed
 #
 #   Run from the repo root (or any directory), having already built:
-#     cargo build --release
+#     cargo build --release -p synology-filestation-fuse
 #     dotnet publish SynologyFuse.Gui -c Release -r linux-x64 -p:SelfContained=true
 #
 #   Or pass --build to have this script run those steps automatically.
@@ -121,7 +121,7 @@ fi
 
 if [[ ! -f "${RUST_RELEASE_DIR}/${CLI_BINARY}" ]]; then
     echo "Error: CLI binary not found at '${RUST_RELEASE_DIR}/${CLI_BINARY}'." >&2
-    echo "  Run 'cargo build --release' first, or pass --build." >&2
+    echo "  Run 'cargo build --release -p synology-filestation-fuse' first, or pass --build." >&2
     exit 1
 fi
 

--- a/SynologyFuse.Installer/Build-Bundle.ps1
+++ b/SynologyFuse.Installer/Build-Bundle.ps1
@@ -11,7 +11,7 @@
         wix extension add -g WixToolset.Bal.wixext/6.0.2
 
     Run from the repo root before calling this script:
-        cargo build -r
+        cargo build -r -p synology-filestation-fuse
         dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
         msbuild SynologyFuse.Installer\SynologyFuse.Installer.wixproj
 

--- a/SynologyFuse.Installer/Build-Installer.ps1
+++ b/SynologyFuse.Installer/Build-Installer.ps1
@@ -10,7 +10,7 @@
         dotnet tool install --global wix
 
     Run from the repo root before calling this script:
-        cargo build -r
+        cargo build -r -p synology-filestation-fuse
         dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
 
 .PARAMETER Version
@@ -45,7 +45,7 @@ if (-not (Get-Command wix -ErrorAction SilentlyContinue)) {
 
 $CliExe = Join-Path $RustBin "synology-filestation-fuse.exe"
 if (-not (Test-Path $CliExe)) {
-    throw "Rust CLI not found at '$CliExe'. Build it first: cargo build -r"
+    throw "Rust CLI not found at '$CliExe'. Build it first: cargo build -r -p synology-filestation-fuse"
 }
 
 if (-not (Test-Path $GuiPublish)) {

--- a/SynologyFuse.Installer/Bundle.wxs
+++ b/SynologyFuse.Installer/Bundle.wxs
@@ -7,7 +7,7 @@
     2. SynologyFuse MSI
 
   Build prerequisites (run from repo root):
-    cargo build -r
+    cargo build -r -p synology-filestation-fuse
     dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
     # Build the inner MSI first:
     msbuild SynologyFuse.Installer\SynologyFuse.Installer.wixproj

--- a/SynologyFuse.Installer/Package.wxs
+++ b/SynologyFuse.Installer/Package.wxs
@@ -12,7 +12,7 @@
     • WinFsp  https://winfsp.dev/  (checked at install time)
 
   Build prerequisites (run from repo root):
-    cargo build -r
+    cargo build -r -p synology-filestation-fuse
     dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
 
   Build the MSI (from repo root):

--- a/SynologyFuse.MacInstaller/Build-Installer.sh
+++ b/SynologyFuse.MacInstaller/Build-Installer.sh
@@ -15,7 +15,7 @@
 #     # Rust toolchain and .NET 10 SDK must also be installed
 #
 #   Run from the repo root (or any directory), having already built:
-#     cargo build --release
+#     cargo build --release -p synology-filestation-fuse
 #     dotnet publish SynologyFuse.Gui -c Release -r osx-arm64 -p:SelfContained=true
 #
 #   Or pass --build to have this script run those steps automatically.
@@ -111,7 +111,7 @@ fi
 
 if [[ ! -f "${RUST_RELEASE_DIR}/${CLI_BINARY}" ]]; then
     echo "Error: CLI binary not found at '${RUST_RELEASE_DIR}/${CLI_BINARY}'." >&2
-    echo "  Run 'cargo build --release' first, or pass --build." >&2
+    echo "  Run 'cargo build --release -p synology-filestation-fuse' first, or pass --build." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two stale spots in [README.md](README.md):

1. **`cargo build --release`** under \"Building / CLI\" → now scoped to **`cargo build --release -p synology-filestation-fuse`**. The repo became a Cargo workspace in #40, and a bare `cargo build` now also tries to build [`python/synology_filestation/`](python/synology_filestation/), which requires Python development headers. Added a one-line note explaining the `-p` scope and pointing to the Python package's own README.
2. **Architecture tree** still showed the pre-refactor single-crate `src/` layout. Replaced with the workspace tree so contributors can see where the FUSE/WebDAV/WinFsp source actually lives now.

[CLAUDE.md](CLAUDE.md) was already up-to-date (it was rewritten for the workspace during #40). The Python package's [README](python/synology_filestation/README.md) has no workspace-relative paths so it didn't need changes.

## Side benefit

Merging this provides the push-to-main that release-please needs to retrigger after #41 was closed. With #43's include-paths now on main, the next release-please run should produce a fresh release PR that correctly attributes f540739 (\"UI should have icon when running on ubuntu\") to the FUSE package's changelog.

## Test plan

- [x] Visual check that the architecture tree matches the actual repo layout (`ls rust/ python/`)
- [x] `cargo build --release -p synology-filestation-fuse` still works locally
- [ ] After merge, verify release-please regenerates a release PR with f540739 in `rust/synology-filestation-fuse/CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)