### PR TITLE
fix(python): bump requires-python to >=3.10

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Match the abi3-py39 wheel target — runtime CPython versions our
+        # Match the abi3-py310 wheel target — runtime CPython versions our
         # wheel will be loaded under in the wild.
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:

--- a/python/synology_filestation/Cargo.toml
+++ b/python/synology_filestation/Cargo.toml
@@ -13,10 +13,11 @@ crate-type = ["cdylib"]
 [dependencies]
 synology-filestation-core = { path = "../../rust/synology-filestation-core", version = "0.1.16" }
 
-# pyo3 0.23 supports abi3-py39, which gives us a single Linux wheel that works
-# on Python 3.9 through whatever's current. Bumping to 0.24+ later is a
-# straight find/replace; pyo3-async-runtimes versions track pyo3 versions.
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py39"] }
+# abi3-py310 lets a single Linux wheel cover Python 3.10 through whatever's
+# current. Tied to pyproject.toml's `requires-python = ">=3.10"` and the CI
+# test matrix (3.10–3.13). Bumping pyo3 itself to 0.24+ later is a straight
+# find/replace; pyo3-async-runtimes versions track pyo3 versions.
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py310"] }
 pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
 
 # pyo3-log routes Rust `log` records into Python's `logging`. tracing-log

--- a/python/synology_filestation/pyproject.toml
+++ b/python/synology_filestation/pyproject.toml
@@ -9,7 +9,7 @@ features = ["pyo3/extension-module"]
 
 [project]
 name = "synology-filestation"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
## Summary

Bumps the Python package's declared minimum Python version from 3.9 to 3.10, and aligns the pyo3 abi3 target accordingly.

## Why

[Dependabot run 25510756514](https://github.com/UCSD-E4E/synology-filestation/actions/runs/25510756514) — the security update for pytest — failed with:

\`\`\`
security_update_not_possible:
  dependency-name: pytest
  latest-resolvable-version: 8.4.2
  lowest-non-vulnerable-version: 9.0.3
\`\`\`

pytest 9.0+ requires Python 3.10+. Our [pyproject.toml](python/synology_filestation/pyproject.toml) claimed \`requires-python = ">=3.9"\`, so dependabot filtered out pytest 9.x as "unsupported" for our project and concluded 8.4.2 was the highest resolvable version — which still has the CVE.

The 3.9 claim wasn't backed up anywhere: [python.yml](.github/workflows/python.yml)'s test matrix is \`["3.10", "3.11", "3.12", "3.13"]\`, so we don't actually verify 3.9. Bringing the declared minimum in line with the tested minimum.

## Changes

| File | Change |
|---|---|
| [python/synology_filestation/pyproject.toml](python/synology_filestation/pyproject.toml) | \`requires-python = ">=3.9"\` → \`">=3.10"\` |
| [python/synology_filestation/Cargo.toml](python/synology_filestation/Cargo.toml) | pyo3 feature \`abi3-py39\` → \`abi3-py310\` (so the wheel's binary requirement matches the declared one) |
| [.github/workflows/python.yml](.github/workflows/python.yml) | comment update from "abi3-py39 wheel target" → "abi3-py310 wheel target" |

## Test plan

- [x] \`cargo build -p synology_filestation\` — clean
- [x] \`uv sync && uv run pytest\` — 66 passing
- [ ] After merge, dependabot's pytest security update should resolve to 9.x successfully

## Note on the other failed dependabot run

[Run 25510755470](https://github.com/UCSD-E4E/synology-filestation/actions/runs/25510755470) (pyo3 security update via cargo) is a **separate issue** — \`dependency_file_not_supported\` because dependabot was pointed at \`/python/synology_filestation\` for cargo, but in a Cargo workspace the lockfile lives only at the root. Fixing that requires a [.github/dependabot.yml](.github/dependabot.yml) update to move/consolidate the cargo entry to \`/\`. Happy to follow up with a separate PR for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)