### PR TITLE
fix(deps): explicit dependabot.yml for cargo workspace + other ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Explicit Dependabot config so cargo updates target the workspace root
+# (where Cargo.lock lives). Auto-detection finds each member crate's
+# Cargo.toml separately and then can't locate a lockfile when running
+# security updates — see the pyo3 failure in run 25510755470.
+#
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  # Rust workspace — one entry covers all three member crates
+  # (synology-filestation-core, synology-filestation-fuse, synology_filestation)
+  # because they share the workspace Cargo.lock at the repo root.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # Python bindings — uv-managed, lockfile is python/synology_filestation/uv.lock.
+  - package-ecosystem: uv
+    directory: /python/synology_filestation
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # GitHub Actions versions used in .github/workflows/*.yml.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # .NET / NuGet for the desktop GUI and its xUnit test project.
+  # SynologyFuse.{Mac,Deb,}Installer projects don't have their own
+  # .csproj-driven NuGet deps — they're shell/PowerShell/WiX builders.
+  - package-ecosystem: nuget
+    directory: /SynologyFuse.Gui
+    schedule:
+      interval: weekly
+  - package-ecosystem: nuget
+    directory: /SynologyFuse.Tests
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

Adds an explicit [.github/dependabot.yml](.github/dependabot.yml) so cargo security updates can find the workspace's shared lockfile.

## Why

Without a config file, Dependabot's auto-detection scans the repo and treats every directory containing a \`Cargo.toml\` as its own cargo ecosystem:
- \`/\` (workspace root)
- \`/rust/synology-filestation-core\`
- \`/rust/synology-filestation-fuse\`
- \`/python/synology_filestation\`

For **security updates** Dependabot needs a lockfile to determine the exact installed version, but only the workspace root has \`Cargo.lock\`. So security updates targeted at member crates fail with \`dependency_file_not_supported\` — see [run 25510755470](https://github.com/UCSD-E4E/synology-filestation/actions/runs/25510755470) where the pyo3 update failed for exactly this reason.

(Regular version-update PRs like #33 / #34 still worked because those don't strictly need a lockfile.)

## Changes

The new dependabot.yml enumerates every ecosystem we want covered, since an explicit config replaces auto-detection wholesale:

| Ecosystem | Directory | Why |
|---|---|---|
| cargo | \`/\` | Workspace root — single entry covers all three member crates through the shared \`Cargo.lock\`. **This is the actual fix.** |
| uv | \`/python/synology_filestation\` | uv.lock lives here |
| github-actions | \`/\` | workflow files in \`.github/workflows/\` |
| nuget | \`/SynologyFuse.Gui\` | .NET GUI project |
| nuget | \`/SynologyFuse.Tests\` | .NET test project |

The Mac / Deb / Windows installer projects are shell/PowerShell/WiX builders without .csproj-driven NuGet deps, so they don't need their own entry.

## Test plan

- [x] \`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"\` parses cleanly
- [ ] After merge, observe the next pyo3 security update target the workspace root and succeed (will appear in the security alerts dashboard)
- [ ] Verify existing weekly cadence is preserved — open PR #42 (rpassword bump) is the most recent example

🤖 Generated with [Claude Code](https://claude.com/claude-code)