### PR TITLE
feat: add Nix flake for CLI, GUI, and dev shell

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,28 @@
+name: Nix
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  flake-check:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@main
+    # Caches /nix/store across runs (keyed on the flake lockfile) so the heavy
+    # Rust + .NET builds only run from scratch when inputs change.
+    - name: Cache Nix store
+      uses: nix-community/cache-nix-action@v6
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'nix/deps.json') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+    # Runs the CLI build, clippy (-D warnings), rustfmt, and the GUI build +
+    # test suite — i.e. every `checks.x86_64-linux.*` output in the flake.
+    - name: nix flake check
+      run: nix flake check -L

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+### Nix ###
+# Build symlinks produced by `nix build`
+/result
+/result-*
+
 # Created by https://www.toptal.com/developers/gitignore/api/linux,windows,macos,visualstudiocode,rust,rust-analyzer,csharp,rider,visualstudio,dotnetcore
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,windows,macos,visualstudiocode,rust,rust-analyzer,csharp,rider,visualstudio,dotnetcore
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,4 +191,5 @@ CI workflows:
 | `.github/workflows/rust.yml`           | every push / PR        | clippy, build, test for the rust crates + .deb/.pkg/.msi smoke builds |
 | `.github/workflows/python.yml`         | every push             | pytest matrix (Python 3.10–3.13) for the bindings |
 | `.github/workflows/maturin.yml`        | every push             | manylinux wheel smoke build |
+| `.github/workflows/nix.yml`            | push to main / PR      | `nix flake check` — CLI + GUI builds, clippy, rustfmt, GUI tests |
 | `.github/workflows/release-please.yml` | tag (or workflow_dispatch) | release-please PRs and per-package artifact uploads |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,75 @@ The installer includes [WinFsp](https://winfsp.dev/) and automatically installs 
 
 To build the installer yourself, see [Building the installer](#building-the-installer) below.
 
+## Nix installation
+
+The repository ships a flake exposing both binaries as packages:
+
+| Output | Contents |
+|---|---|
+| `synology-filestation-fuse` (also `default`) | The Rust CLI |
+| `synologyfuse-gui` | The .NET 10 / Avalonia desktop GUI |
+
+> **Install both if you use the GUI.** The GUI launches the CLI as a subprocess and resolves it via `PATH`, so `synologyfuse-gui` on its own cannot mount anything.
+
+### Try it without installing
+
+```bash
+nix run github:UCSD-E4E/synology-filestation          # CLI
+nix run github:UCSD-E4E/synology-filestation#gui       # GUI
+```
+
+### Imperative (user profile)
+
+```bash
+nix profile install \
+  github:UCSD-E4E/synology-filestation#synology-filestation-fuse \
+  github:UCSD-E4E/synology-filestation#synologyfuse-gui
+```
+
+### Declarative (NixOS flake)
+
+Add the flake as an input and pull the packages into `environment.systemPackages`:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    synology-filestation.url = "github:UCSD-E4E/synology-filestation";
+    # Reuse your system's nixpkgs instead of evaluating a second copy:
+    synology-filestation.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, synology-filestation, ... }: {
+    nixosConfigurations.YOUR_HOST = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            synology-filestation.packages.${pkgs.system}.synology-filestation-fuse
+            synology-filestation.packages.${pkgs.system}.synologyfuse-gui   # optional
+          ];
+
+          # Required for non-root FUSE mounting (see below).
+          programs.fuse.userAllowOther = true;
+        })
+      ];
+    };
+  };
+}
+```
+
+Then `sudo nixos-rebuild switch --flake .#YOUR_HOST`. For [Home Manager](https://nix-community.github.io/home-manager/), use the same packages in `home.packages` instead.
+
+On NixOS the CLI mounts via a setuid `fusermount3`; if you hit `fusermount3: permission denied`, the `programs.fuse.userAllowOther = true` option above provides it (this is the NixOS equivalent of the [`/etc/fuse.conf` step](#linux-fuse-configuration-allow_other) below).
+
+### Develop against the flake
+
+`nix develop` drops you into a shell with the Rust toolchain (clippy/rustfmt), `pkg-config` + `fuse3`, the Python binding toolchain (`uv`, `maturin`, `python3`), and the .NET 10 SDK — everything needed to build every component in this repo. `nix flake check` runs the CLI build, clippy, rustfmt, and the GUI build + test suite.
+
+Supported systems: `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`.
+
 ## Requirements
 
 ### System

--- a/README.md
+++ b/README.md
@@ -77,21 +77,22 @@ The repository ships a flake exposing both binaries as packages:
 | `synology-filestation-fuse` (also `default`) | The Rust CLI |
 | `synologyfuse-gui` | The .NET 10 / Avalonia desktop GUI |
 
-> **Install both if you use the GUI.** The GUI launches the CLI as a subprocess and resolves it via `PATH`, so `synologyfuse-gui` on its own cannot mount anything.
+The GUI launches the CLI as a subprocess, so the `synologyfuse-gui` package wraps its launcher with the CLI already on `PATH` — installing or running the GUI alone is enough to mount. Install `synology-filestation-fuse` as well if you also want the CLI available directly in your shell.
 
 ### Try it without installing
 
 ```bash
 nix run github:UCSD-E4E/synology-filestation          # CLI
-nix run github:UCSD-E4E/synology-filestation#gui       # GUI
+nix run github:UCSD-E4E/synology-filestation#gui       # GUI (bundles the CLI)
 ```
 
 ### Imperative (user profile)
 
 ```bash
+# GUI (self-contained), plus the CLI for direct shell use:
 nix profile install \
-  github:UCSD-E4E/synology-filestation#synology-filestation-fuse \
-  github:UCSD-E4E/synology-filestation#synologyfuse-gui
+  github:UCSD-E4E/synology-filestation#synologyfuse-gui \
+  github:UCSD-E4E/synology-filestation#synology-filestation-fuse
 ```
 
 ### Declarative (NixOS flake)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780029330,
+        "narHash": "sha256-fWFKEKB5CP+NO8/3uOaEZIVbd03mvDJ//VsnKkXty08=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "6823b493a0bc2142082075576efa6633b537197e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780024773,
+        "narHash": "sha256-aU9nlrS9S+IJ2EiCzsaxzOXUhggogqTrJojBicE6Oeg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "40b0a3a193e0840c76174b4a322874c8f6dd0a63",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -149,6 +149,15 @@
             selfContainedBuild = true;
             runtimeDeps = guiRuntimeDeps;
 
+            # The GUI shells out to the CLI, which MountService.FindBinary()
+            # resolves via PATH (the CLI is a separate derivation, so it is not
+            # beside the GUI binary). Put it on the launcher's PATH so the GUI is
+            # self-sufficient — `nix run .#gui` can mount without the user also
+            # installing synology-filestation-fuse separately.
+            makeWrapperArgs = [
+              "--prefix PATH : ${lib.makeBinPath [ synology-filestation-fuse ]}"
+            ];
+
             meta = {
               description = "Desktop GUI for the Synology FileStation filesystem driver";
               homepage = "https://github.com/UCSD-E4E/synology-filestation";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,224 @@
+{
+  description = "Cross-platform filesystem driver mounting a Synology FileStation share as a local directory";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      crane,
+    }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (
+        system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+
+          inherit (pkgs) lib;
+          isLinux = pkgs.stdenv.hostPlatform.isLinux;
+          isDarwin = pkgs.stdenv.hostPlatform.isDarwin;
+
+          # Pinned stable toolchain. rust-src/clippy/rustfmt are bundled so the
+          # dev shell and `cargo clippy --workspace` (per CLAUDE.md) work as-is.
+          rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [
+              "rust-src"
+              "clippy"
+              "rustfmt"
+            ];
+          };
+
+          craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+          # The crate sources. We keep the full workspace in scope (the CLI
+          # depends on the path-dep core crate) but build only the CLI package.
+          src = craneLib.cleanCargoSource ./.;
+
+          # The root Cargo.toml is a bare workspace with no [package], so read
+          # pname/version from the CLI crate's own manifest. Without this crane
+          # falls back to a "cargo-package-0.0.1" placeholder.
+          crateName = craneLib.crateNameFromCargoToml {
+            cargoToml = ./rust/synology-filestation-fuse/Cargo.toml;
+          };
+
+          # pkg-config locates libfuse3 on Linux. The FUSE backend (fuser 0.17)
+          # is cfg-gated to target_os = "linux"; macOS uses the dav-server
+          # WebDAV backend, which needs no extra system library.
+          nativeBuildInputs = [ pkgs.pkg-config ];
+
+          buildInputs =
+            lib.optionals isLinux [ pkgs.fuse3 ]
+            ++ lib.optionals isDarwin [
+              # reqwest's rustls-tls path avoids OpenSSL; libiconv + the
+              # SystemConfiguration framework cover the common darwin link needs.
+              pkgs.libiconv
+              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+            ];
+
+          commonArgs = {
+            inherit (crateName) pname version;
+            inherit src nativeBuildInputs buildInputs;
+            strictDeps = true;
+
+            # Scope every cargo invocation to the CLI crate so the PyO3 cdylib
+            # crate (python/synology_filestation) is never built here — that
+            # belongs to the maturin/uv path, not this Nix derivation.
+            cargoExtraArgs = "--package synology-filestation-fuse";
+          };
+
+          # Dependency-only build, cached independently of the source so source
+          # edits don't rebuild the dependency graph.
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+          synology-filestation-fuse = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = false; # tests hit a live NAS / wiremock; run via dev shell
+              meta = {
+                description = "Mount a Synology FileStation share as a local directory";
+                homepage = "https://github.com/UCSD-E4E/synology-filestation";
+                license = lib.licenses.mit;
+                mainProgram = "synology-filestation-fuse";
+                platforms = lib.platforms.linux ++ lib.platforms.darwin;
+              };
+            }
+          );
+
+          # ── .NET 10 GUI (Avalonia) ────────────────────────────────────────
+          dotnet = pkgs.dotnetCorePackages.sdk_10_0;
+
+          # Avalonia needs these shared libraries at runtime on Linux; the
+          # buildDotnetModule wrapper bakes them into the launcher's
+          # LD_LIBRARY_PATH. Harmless/ignored on darwin, so we gate the list.
+          guiRuntimeDeps = lib.optionals isLinux (
+            with pkgs;
+            [
+              fontconfig
+              libGL
+              libxkbcommon
+              libx11
+              libice
+              libsm
+              libxi
+              libxext
+              libxrandr
+              libxcursor
+              libxrender
+            ]
+          );
+
+          synologyfuse-gui = pkgs.buildDotnetModule {
+            pname = "synologyfuse-gui";
+            inherit (crateName) version;
+
+            src = ./.;
+
+            projectFile = "SynologyFuse.Gui/SynologyFuse.Gui.csproj";
+            testProjectFile = "SynologyFuse.Tests/SynologyFuse.Tests.csproj";
+
+            # Regenerate with: nix build .#synologyfuse-gui.fetch-deps
+            # then run the resulting script (writes to ./nix/deps.json).
+            nugetDeps = ./nix/deps.json;
+
+            dotnet-sdk = dotnet;
+            dotnet-runtime = pkgs.dotnetCorePackages.runtime_10_0;
+
+            executables = [ "SynologyFuse.Gui" ];
+            selfContainedBuild = true;
+            runtimeDeps = guiRuntimeDeps;
+
+            meta = {
+              description = "Desktop GUI for the Synology FileStation filesystem driver";
+              homepage = "https://github.com/UCSD-E4E/synology-filestation";
+              license = lib.licenses.mit;
+              mainProgram = "SynologyFuse.Gui";
+              platforms = lib.platforms.linux ++ lib.platforms.darwin;
+            };
+          };
+        in
+        {
+          packages = {
+            inherit synology-filestation-fuse synologyfuse-gui;
+            default = synology-filestation-fuse;
+          };
+
+          apps = {
+            default = flake-utils.lib.mkApp {
+              drv = synology-filestation-fuse;
+            };
+            gui = flake-utils.lib.mkApp {
+              drv = synologyfuse-gui;
+              name = "SynologyFuse.Gui";
+            };
+          };
+
+          checks = {
+            inherit synology-filestation-fuse synologyfuse-gui;
+
+            clippy = craneLib.cargoClippy (
+              commonArgs
+              // {
+                inherit cargoArtifacts;
+                cargoClippyExtraArgs = "--all-targets -- -D warnings";
+              }
+            );
+
+            fmt = craneLib.cargoFmt { inherit (crateName) pname version; inherit src; };
+          };
+
+          devShells.default = craneLib.devShell {
+            inputsFrom = [ synology-filestation-fuse ];
+
+            packages =
+              [
+                # Python-bindings toolchain (python/synology_filestation).
+                pkgs.uv
+                pkgs.maturin
+                pkgs.python3
+
+                # .NET 10 GUI (SynologyFuse.Gui).
+                dotnet
+              ]
+              ++ lib.optionals isLinux [
+                # Handy for mounting/unmounting during manual testing.
+                pkgs.fuse3
+              ];
+
+            env = {
+              DOTNET_ROOT = "${dotnet}";
+              DOTNET_CLI_TELEMETRY_OPTOUT = "1";
+              DOTNET_NOLOGO = "1";
+            }
+            // lib.optionalAttrs isLinux {
+              # uv/maturin build the PyO3 extension against a real interpreter;
+              # some crates' build scripts look for libfuse via pkg-config.
+              PKG_CONFIG_PATH = "${pkgs.fuse3.dev}/lib/pkgconfig";
+            };
+          };
+
+          formatter = pkgs.nixfmt;
+        }
+      );
+}

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,0 +1,197 @@
+[
+  {
+    "pname": "Avalonia",
+    "version": "11.2.3",
+    "hash": "sha256-NUoyXJkIsgbkcKFVb10VRafM4ViHs801c/7vhu3ssUY="
+  },
+  {
+    "pname": "Avalonia",
+    "version": "12.0.2",
+    "hash": "sha256-Ht2h4cBtnVhrk9VWsHDOEvU1wd/y80CxMDWn8W0lHKk="
+  },
+  {
+    "pname": "Avalonia.Angle.Windows.Natives",
+    "version": "2.1.22045.20230930",
+    "hash": "sha256-RxPcWUT3b/+R3Tu5E5ftpr5ppCLZrhm+OTsi0SwW3pc="
+  },
+  {
+    "pname": "Avalonia.BuildServices",
+    "version": "11.3.2",
+    "hash": "sha256-6wx06tjSKWQOlX2czdp6Wh0nuwVapx5qf/s8Qj5we40="
+  },
+  {
+    "pname": "Avalonia.Desktop",
+    "version": "11.2.3",
+    "hash": "sha256-srtZi+kDbhRtMl33l91zssBWETU5oHodKbbWyfEsb/I="
+  },
+  {
+    "pname": "Avalonia.Fonts.Inter",
+    "version": "11.2.3",
+    "hash": "sha256-ySsCXVpjqjCX/uYkwluSfrAoBtuq9k7fC1bFjxKC9/Q="
+  },
+  {
+    "pname": "Avalonia.FreeDesktop",
+    "version": "11.2.3",
+    "hash": "sha256-3sNemBmZE06w2ul87T5HrEeHUxXMOa9MfQhpI4AoxDY="
+  },
+  {
+    "pname": "Avalonia.Native",
+    "version": "11.2.3",
+    "hash": "sha256-2Gp98NGWcrILqF+P5PDMPRdsMby/lZiT3eWAUskFim8="
+  },
+  {
+    "pname": "Avalonia.Remote.Protocol",
+    "version": "12.0.2",
+    "hash": "sha256-19hc0GSsa9JujiZlHxLKn7x6fUjAeJSH3lO43hL0bD0="
+  },
+  {
+    "pname": "Avalonia.Skia",
+    "version": "11.2.3",
+    "hash": "sha256-QBp8wTA92hGwbmNSVL4gsjrqA9CfwDPgdTiOEqcogGA="
+  },
+  {
+    "pname": "Avalonia.Themes.Fluent",
+    "version": "12.0.2",
+    "hash": "sha256-H8AXau1gV8m33lKYrSzxp0GDmoCuyx7+B93gTfcpXXU="
+  },
+  {
+    "pname": "Avalonia.Win32",
+    "version": "11.2.3",
+    "hash": "sha256-xKFKObvqdJaQjphEktRJvzmAoDEsKg3WqlEG31V3qLE="
+  },
+  {
+    "pname": "Avalonia.X11",
+    "version": "11.2.3",
+    "hash": "sha256-SD4dmpKx4l8YOyUnrA0fnf2Bb+tHSNyARh7GAtHyg60="
+  },
+  {
+    "pname": "CommunityToolkit.Mvvm",
+    "version": "8.4.2",
+    "hash": "sha256-jLS1vo6V+fHsJs80HYT77oJE6IEC68fIgkLpYODjWAU="
+  },
+  {
+    "pname": "HarfBuzzSharp",
+    "version": "7.3.0.3",
+    "hash": "sha256-1vDIcG1aVwVABOfzV09eAAbZLFJqibip9LaIx5k+JxM="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.Linux",
+    "version": "7.3.0.3",
+    "hash": "sha256-HW5r16wdlgDMbE/IfE5AQGDVFJ6TS6oipldfMztx+LM="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.macOS",
+    "version": "7.3.0.3",
+    "hash": "sha256-UpAVfRIYY8Wh8xD4wFjrXHiJcvlBLuc2Xdm15RwQ76w="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.WebAssembly",
+    "version": "7.3.0.3",
+    "hash": "sha256-jHrU70rOADAcsVfVfozU33t/5B5Tk0CurRTf4fVQe3I="
+  },
+  {
+    "pname": "HarfBuzzSharp.NativeAssets.Win32",
+    "version": "7.3.0.3",
+    "hash": "sha256-v/PeEfleJcx9tsEQAo5+7Q0XPNgBqiSLNnB2nnAGp+I="
+  },
+  {
+    "pname": "MicroCom.Runtime",
+    "version": "0.11.4",
+    "hash": "sha256-hd13T4Z9DsF1Sb56bS+SDpWjksJVzb4m/Kp37jaUhkU="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "18.5.1",
+    "hash": "sha256-OnahMnRBbdlGSz+igNB0GaMS7PAppefPL1fWN1+cs0w="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "18.5.1",
+    "hash": "sha256-X69wQBKd5GvXfO7BaPWFcyrwfi/kZFVdH/axorIra5Y="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "18.5.1",
+    "hash": "sha256-CUuOoANj4lXhQAE1/265X6S+afmNxhpsICEIDqNzSXk="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "18.5.1",
+    "hash": "sha256-jtb74D0mqq7hu/nlCtV7IU2dXhviLrmGPER0ttdH2Dg="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "SkiaSharp",
+    "version": "2.88.9",
+    "hash": "sha256-jZ/4nVXYJtrz9SBf6sYc/s0FxS7ReIYM4kMkrhZS+24="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Linux",
+    "version": "2.88.9",
+    "hash": "sha256-mQ/oBaqRR71WfS66mJCvcc3uKW7CNEHoPN2JilDbw/A="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.macOS",
+    "version": "2.88.9",
+    "hash": "sha256-qvGuAmjXGjGKMzOPBvP9VWRVOICSGb7aNVejU0lLe/g="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.WebAssembly",
+    "version": "2.88.9",
+    "hash": "sha256-vgFL4Pdy3O1RKBp+T9N3W4nkH9yurZ0suo8u3gPmmhY="
+  },
+  {
+    "pname": "SkiaSharp.NativeAssets.Win32",
+    "version": "2.88.9",
+    "hash": "sha256-kP5XM5GgwHGfNJfe4T2yO5NIZtiF71Ddp0pd1vG5V/4="
+  },
+  {
+    "pname": "Tmds.DBus.Protocol",
+    "version": "0.20.0",
+    "hash": "sha256-CRW/tkgsuBiBJfRwou12ozRQsWhHDooeP88E5wWpWJw="
+  },
+  {
+    "pname": "xunit",
+    "version": "2.9.3",
+    "hash": "sha256-BPrpSbjlIB7PoH+ocCusqMDrMZgRQZSzeTeJzHK/I9c="
+  },
+  {
+    "pname": "xunit.abstractions",
+    "version": "2.0.3",
+    "hash": "sha256-0D1y/C34iARI96gb3bAOG8tcGPMjx+fMabTPpydGlAM="
+  },
+  {
+    "pname": "xunit.analyzers",
+    "version": "1.18.0",
+    "hash": "sha256-DOgamLnfi9Ua5IDm3JVm9MaOFbSSbmq5l8j2NPO3qd0="
+  },
+  {
+    "pname": "xunit.assert",
+    "version": "2.9.3",
+    "hash": "sha256-vHYOde8bd10pOmr7iTAYNtPlqHzsJl4x3t1DDuYdDCA="
+  },
+  {
+    "pname": "xunit.core",
+    "version": "2.9.3",
+    "hash": "sha256-qkVQ8Jw/LZWmxirkPOwiry7bvZn3IuaRzu/sp2H8anw="
+  },
+  {
+    "pname": "xunit.extensibility.core",
+    "version": "2.9.3",
+    "hash": "sha256-mcpVX+m0R7F0ev9CaBnbai9gtu4GVcqijEuRqe89D0g="
+  },
+  {
+    "pname": "xunit.extensibility.execution",
+    "version": "2.9.3",
+    "hash": "sha256-2rxMs2Dt4cAcmOFMwP5Yd3RpP0BnmiL8cXlKysXY0jw="
+  },
+  {
+    "pname": "xunit.runner.visualstudio",
+    "version": "3.1.5",
+    "hash": "sha256-O5657884QGldszsEWQFCDRTXViFBmZ4GGC+4iU+usSQ="
+  }
+]


### PR DESCRIPTION
## Summary

Adds a Nix flake so the project can be built, installed, and developed on any Nix system (including NixOS). Exposes both shippable binaries as packages and a one-stop dev shell.

| Output | Contents |
|---|---|
| `packages.default` / `.synology-filestation-fuse` | Rust CLI (built with [crane](https://crane.dev)) |
| `packages.synologyfuse-gui` | .NET 10 / Avalonia desktop GUI (`buildDotnetModule`) |
| `apps.default` / `apps.gui` | `nix run` either binary |
| `devShells.default` | Rust + Python + .NET 10 toolchains |
| `checks` | CLI build · clippy (`-D warnings`) · rustfmt · GUI build + tests |

Targets `x86_64`/`aarch64` × `linux`/`darwin`.

## Design notes

- **CLI build is scoped to `--package synology-filestation-fuse`** so the workspace's PyO3 `cdylib` crate is never dragged into the Nix build — that stays on the maturin/uv path.
- `reqwest`'s `rustls-tls` path avoids OpenSSL, so the only Linux system deps are `fuse3` + `pkg-config`. macOS uses the `cfg`-gated WebDAV backend (`libiconv` + `SystemConfiguration`).
- **GUI**: `nix/deps.json` is the pinned NuGet lockfile (regenerate with `nix build .#synologyfuse-gui.fetch-deps` then run the script). Avalonia's Linux runtime libs are baked into the launcher's `LD_LIBRARY_PATH`.
- `result` build symlinks are now gitignored.

## README

A new **Nix installation** section documents `nix run`, `nix profile install`, the declarative NixOS flake-input route (with `inputs.nixpkgs.follows` and `programs.fuse.userAllowOther`), and Home Manager.

## Validation

All run locally on NixOS (Nix 2.34):

- `nix build .#synology-filestation-fuse` → working CLI
- `nix build .#synologyfuse-gui` → GUI built, xunit tests pass
- `nix flake check` → all checks pass, no eval warnings
- `nix develop` → cargo/rustc, uv/maturin, and `dotnet 10.0.300` all present

> Note: the GUI resolves the CLI via `PATH`, so installing the GUI alone is not enough — install both packages. This is documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)