### PR TITLE
build(deps): bump rpassword to 7.5.2 (skip the broken 7.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,13 +1567,13 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.4.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-core"
-version = "0.1.16"
+version = "0.1.18"
 dependencies = [
  "bytes",
  "libc",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-fuse"
-version = "0.1.16"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1851,7 +1851,7 @@ dependencies = [
 
 [[package]]
 name = "synology_filestation"
-version = "0.1.16"
+version = "0.1.18"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",


### PR DESCRIPTION
## Summary

Bumps \`rpassword\` from 7.4.0 → **7.5.2** (a Cargo.lock-only change; the manifest stays \`rpassword = "7"\`). Supersedes Dependabot's #42, which targeted 7.5.0 and was failing \`build-macos\` on every rebase.

## Why not just merge #42

\`rpassword 7.5.0\` doesn't compile on macOS. The maintainer introduced unconditional use of \`libc::__errno_location()\`:

\`\`\`
error[E0425]: cannot find function \`__errno_location\` in crate \`libc\`
   --> rpassword-7.5.0/src/unix.rs:26:16
26  |         *libc::__errno_location() = 0;
    |                ^^^^^^^^^^^^^^^^ not found in \`libc\`
\`\`\`

\`__errno_location\` is a Linux/glibc symbol; macOS uses \`__error()\` instead. They published 7.5.1 (2026-04-29) and 7.5.2 (2026-05-03) shortly after, presumably with the fix. Dependabot pinned its PR to 7.5.0 and won't auto-rebase to a newer 7.5.x — so the cleanest move is to skip past 7.5.0 entirely.

## Test plan

- [x] \`cargo build --workspace\` — clean on Linux
- [x] \`cargo test --workspace\` — 72/72 passing
- [ ] \`build-macos\` CI check on this PR — if green, the upstream fix landed as expected
- [ ] Close #42 once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)