### PR TITLE
feat: GUI calls the Rust core directly via a native FFI binding

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,13 +41,13 @@ jobs:
     # Python development headers on macOS/Windows runners just to compile
     # an extension we don't ship via this pipeline.
     - name: Clippy
-      run: cargo clippy -p synology-filestation-fuse -p synology-filestation-core --all-targets --all-features -- -D warnings
+      run: cargo clippy -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --all-targets --all-features -- -D warnings
     - name: Build
-      run: cargo build -p synology-filestation-fuse -p synology-filestation-core --verbose
+      run: cargo build -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --verbose
     - name: Run Rust tests
-      run: cargo test -p synology-filestation-fuse -p synology-filestation-core --verbose
+      run: cargo test -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --verbose
     - name: Build release (required for installer)
-      run: cargo build --release -p synology-filestation-fuse --verbose
+      run: cargo build --release -p synology-filestation-fuse -p synology-filestation-ffi --verbose
     - name: Set up .NET 10
       uses: actions/setup-dotnet@v5
       with:
@@ -78,13 +78,13 @@ jobs:
     # Python development headers on macOS/Windows runners just to compile
     # an extension we don't ship via this pipeline.
     - name: Clippy
-      run: cargo clippy -p synology-filestation-fuse -p synology-filestation-core --all-targets --all-features -- -D warnings
+      run: cargo clippy -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --all-targets --all-features -- -D warnings
     - name: Build
-      run: cargo build -p synology-filestation-fuse -p synology-filestation-core --verbose
+      run: cargo build -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --verbose
     - name: Run Rust tests
-      run: cargo test -p synology-filestation-fuse -p synology-filestation-core --verbose
+      run: cargo test -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --verbose
     - name: Build release (required for installer)
-      run: cargo build --release -p synology-filestation-fuse --verbose
+      run: cargo build --release -p synology-filestation-fuse -p synology-filestation-ffi --verbose
     - name: Set up .NET 10
       uses: actions/setup-dotnet@v5
       with:
@@ -119,13 +119,13 @@ jobs:
     # Python development headers on macOS/Windows runners just to compile
     # an extension we don't ship via this pipeline.
     - name: Clippy
-      run: cargo clippy -p synology-filestation-fuse -p synology-filestation-core --all-targets --all-features -- -D warnings
+      run: cargo clippy -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --all-targets --all-features -- -D warnings
     - name: Build
-      run: cargo build -p synology-filestation-fuse -p synology-filestation-core --verbose
+      run: cargo build -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --verbose
     - name: Run Rust tests
-      run: cargo test -p synology-filestation-fuse -p synology-filestation-core --verbose
+      run: cargo test -p synology-filestation-fuse -p synology-filestation-core -p synology-filestation-ffi --verbose
     - name: Build release (required for installer)
-      run: cargo build --release -p synology-filestation-fuse --verbose
+      run: cargo build --release -p synology-filestation-fuse -p synology-filestation-ffi --verbose
     - name: Set up .NET 10
       uses: actions/setup-dotnet@v5
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a cross-platform filesystem driver that mounts a Synology FileStation NAS share as a local directory. The core driver is written in **Rust**; an optional desktop GUI uses **.NET 10 / Avalonia**. Platform backends: Linux (FUSE via `fuser`), macOS (WebDAV via `dav-server`), Windows (WinFsp via `winfsp` crate). A **Python binding** (PyO3, see `python/synology_filestation/`) exposes the FileStation HTTP client surface as a `pip install`-able package — drop-in replacement for the `synology-api` PyPI package's FileStation operations, with typed exceptions, atomic downloads, and transparent SID-expiry recovery.
+This is a cross-platform filesystem driver that mounts a Synology FileStation NAS share as a local directory. The core driver is written in **Rust**; an optional desktop GUI uses **.NET 10 / Avalonia**. Platform backends: Linux (FUSE via `fuser`), macOS (WebDAV via `dav-server`), Windows (WinFsp via `winfsp` crate). A **Python binding** (PyO3, see `python/synology_filestation/`) exposes the FileStation HTTP client surface as a `pip install`-able package — drop-in replacement for the `synology-api` PyPI package's FileStation operations, with typed exceptions, atomic downloads, and transparent SID-expiry recovery. The GUI talks to the Rust core **in-process** through a C ABI (`rust/synology-filestation-ffi`, a cdylib) via P/Invoke — it does not spawn the CLI.
 
 ## Repository layout
 
-The repo is a **Cargo workspace** with three crates plus the existing .NET projects:
+The repo is a **Cargo workspace** with four crates plus the existing .NET projects:
 
 ```
 rust/synology-filestation-core/    # Pure HTTP client (no FS code, no platform deps)
-rust/synology-filestation-fuse/    # Existing CLI + FUSE/WebDAV/WinFsp backends
+rust/synology-filestation-fuse/    # CLI binary + a library exposing the FUSE/WebDAV/WinFsp mount backends
+rust/synology-filestation-ffi/     # C ABI cdylib — connect/browse/transfer/mount, consumed by the GUI
 python/synology_filestation/       # PyO3 bindings (cdylib) — Python wheel builds
-SynologyFuse.Gui/                  # Avalonia desktop GUI
+SynologyFuse.Gui/                  # Avalonia desktop GUI (P/Invokes the FFI cdylib)
 SynologyFuse.{Mac,Deb}Installer/   # macOS .pkg / Debian .deb builders
 SynologyFuse.Installer/            # Windows MSI/bundle builder (WiX 4)
 ```
@@ -25,6 +26,7 @@ SynologyFuse.Installer/            # Windows MSI/bundle builder (WiX 4)
 
 ```bash
 cargo build --release -p synology-filestation-fuse
+cargo build --release -p synology-filestation-ffi   # cdylib the GUI loads (libsynology_filestation_ffi.{so,dylib,dll})
 cargo test --workspace
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features -- -D warnings
@@ -115,15 +117,18 @@ dotnet tool install --global wix --version 6.0.2
 ### Data Flow
 
 ```
-CLI (main.rs) or GUI (MountService.cs → subprocess) or Python (Client/AsyncClient)
+CLI (main.rs) or GUI (MountService/SynoClient → FFI cdylib) or Python (Client/AsyncClient)
     → Tokio runtime
     → SynologyClient (rust/synology-filestation-core/src/client.rs) — async HTTP
-    → Platform backend (dispatched in main.rs) OR PyO3 binding:
+    → Platform backend (spawned by synology-filestation-fuse's lib.rs::spawn_mount) OR PyO3 binding:
         Linux:   rust/synology-filestation-fuse/src/fs.rs       (fuser FUSE callbacks)
         macOS:   rust/synology-filestation-fuse/src/webdav.rs   (local HTTP, mounted via Finder)
         Windows: rust/synology-filestation-fuse/src/winfs.rs    (WinFsp callbacks)
         Python:  python/synology_filestation/src/lib.rs         (PyO3 _native module)
     → OS filesystem / user Python code
+
+The GUI path goes: MountService.cs / SynoClient.cs → P/Invoke (Interop/NativeMethods.cs)
+    → rust/synology-filestation-ffi/src/lib.rs (C ABI) → SynologyClient + spawn_mount.
 ```
 
 ### Rust core (`rust/synology-filestation-core/src/`)
@@ -139,7 +144,8 @@ CLI (main.rs) or GUI (MountService.cs → subprocess) or Python (Client/AsyncCli
 
 | File | Role |
 |------|------|
-| `main.rs`   | CLI parsing (clap), interactive prompts, platform dispatch |
+| `main.rs`   | CLI binary: parsing (clap), interactive prompts, login, then calls `lib.rs::spawn_mount` and parks on Ctrl-C |
+| `lib.rs`    | Library surface: `spawn_mount`/`MountHandle` (non-blocking, background mount) + `is_otp_required`, shared by the CLI and the FFI crate |
 | `fs.rs`     | Linux FUSE backend; uses `runtime.block_on()` for each FUSE callback |
 | `cache.rs`  | Linux only — `InodeCache` (TTL metadata), `ReadCache` (LRU block cache, 256 KiB blocks, prefetch) |
 | `webdav.rs` | macOS WebDAV backend; directory moves are download→upload→delete |
@@ -155,9 +161,25 @@ CLI (main.rs) or GUI (MountService.cs → subprocess) or Python (Client/AsyncCli
 | `synology_filestation/fsspec.py`   | `SynologyFileSystem(AsyncFileSystem)` — fsspec backend registered as protocol `synofs` (opt-in via `pip install synology-filestation[fsspec]`) |
 | `tests/`                           | pytest + pytest-httpserver — covers atomic download, SID-expiry recovery, exception mapping, fsspec sync+async surface |
 
+### FFI bindings (`rust/synology-filestation-ffi/`)
+
+| File | Role |
+|------|------|
+| `src/lib.rs`     | C ABI: opaque `SynoClient`/`SynoMount` handles over an `Arc<SynologyClient>` + per-client Tokio runtime; `syno_connect` (returns `OtpRequired` so the GUI prompts), browse (`syno_list_*`/`syno_get_info`), transfers (`syno_download_to`/`syno_upload` with a progress callback), `syno_delete`/`syno_create_folder`/`syno_rename`, `syno_mount`/`syno_unmount`. Errors come back as a typed `SynoError` (status + DSM code + message); every export wraps `catch_unwind` |
+| `src/logging.rs` | Bridges `tracing` events to a registered C log callback (`syno_set_log_callback`) for the GUI log pane |
+
+The `kind`/`dsm_code` error classification mirrors the PyO3 exception mapping. Download progress is fine-grained (loops the core's ranged `download`); upload progress is coarse (the core upload is single-shot). Built/clipped/tested in CI alongside the CLI and core.
+
 ### .NET GUI (`SynologyFuse.Gui/`)
 
-MVVM pattern (Avalonia 11). `MountService.cs` launches the Rust CLI as a subprocess and streams its stdout/stderr. It detects when the CLI pauses for OTP input and injects the code. `SettingsService.cs` persists config to platform-specific app-data directories.
+MVVM pattern (Avalonia). The GUI calls the Rust core **directly via the FFI cdylib** (no subprocess):
+- `Interop/NativeMethods.cs` — `[LibraryImport]` P/Invoke declarations (UTF-8 strings, blittable `NativeError`) + a `NativeLibrary` resolver that finds `lib*synology_filestation_ffi*` beside the GUI, in `target/{release,debug}`, or via the `SYNOFS_NATIVE_DIR` override.
+- `Services/SynoClient.cs` — managed wrapper translating status codes to `SynoException`/`OtpRequiredException` and JSON to `SynoFileInfo`.
+- `Services/MountService.cs` — connect + mount + test orchestration; surfaces native log lines via `OutputReceived`.
+- `ViewModels/MainWindowViewModel.cs` — `IsConnecting` spinner, **Test Connection**, typed OTP retry (login once, reused for the mount).
+- `ViewModels/FileBrowserViewModel.cs` + `Views/FileBrowserWindow.axaml` — pre-mount NAS browser (list/download/upload/delete/mkdir) with transfer progress.
+
+`SettingsService.cs` persists config to platform-specific app-data directories.
 
 ### Caching (Linux Only)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-core"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "bytes",
  "libc",
@@ -1886,8 +1886,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "synology-filestation-ffi"
+version = "0.1.19"
+dependencies = [
+ "serde_json",
+ "synology-filestation-core",
+ "synology-filestation-fuse",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wiremock",
+]
+
+[[package]]
 name = "synology-filestation-fuse"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1914,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "synology_filestation"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ resolver = "2"
 members = [
     "rust/synology-filestation-core",
     "rust/synology-filestation-fuse",
+    "rust/synology-filestation-ffi",
     "python/synology_filestation",
 ]

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ dotnet publish SynologyFuse.Gui -c Release -r osx-x64 -p:SelfContained=true
 dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
 ```
 
-Output goes to `SynologyFuse.Gui/bin/Release/net10.0/<rid>/publish/`. The GUI calls the Rust core through the native FFI library (`libsynology_filestation_ffi.{so,dylib}` / `synology_filestation_ffi.dll`); build it with `cargo build --release -p synology-filestation-ffi` and place it beside the GUI executable. The resolver searches: beside the GUI (deployed layout), then `target/{release,debug}/` relative to the repo root (development layout), then the `SYNOFS_NATIVE_DIR` environment variable. The platform installers bundle the library automatically.
+Output goes to `SynologyFuse.Gui/bin/Release/net10.0/<rid>/publish/`. The GUI calls the Rust core through the native FFI library (`libsynology_filestation_ffi.{so,dylib}` / `synology_filestation_ffi.dll`); build it with `cargo build --release -p synology-filestation-ffi` and place it beside the GUI executable. The resolver searches, in order: the `SYNOFS_NATIVE_DIR` environment variable (explicit override), then beside the GUI (deployed layout), then `target/{release,debug}/` relative to the repo root (development layout). The platform installers bundle the library automatically.
 
 ### Building the installer
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tools for working with Synology [FileStation](https://www.synology.com/en-global
 - **Linux** — FUSE via the `fuser` crate
 - **macOS** — local WebDAV proxy; no kernel extension required
 - **Windows** — user-mode filesystem via [WinFsp](https://winfsp.dev/)
-- **GUI (all platforms)** — Avalonia desktop app for point-and-click mounting
+- **GUI (all platforms)** — Avalonia desktop app for point-and-click mounting; calls the Rust core in-process (no subprocess), with a connecting spinner, a **Test Connection** check, and a pre-mount file browser
 
 **Python package** (`pip install synology-filestation`) — typed exceptions, atomic downloads, transparent SID-expiry recovery; a drop-in replacement for the `synology-api` PyPI package's FileStation surface. Includes an [fsspec](https://filesystem-spec.readthedocs.io/) backend registered as protocol `synofs` so it composes with pandas / dask / polars / pyarrow. See [python/synology_filestation/README.md](python/synology_filestation/README.md).
 
@@ -22,7 +22,7 @@ Tools for working with Synology [FileStation](https://www.synology.com/en-global
 - **Linux:** metadata cache with configurable TTL; block-level read cache (default 256 MiB) with background prefetch
 - **macOS:** no kernel extension; uses macOS's built-in WebDAV filesystem support
 - **Windows:** user-mode filesystem via WinFsp; mounts as a drive letter (e.g. `Z:`)
-- **GUI (all platforms):** Avalonia app that wraps the CLI with live log output, inline 2FA prompt, and settings persistence
+- **GUI (all platforms):** Avalonia app that calls the Rust core directly through a native library (no subprocess) — connecting spinner, **Test Connection**, typed error messages, inline 2FA prompt, live log output, a pre-mount file browser (browse / download / upload / delete / new folder with transfer progress), and settings persistence
 
 ## Linux installation
 
@@ -38,7 +38,7 @@ Install with `apt` (which also satisfies the `libfuse3-3` dependency automatical
 sudo apt install ./synologyfuse-<version>_amd64.deb
 ```
 
-This places the CLI at `/usr/bin/synology-filestation-fuse`, the GUI and its .NET runtime at `/opt/SynologyFuse/`, and a desktop launcher in your application menu.
+This places the CLI at `/usr/bin/synology-filestation-fuse`, the GUI and its .NET runtime (plus the native `libsynology_filestation_ffi.so` the GUI loads) at `/opt/SynologyFuse/`, and a desktop launcher in your application menu.
 
 To build the package yourself, see [Building the installer](#building-the-installer) below.
 
@@ -75,9 +75,10 @@ The repository ships a flake exposing both binaries as packages:
 | Output | Contents |
 |---|---|
 | `synology-filestation-fuse` (also `default`) | The Rust CLI |
+| `synology-filestation-ffi` | The native C ABI library (cdylib) the GUI loads |
 | `synologyfuse-gui` | The .NET 10 / Avalonia desktop GUI |
 
-The GUI launches the CLI as a subprocess, so the `synologyfuse-gui` package wraps its launcher with the CLI already on `PATH` — installing or running the GUI alone is enough to mount. Install `synology-filestation-fuse` as well if you also want the CLI available directly in your shell.
+The GUI calls the Rust core directly through the native library, so the `synologyfuse-gui` package wraps its launcher with `SYNOFS_NATIVE_DIR` pointing at the cdylib (and the CLI on `PATH` too) — installing or running the GUI alone is enough to mount. Install `synology-filestation-fuse` as well if you also want the CLI available directly in your shell.
 
 ### Try it without installing
 
@@ -237,7 +238,7 @@ dotnet publish SynologyFuse.Gui -c Release -r osx-x64 -p:SelfContained=true
 dotnet publish SynologyFuse.Gui -c Release -r win-x64 -p:SelfContained=true
 ```
 
-Output goes to `SynologyFuse.Gui/bin/Release/net10.0/<rid>/publish/`. The GUI locates the Rust CLI automatically: first beside itself (deployed layout), then in `target/release/` relative to the repo root (development layout), then on `PATH`.
+Output goes to `SynologyFuse.Gui/bin/Release/net10.0/<rid>/publish/`. The GUI calls the Rust core through the native FFI library (`libsynology_filestation_ffi.{so,dylib}` / `synology_filestation_ffi.dll`); build it with `cargo build --release -p synology-filestation-ffi` and place it beside the GUI executable. The resolver searches: beside the GUI (deployed layout), then `target/{release,debug}/` relative to the repo root (development layout), then the `SYNOFS_NATIVE_DIR` environment variable. The platform installers bundle the library automatically.
 
 ### Building the installer
 
@@ -263,7 +264,7 @@ The package installs:
 | Path | Contents |
 |---|---|
 | `/usr/bin/synology-filestation-fuse` | CLI binary |
-| `/opt/SynologyFuse/` | GUI executable and .NET runtime |
+| `/opt/SynologyFuse/` | GUI executable, .NET runtime, and `libsynology_filestation_ffi.so` |
 | `/usr/share/applications/synologyfuse.desktop` | Application menu entry |
 | `/usr/share/icons/hicolor/256x256/apps/synologyfuse.png` | Application icon |
 
@@ -400,7 +401,7 @@ diskutil unmount /Volumes/nas
 
 ## Architecture
 
-The repo is a Cargo workspace with three Rust crates plus the .NET desktop GUI and platform installers:
+The repo is a Cargo workspace with four Rust crates plus the .NET desktop GUI and platform installers:
 
 ```
 synology-filestation/
@@ -410,13 +411,18 @@ synology-filestation/
 │   │       ├── client.rs            FileStation API; auto-relogin; atomic download_to_path
 │   │       ├── types.rs             Serde types for API JSON responses
 │   │       └── error.rs             SynoFsError + Linux errno mapping
-│   └── synology-filestation-fuse/   CLI + FUSE / WebDAV / WinFsp backends
+│   ├── synology-filestation-fuse/   CLI + FUSE / WebDAV / WinFsp backends
+│   │   └── src/
+│   │       ├── main.rs              CLI: arg parsing, Tokio runtime, login, then spawn_mount
+│   │       ├── lib.rs               spawn_mount / MountHandle (non-blocking) — shared by CLI + FFI
+│   │       ├── fs.rs                fuser::Filesystem trait (Linux FUSE backend)
+│   │       ├── cache.rs             Inode ↔ path cache + block-level read cache (Linux)
+│   │       ├── webdav.rs            dav_server::DavFileSystem trait (macOS WebDAV backend)
+│   │       └── winfs.rs             winfsp::FileSystemContext trait (Windows WinFsp backend)
+│   └── synology-filestation-ffi/    C ABI cdylib consumed by the GUI (P/Invoke)
 │       └── src/
-│           ├── main.rs              CLI argument parsing, Tokio runtime, platform dispatch
-│           ├── fs.rs                fuser::Filesystem trait (Linux FUSE backend)
-│           ├── cache.rs             Inode ↔ path cache + block-level read cache (Linux)
-│           ├── webdav.rs            dav_server::DavFileSystem trait (macOS WebDAV backend)
-│           └── winfs.rs             winfsp::FileSystemContext trait (Windows WinFsp backend)
+│           ├── lib.rs               connect / browse / transfer / mount; typed SynoError; catch_unwind
+│           └── logging.rs           tracing → C log callback bridge
 ├── python/
 │   └── synology_filestation/        PyO3 + maturin Python bindings (synofs fsspec)
 │       ├── src/lib.rs               PyO3 _native module: Client, AsyncClient, exceptions
@@ -431,14 +437,17 @@ synology-filestation/
 
 ### GUI
 
-`SynologyFuse.Gui` is a cross-platform Avalonia application that wraps the CLI. It provides:
+`SynologyFuse.Gui` is a cross-platform Avalonia application that calls the Rust core **in-process** through the `synology-filestation-ffi` cdylib via P/Invoke — it does not spawn the CLI. It provides:
 
 - Form fields for host, username, password, OTP, mountpoint, and advanced options (cache TTL, read cache size, log level)
-- Connect / Disconnect buttons that launch and terminate the CLI subprocess
-- Live log output streamed from the CLI's stdout/stderr
-- Inline 2FA prompt: when the CLI pauses waiting for a TOTP code on stdin, the GUI shows an input banner so the user can submit the code without restarting
+- **Connect** (login + mount), **Test Connection** (login only), and **Disconnect** (unmount + logout), with a connecting spinner while a call is in flight
+- Typed error reporting — the native layer returns structured errors (with the DSM code), so messages are accurate instead of scraped from log text
+- Inline 2FA prompt: when login reports that an OTP is required, the GUI shows an input banner and retries the connect with the code (entered once, then reused for the mount)
+- A pre-mount **file browser** ([`FileBrowserWindow`](SynologyFuse.Gui/Views/FileBrowserWindow.axaml)) that lists shares/directories and supports download, upload, delete, and new-folder with a transfer progress bar — all without mounting
+- Live log output, bridged from the native library's `tracing` events via a log callback
 - Settings persistence — connection parameters are saved to the platform settings directory and reloaded on next launch
-- Platform-aware argument building: Linux-only flags (`--cache-ttl`, `--read-cache-mb`) are omitted on macOS and Windows
+
+The P/Invoke surface lives in `SynologyFuse.Gui/Interop/` (`NativeMethods.cs` declarations + native-library resolver, `SynoException.cs`); `Services/SynoClient.cs` is the managed wrapper and `Services/MountService.cs` orchestrates connect/mount/test.
 
 ### Virtual root
 

--- a/SynologyFuse.DebInstaller/Build-Package.sh
+++ b/SynologyFuse.DebInstaller/Build-Package.sh
@@ -181,6 +181,16 @@ mkdir -p "${GUI_DEST}"
 cp -R "${GUI_PUBLISH_DIR}/"* "${GUI_DEST}/"
 chmod +x "${GUI_DEST}/${GUI_BINARY}"
 
+# The GUI calls the Rust core directly through this native library; the
+# resolver in NativeMethods.cs looks for it beside the GUI executable.
+FFI_LIB="libsynology_filestation_ffi.so"
+if [[ ! -f "${RUST_RELEASE_DIR}/${FFI_LIB}" ]]; then
+    echo "Error: FFI library not found at '${RUST_RELEASE_DIR}/${FFI_LIB}'." >&2
+    echo "Build it first: cargo build --release -p synology-filestation-ffi" >&2
+    exit 1
+fi
+install -Dm755 "${RUST_RELEASE_DIR}/${FFI_LIB}" "${GUI_DEST}/${FFI_LIB}"
+
 # ── Desktop entry ─────────────────────────────────────────────────────────────
 
 install -Dm644 /dev/stdin \

--- a/SynologyFuse.Gui/Interop/NativeMethods.cs
+++ b/SynologyFuse.Gui/Interop/NativeMethods.cs
@@ -1,0 +1,200 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace SynologyFuse.Gui.Interop;
+
+/// <summary>
+/// P/Invoke surface for the <c>synology_filestation_ffi</c> native library
+/// (the Rust C ABI in <c>rust/synology-filestation-ffi</c>). Strings cross the
+/// boundary as UTF-8; errors come back through a <see cref="NativeError"/>
+/// out-param whose <see cref="NativeError.Message"/> must be freed with
+/// <see cref="syno_string_free"/>.
+/// </summary>
+internal static partial class NativeMethods
+{
+    /// <summary>Base name; the OS loader / our resolver maps it to
+    /// lib&lt;name&gt;.so / &lt;name&gt;.dll / lib&lt;name&gt;.dylib.</summary>
+    internal const string Lib = "synology_filestation_ffi";
+
+    /// <summary>Mirrors the Rust <c>SynoStatus</c> enum.</summary>
+    internal enum SynoStatus
+    {
+        Ok = 0,
+        NotFound = 1,
+        PermissionDenied = 2,
+        AlreadyExists = 3,
+        NotEmpty = 4,
+        InvalidArg = 5,
+        NoSpace = 6,
+        NotSupported = 7,
+        Io = 8,
+        Api = 9,
+        LoginFailed = 10,
+        OtpRequired = 11,
+        NullArg = 12,
+        Panic = 13,
+    }
+
+    /// <summary>Blittable mirror of the Rust <c>SynoError</c> struct.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct NativeError
+    {
+        public int Kind;
+        public uint DsmCode;
+        public IntPtr Message;
+    }
+
+    /// <summary>Progress callback: (bytesDone, bytesTotal, userData).</summary>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void ProgressCb(ulong done, ulong total, IntPtr userData);
+
+    /// <summary>Log callback: (level, line, userData). level: 1=ERROR…5=TRACE.</summary>
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    internal delegate void LogCb(int level, IntPtr line, IntPtr userData);
+
+    // ── Session lifecycle ──────────────────────────────────────────────────────
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_connect(
+        string host, ushort port, [MarshalAs(UnmanagedType.U1)] bool https,
+        string username, string password, string? otp,
+        [MarshalAs(UnmanagedType.U1)] bool autoRelogin,
+        out IntPtr outClient, ref NativeError err);
+
+    [LibraryImport(Lib)]
+    internal static partial void syno_logout(IntPtr client);
+
+    [LibraryImport(Lib)]
+    internal static partial void syno_client_free(IntPtr client);
+
+    [LibraryImport(Lib)]
+    internal static partial void syno_string_free(IntPtr s);
+
+    // ── Browse ─────────────────────────────────────────────────────────────────
+
+    [LibraryImport(Lib)]
+    internal static partial int syno_list_shares(IntPtr client, out IntPtr outJson, ref NativeError err);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_list_dir(IntPtr client, string path, out IntPtr outJson, ref NativeError err);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_get_info(IntPtr client, string path, out IntPtr outJson, ref NativeError err);
+
+    // ── Transfers ──────────────────────────────────────────────────────────────
+    // Callbacks are passed as function pointers (nint); pass IntPtr.Zero for none.
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_download_to(
+        IntPtr client, string remote, string local, IntPtr progress, IntPtr userData, ref NativeError err);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_upload(
+        IntPtr client, string local, string remoteDir, [MarshalAs(UnmanagedType.U1)] bool overwrite,
+        IntPtr progress, IntPtr userData, ref NativeError err);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_delete(IntPtr client, string path, ref NativeError err);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_create_folder(IntPtr client, string parent, string name, ref NativeError err);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_rename(IntPtr client, string path, string newName, ref NativeError err);
+
+    // ── Mount lifecycle ────────────────────────────────────────────────────────
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int syno_mount(
+        IntPtr client, string mountpoint, ulong cacheTtl, ulong readCacheMb,
+        out IntPtr outMount, ref NativeError err);
+
+    [LibraryImport(Lib)]
+    internal static partial void syno_unmount(IntPtr mount);
+
+    // ── Logging ────────────────────────────────────────────────────────────────
+
+    [LibraryImport(Lib)]
+    internal static partial void syno_set_log_callback(IntPtr cb, IntPtr userData);
+
+    // ── Native library resolution ──────────────────────────────────────────────
+
+    private static bool _resolverRegistered;
+    private static readonly object _gate = new();
+
+    /// <summary>
+    /// Register a resolver that finds the native library next to the GUI, then
+    /// in a dev build tree, honouring a <c>SYNOFS_NATIVE_DIR</c> override.
+    /// Idempotent and called from <see cref="Services.SynoClient"/>'s static ctor.
+    /// </summary>
+    internal static void EnsureResolver()
+    {
+        lock (_gate)
+        {
+            if (_resolverRegistered) return;
+            NativeLibrary.SetDllImportResolver(typeof(NativeMethods).Assembly, Resolve);
+            _resolverRegistered = true;
+        }
+    }
+
+    private static IntPtr Resolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+    {
+        if (libraryName != Lib)
+            return IntPtr.Zero; // not ours — fall back to default resolution
+
+        foreach (var candidate in CandidatePaths())
+        {
+            if (File.Exists(candidate) && NativeLibrary.TryLoad(candidate, out var handle))
+                return handle;
+        }
+
+        // Last resort: let the OS resolve by base name (e.g. installed in a
+        // standard library directory).
+        return NativeLibrary.TryLoad(Lib, assembly, searchPath, out var fallback)
+            ? fallback
+            : IntPtr.Zero;
+    }
+
+    private static string FileName()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return $"{Lib}.dll";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return $"lib{Lib}.dylib";
+        return $"lib{Lib}.so";
+    }
+
+    private static System.Collections.Generic.IEnumerable<string> CandidatePaths()
+    {
+        var file = FileName();
+
+        // 1. Explicit override (used by the Nix wrapper and tests).
+        var overrideDir = Environment.GetEnvironmentVariable("SYNOFS_NATIVE_DIR");
+        if (!string.IsNullOrEmpty(overrideDir))
+            yield return Path.Combine(overrideDir, file);
+
+        // 2. Beside the GUI assembly (deployed layout).
+        var baseDir = AppContext.BaseDirectory;
+        yield return Path.Combine(baseDir, file);
+
+        // 3. Development layout: <repo>/target/{release,debug}.
+        var repoRoot = FindRepoRoot(baseDir);
+        if (repoRoot is not null)
+        {
+            yield return Path.Combine(repoRoot, "target", "release", file);
+            yield return Path.Combine(repoRoot, "target", "debug", file);
+        }
+    }
+
+    internal static string? FindRepoRoot(string startDir)
+    {
+        var dir = new DirectoryInfo(startDir);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Cargo.toml")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/SynologyFuse.Gui/Interop/NativeMethods.cs
+++ b/SynologyFuse.Gui/Interop/NativeMethods.cs
@@ -35,6 +35,7 @@ internal static partial class NativeMethods
         OtpRequired = 11,
         NullArg = 12,
         Panic = 13,
+        SidNotFound = 14,
     }
 
     /// <summary>Blittable mirror of the Rust <c>SynoError</c> struct.</summary>
@@ -118,6 +119,9 @@ internal static partial class NativeMethods
 
     [LibraryImport(Lib)]
     internal static partial void syno_set_log_callback(IntPtr cb, IntPtr userData);
+
+    [LibraryImport(Lib, StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial void syno_set_log_level(string level);
 
     // ── Native library resolution ──────────────────────────────────────────────
 

--- a/SynologyFuse.Gui/Interop/SynoException.cs
+++ b/SynologyFuse.Gui/Interop/SynoException.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace SynologyFuse.Gui.Interop;
+
+/// <summary>
+/// A typed error from the native FileStation client. Carries the
+/// <see cref="Status"/> classification and, when applicable, the raw Synology
+/// <see cref="DsmCode"/> so callers can react precisely instead of scraping
+/// log text.
+/// </summary>
+public class SynoException : Exception
+{
+    internal SynoException(NativeMethods.SynoStatus status, uint dsmCode, string message)
+        : base(message)
+    {
+        Status = status;
+        DsmCode = dsmCode;
+    }
+
+    internal NativeMethods.SynoStatus Status { get; }
+
+    /// <summary>Raw Synology DSM error code, or 0 when not applicable.</summary>
+    public uint DsmCode { get; }
+}
+
+/// <summary>
+/// Raised by <see cref="Services.SynoClient.Connect"/> when the account needs a
+/// 2FA / OTP code. The GUI prompts for the code and retries the connect with it.
+/// </summary>
+public sealed class OtpRequiredException : SynoException
+{
+    internal OtpRequiredException(string message)
+        : base(NativeMethods.SynoStatus.OtpRequired, 0, message)
+    {
+    }
+}

--- a/SynologyFuse.Gui/Models/SynoFileInfo.cs
+++ b/SynologyFuse.Gui/Models/SynoFileInfo.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace SynologyFuse.Gui.Models;
+
+/// <summary>
+/// A file or directory entry returned by the native browse calls. Deserialized
+/// from the stable flat JSON shape emitted by the FFI (<c>fileinfo_json</c>):
+/// keys are always present, with nulls for missing metadata.
+/// </summary>
+public sealed record SynoFileInfo
+{
+    [JsonPropertyName("name")] public string Name { get; init; } = "";
+    [JsonPropertyName("path")] public string Path { get; init; } = "";
+    [JsonPropertyName("isdir")] public bool IsDir { get; init; }
+    [JsonPropertyName("size")] public ulong? Size { get; init; }
+    [JsonPropertyName("mtime")] public long? Mtime { get; init; }
+    [JsonPropertyName("atime")] public long? Atime { get; init; }
+    [JsonPropertyName("ctime")] public long? Ctime { get; init; }
+    [JsonPropertyName("perm")] public uint? Perm { get; init; }
+}

--- a/SynologyFuse.Gui/Services/MountService.cs
+++ b/SynologyFuse.Gui/Services/MountService.cs
@@ -1,267 +1,102 @@
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
+using SynologyFuse.Gui.Interop;
 using SynologyFuse.Gui.Models;
 
 namespace SynologyFuse.Gui.Services;
 
+/// <summary>
+/// Drives the native FileStation client directly (no subprocess). Connecting,
+/// mounting and unmounting all run in-process via <see cref="SynoClient"/>.
+/// Log lines from the native library are surfaced through
+/// <see cref="OutputReceived"/>; connect/mount failures surface as
+/// <see cref="SynoException"/> (or <see cref="OtpRequiredException"/> when a
+/// 2FA code is needed).
+/// </summary>
 public sealed class MountService : IDisposable
 {
-    private Process? _process;
-    private CancellationTokenSource? _cts;
+    private SynoClient? _client;
 
+    /// <summary>Raised for each log line emitted by the native library.
+    /// May fire on a background thread — marshal to the UI thread in handlers.</summary>
     public event Action<string>? OutputReceived;
-    public event Action<int>? Exited;
 
-    /// <summary>
-    /// Raised when the CLI is blocking on an interactive prompt (e.g. the 2FA
-    /// code prompt). The string is the prompt label the CLI printed.
-    /// </summary>
-    public event Action<string>? PromptRequired;
-
-    /// <summary>
-    /// Starts the CLI process with the given config.
-    /// Throws <see cref="FileNotFoundException"/> if the binary cannot be located.
-    /// </summary>
-    public async Task StartAsync(MountConfig config)
+    public MountService()
     {
-        if (_process is not null)
+        // Route native log output to subscribers for the GUI log pane.
+        SynoClient.SetLogCallback((_, line) => OutputReceived?.Invoke(line));
+    }
+
+    public bool IsMounted => _client is { IsMounted: true };
+
+    /// <summary>
+    /// Connect and mount in one step. Throws <see cref="OtpRequiredException"/>
+    /// when the account needs a 2FA code (prompt and retry with
+    /// <paramref name="otp"/> set), or <see cref="SynoException"/> on failure.
+    /// </summary>
+    public async Task ConnectAndMountAsync(MountConfig config, string? otp = null)
+    {
+        if (_client is not null)
             throw new InvalidOperationException("Already mounted.");
 
-        var binaryPath = FindBinary();
+        var mountpoint = ExpandPath(config.Mountpoint);
 
-        var args = BuildArgs(config);
-
-        var psi = new ProcessStartInfo(binaryPath)
+        _client = await Task.Run(() =>
         {
-            Arguments = args,
-            UseShellExecute = false,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true,
-        };
-
-        // Pass credentials via environment variables to avoid exposure in process list.
-        psi.Environment["SYNO_PASSWORD"] = config.Password;
-
-        _cts = new CancellationTokenSource();
-        _process = new Process { StartInfo = psi, EnableRaisingEvents = true };
-
-        _process.OutputDataReceived += (_, e) =>
-        {
-            if (e.Data is not null) OutputReceived?.Invoke(StripAnsi(e.Data));
-        };
-        _process.Exited += (_, _) =>
-        {
-            var code = _process.ExitCode;
-            Exited?.Invoke(code);
-            Cleanup();
-        };
-
-        _process.Start();
-        _process.BeginOutputReadLine();
-
-        // stderr must be read manually rather than via BeginErrorReadLine because
-        // the CLI's 2FA prompt uses eprint! (no trailing newline). BeginErrorReadLine
-        // only fires on '\n', so the prompt would never be seen and the process
-        // would hang forever waiting for stdin.
-        _ = ReadStderrAsync(_process, _cts.Token);
-
-        // Give the process a moment to fail fast (e.g. bad host).
-        await Task.Delay(500, _cts.Token).ContinueWith(_ => { });
+            var client = SynoClient.Connect(
+                config.Host, config.Port, config.UseHttps, config.Username, config.Password, otp);
+            try
+            {
+                client.Mount(mountpoint, config.CacheTtl, config.ReadCacheMb);
+            }
+            catch
+            {
+                client.Dispose();
+                throw;
+            }
+            return client;
+        });
     }
-
-    public void Stop()
-    {
-        if (_process is null || _process.HasExited) return;
-
-        try
-        {
-            // On Unix, send SIGINT so the CLI can logout gracefully.
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                _process.Kill(entireProcessTree: false);
-            else
-                _process.Kill();
-        }
-        catch (InvalidOperationException) { }
-    }
-
-    public bool IsRunning => _process is { HasExited: false };
 
     /// <summary>
-    /// Writes a line to the CLI's stdin (used to answer interactive prompts
-    /// such as the 2FA code request).
+    /// Validate credentials by logging in and straight back out — no mount.
+    /// Same exception contract as <see cref="ConnectAndMountAsync"/>.
     /// </summary>
-    public void SendLine(string value)
-    {
-        if (_process is null || _process.HasExited) return;
-        _process.StandardInput.WriteLine(value);
-        _process.StandardInput.Flush();
-    }
-
-    // Reads stderr character-by-character so we can detect prompts that have no
-    // trailing newline (e.g. "Two-factor authentication code: ").
-    private async Task ReadStderrAsync(Process process, CancellationToken ct)
-    {
-        var reader = process.StandardError;
-        var buf = new char[256];
-        var line = new System.Text.StringBuilder();
-
-        try
+    public Task TestConnectionAsync(MountConfig config, string? otp = null) =>
+        Task.Run(() =>
         {
-            while (true)
-            {
-                var read = await reader.ReadAsync(buf, ct);
-                if (read == 0) break; // EOF
+            using var client = SynoClient.Connect(
+                config.Host, config.Port, config.UseHttps, config.Username, config.Password, otp);
+            // Dispose logs out immediately; reaching here means success.
+        });
 
-                line.Append(buf, 0, read);
-
-                // Flush any complete lines first.
-                FlushLines(line);
-
-                // After flushing complete lines, check if the remainder is a known prompt.
-                var pending = line.ToString();
-                if (pending.Contains("Two-factor authentication code", StringComparison.OrdinalIgnoreCase))
-                {
-                    PromptRequired?.Invoke("Two-factor authentication code");
-                    line.Clear();
-                }
-            }
-        }
-        catch (OperationCanceledException) { }
-        catch (Exception) { }
-
-        // Emit any trailing partial line (e.g. a final error message without newline).
-        var remaining = StripAnsi(line.ToString()).Trim();
-        if (remaining.Length > 0)
-            OutputReceived?.Invoke(remaining);
-    }
-
-    private void FlushLines(System.Text.StringBuilder sb)
+    /// <summary>Unmount and log out, if connected.</summary>
+    public void Stop()
     {
-        while (true)
-        {
-            var text = sb.ToString();
-            var nl = text.IndexOf('\n');
-            if (nl < 0) break;
-
-            var completeLine = text[..nl].TrimEnd('\r');
-            sb.Remove(0, nl + 1);
-
-            var stripped = StripAnsi(completeLine);
-            if (stripped.Length > 0)
-                OutputReceived?.Invoke(stripped);
-        }
-    }
-
-    private void Cleanup()
-    {
-        _cts?.Cancel();
-        _cts?.Dispose();
-        _cts = null;
-        _process?.Dispose();
-        _process = null;
+        _client?.Dispose();
+        _client = null;
     }
 
     public void Dispose()
     {
         Stop();
-        Cleanup();
+        SynoClient.SetLogCallback(null);
     }
 
-    // -------------------------------------------------------------------------
-
-    private static string FindBinary()
-    {
-        var binaryName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "synology-filestation-fuse.exe"
-            : "synology-filestation-fuse";
-
-        // 1. Beside the GUI executable (deployed layout).
-        var exeDir = Path.GetDirectoryName(Environment.ProcessPath) ?? ".";
-        var candidate1 = Path.Combine(exeDir, binaryName);
-        if (File.Exists(candidate1)) return candidate1;
-
-        // 2. Development layout: repo root / target / release.
-        // GUI is at <repo>/SynologyFuse.Gui/bin/...
-        var repoRoot = FindRepoRoot(exeDir);
-        if (repoRoot is not null)
-        {
-            var candidate2 = Path.Combine(repoRoot, "target", "release", binaryName);
-            if (File.Exists(candidate2)) return candidate2;
-
-            var candidate3 = Path.Combine(repoRoot, "target", "debug", binaryName);
-            if (File.Exists(candidate3)) return candidate3;
-        }
-
-        // 3. PATH fallback.
-        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
-        {
-            var candidate4 = Path.Combine(dir, binaryName);
-            if (File.Exists(candidate4)) return candidate4;
-        }
-
-        throw new FileNotFoundException(
-            $"Could not locate '{binaryName}'. " +
-            "Build the Rust CLI with 'cargo build --release' and place it beside the GUI, " +
-            "or add it to PATH.");
-    }
-
-    internal static string? FindRepoRoot(string startDir)
-    {
-        var dir = new DirectoryInfo(startDir);
-        while (dir is not null)
-        {
-            if (File.Exists(Path.Combine(dir.FullName, "Cargo.toml")))
-                return dir.FullName;
-            dir = dir.Parent;
-        }
-        return null;
-    }
-
-    internal static string BuildArgs(MountConfig config)
-    {
-        var parts = new List<string>
-        {
-            "--host", Quote(config.Host),
-            "--username", Quote(config.Username),
-            "--port", config.Port.ToString(),
-            "--log-level", config.LogLevel,
-        };
-
-        if (!config.UseHttps)
-            parts.AddRange(["--https", "false"]);
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            parts.AddRange(["--cache-ttl", config.CacheTtl.ToString()]);
-            parts.AddRange(["--read-cache-mb", config.ReadCacheMb.ToString()]);
-        }
-
-        parts.Add(Quote(ExpandPath(config.Mountpoint)));
-
-        return string.Join(" ", parts);
-    }
+    // ── Path expansion (shell-style conveniences the user expects) ──────────────
 
     internal static string ExpandPath(string path)
     {
-        // Expand ~ to the user's home directory (shells do this, direct process spawn doesn't).
+        // Expand ~ to the user's home directory (a direct native call does not
+        // get shell expansion).
         if (path == "~" || path.StartsWith("~/") || path.StartsWith(@"~\"))
         {
             var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
             path = home + path[1..];
         }
 
-        // Expand environment variables: $VAR / ${VAR} on Unix, %VAR% on Windows.
-        path = ExpandEnvVars(path);
-
-        return path;
+        return ExpandEnvVars(path);
     }
 
     private static readonly Regex EnvVarUnix =
@@ -281,14 +116,4 @@ public sealed class MountService : IDisposable
 
         return path;
     }
-
-    internal static string Quote(string s) =>
-        s.Contains(' ') ? $"\"{s}\"" : s;
-
-    // Matches ESC [ ... <letter>  (CSI sequences, covers colors, dim, bold, etc.)
-    // and bare ESC <char> (Fe sequences like ESC M).
-    private static readonly Regex AnsiEscapeRegex =
-        new(@"\x1b(\[[0-9;]*[A-Za-z]|.)", RegexOptions.Compiled);
-
-    internal static string StripAnsi(string s) => AnsiEscapeRegex.Replace(s, "");
 }

--- a/SynologyFuse.Gui/Services/MountService.cs
+++ b/SynologyFuse.Gui/Services/MountService.cs
@@ -17,6 +17,7 @@ namespace SynologyFuse.Gui.Services;
 public sealed class MountService : IDisposable
 {
     private SynoClient? _client;
+    private bool _disposed;
 
     /// <summary>Raised for each log line emitted by the native library.
     /// May fire on a background thread — marshal to the UI thread in handlers.</summary>
@@ -41,35 +42,49 @@ public sealed class MountService : IDisposable
             throw new InvalidOperationException("Already mounted.");
 
         var mountpoint = ExpandPath(config.Mountpoint);
+        SynoClient.SetLogLevel(config.LogLevel);
 
-        _client = await Task.Run(() =>
+        var client = await Task.Run(() =>
         {
-            var client = SynoClient.Connect(
+            var c = SynoClient.Connect(
                 config.Host, config.Port, config.UseHttps, config.Username, config.Password, otp);
             try
             {
-                client.Mount(mountpoint, config.CacheTtl, config.ReadCacheMb);
+                c.Mount(mountpoint, config.CacheTtl, config.ReadCacheMb);
             }
             catch
             {
-                client.Dispose();
+                c.Dispose();
                 throw;
             }
-            return client;
+            return c;
         });
+
+        // If Dispose() ran (app shutdown) while connect+mount was in flight,
+        // tear the freshly-built client down instead of leaking it. The await
+        // resumed on the UI thread, so this can't race Dispose().
+        if (_disposed)
+        {
+            client.Dispose();
+            return;
+        }
+        _client = client;
     }
 
     /// <summary>
     /// Validate credentials by logging in and straight back out — no mount.
     /// Same exception contract as <see cref="ConnectAndMountAsync"/>.
     /// </summary>
-    public Task TestConnectionAsync(MountConfig config, string? otp = null) =>
-        Task.Run(() =>
+    public Task TestConnectionAsync(MountConfig config, string? otp = null)
+    {
+        SynoClient.SetLogLevel(config.LogLevel);
+        return Task.Run(() =>
         {
             using var client = SynoClient.Connect(
                 config.Host, config.Port, config.UseHttps, config.Username, config.Password, otp);
             // Dispose logs out immediately; reaching here means success.
         });
+    }
 
     /// <summary>Unmount and log out, if connected.</summary>
     public void Stop()
@@ -80,6 +95,7 @@ public sealed class MountService : IDisposable
 
     public void Dispose()
     {
+        _disposed = true;
         Stop();
         SynoClient.SetLogCallback(null);
     }

--- a/SynologyFuse.Gui/Services/SynoClient.cs
+++ b/SynologyFuse.Gui/Services/SynoClient.cs
@@ -217,7 +217,11 @@ public sealed class SynoClient : IDisposable
     private static SynoFileInfo ParseObject(IntPtr json)
     {
         var s = TakeString(json);
-        return JsonSerializer.Deserialize<SynoFileInfo>(s, JsonOpts) ?? new SynoFileInfo();
+        // A successful native call always emits a real object; a null here means
+        // the FFI broke its contract, so fail fast rather than hand back an empty
+        // record that looks like a real (but blank) entry.
+        return JsonSerializer.Deserialize<SynoFileInfo>(s, JsonOpts)
+            ?? throw new SynoException(SynoStatus.Io, 0, "native returned malformed file-info JSON");
     }
 
     /// <summary>Copy a native string to managed and free the native buffer.</summary>

--- a/SynologyFuse.Gui/Services/SynoClient.cs
+++ b/SynologyFuse.Gui/Services/SynoClient.cs
@@ -124,6 +124,9 @@ public sealed class SynoClient : IDisposable
     /// Returns once the mount is established (or throws on failure).</summary>
     public void Mount(string mountpoint, ulong cacheTtl, ulong readCacheMb)
     {
+        // Tear down any prior mount first so a second Mount() can't orphan the
+        // previous native SynoMount (and its background worker / runtime).
+        Unmount();
         var err = default(NativeError);
         int rc = syno_mount(_client, mountpoint, cacheTtl, readCacheMb, out var mount, ref err);
         Check(rc, ref err);
@@ -152,8 +155,11 @@ public sealed class SynoClient : IDisposable
         NativeMethods.EnsureResolver();
         if (onLine is null)
         {
-            _logKeepAlive = null;
+            // Tell native to stop calling FIRST, then drop the managed delegate —
+            // otherwise a log line dispatched on a Tokio thread in the gap could
+            // invoke a GC-collected delegate.
             syno_set_log_callback(IntPtr.Zero, IntPtr.Zero);
+            _logKeepAlive = null;
             return;
         }
         _logKeepAlive = (level, line, _) =>
@@ -171,6 +177,13 @@ public sealed class SynoClient : IDisposable
             }
         };
         syno_set_log_callback(Marshal.GetFunctionPointerForDelegate(_logKeepAlive), IntPtr.Zero);
+    }
+
+    /// <summary>Set native log verbosity ("error"/"warn"/"info"/"debug"/"trace").</summary>
+    public static void SetLogLevel(string level)
+    {
+        NativeMethods.EnsureResolver();
+        syno_set_log_level(level);
     }
 
     // ── Dispose ────────────────────────────────────────────────────────────────

--- a/SynologyFuse.Gui/Services/SynoClient.cs
+++ b/SynologyFuse.Gui/Services/SynoClient.cs
@@ -158,8 +158,17 @@ public sealed class SynoClient : IDisposable
         }
         _logKeepAlive = (level, line, _) =>
         {
-            var text = line != IntPtr.Zero ? Marshal.PtrToStringUTF8(line) ?? "" : "";
-            onLine(level, text);
+            // This runs as an unmanaged callback — an exception escaping here
+            // would tear down the process. Swallow anything a subscriber throws.
+            try
+            {
+                var text = line != IntPtr.Zero ? Marshal.PtrToStringUTF8(line) ?? "" : "";
+                onLine(level, text);
+            }
+            catch
+            {
+                // Best-effort logging: never let a log line crash the app.
+            }
         };
         syno_set_log_callback(Marshal.GetFunctionPointerForDelegate(_logKeepAlive), IntPtr.Zero);
     }
@@ -184,7 +193,13 @@ public sealed class SynoClient : IDisposable
     private static (IntPtr fp, ProgressCb? keepAlive) MakeProgress(Action<long, long>? progress)
     {
         if (progress is null) return (IntPtr.Zero, null);
-        ProgressCb cb = (done, total, _) => progress((long)done, (long)total);
+        // Invoked as an unmanaged callback — guard so a throwing progress
+        // handler can't escape the native boundary and crash the process.
+        ProgressCb cb = (done, total, _) =>
+        {
+            try { progress((long)done, (long)total); }
+            catch { /* progress is advisory; never let it abort the transfer */ }
+        };
         return (Marshal.GetFunctionPointerForDelegate(cb), cb);
     }
 

--- a/SynologyFuse.Gui/Services/SynoClient.cs
+++ b/SynologyFuse.Gui/Services/SynoClient.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using SynologyFuse.Gui.Interop;
+using SynologyFuse.Gui.Models;
+using static SynologyFuse.Gui.Interop.NativeMethods;
+
+namespace SynologyFuse.Gui.Services;
+
+/// <summary>
+/// Managed wrapper over the native FileStation client. Owns the opaque native
+/// client handle and (once mounted) the mount handle, translating native
+/// status codes into <see cref="SynoException"/>s and JSON payloads into
+/// <see cref="SynoFileInfo"/>s.
+///
+/// All calls block on the native Tokio runtime; callers should invoke browse /
+/// transfer methods off the UI thread.
+/// </summary>
+public sealed class SynoClient : IDisposable
+{
+    private IntPtr _client;
+    private IntPtr _mount;
+    private bool _disposed;
+
+    static SynoClient() => NativeMethods.EnsureResolver();
+
+    private SynoClient(IntPtr client) => _client = client;
+
+    /// <summary>True once <see cref="Mount"/> has succeeded and not been undone.</summary>
+    public bool IsMounted => _mount != IntPtr.Zero;
+
+    // ── Connect ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Log in and return a connected client. Throws
+    /// <see cref="OtpRequiredException"/> when the account needs a 2FA code (the
+    /// caller should prompt and retry with <paramref name="otp"/> set), or
+    /// <see cref="SynoException"/> on any other failure.
+    /// </summary>
+    public static SynoClient Connect(
+        string host, ushort port, bool https, string username, string password,
+        string? otp = null, bool autoRelogin = true)
+    {
+        NativeMethods.EnsureResolver();
+        var err = default(NativeError);
+        int rc = syno_connect(host, port, https, username, password, otp, autoRelogin,
+            out var handle, ref err);
+        Check(rc, ref err);
+        return new SynoClient(handle);
+    }
+
+    // ── Browse ─────────────────────────────────────────────────────────────────
+
+    public SynoFileInfo[] ListShares()
+    {
+        var err = default(NativeError);
+        int rc = syno_list_shares(_client, out var json, ref err);
+        Check(rc, ref err);
+        return ParseArray(json);
+    }
+
+    public SynoFileInfo[] ListDir(string path)
+    {
+        var err = default(NativeError);
+        int rc = syno_list_dir(_client, path, out var json, ref err);
+        Check(rc, ref err);
+        return ParseArray(json);
+    }
+
+    public SynoFileInfo GetInfo(string path)
+    {
+        var err = default(NativeError);
+        int rc = syno_get_info(_client, path, out var json, ref err);
+        Check(rc, ref err);
+        return ParseObject(json);
+    }
+
+    // ── Transfers ──────────────────────────────────────────────────────────────
+
+    /// <summary>Download <paramref name="remote"/> to <paramref name="local"/>,
+    /// reporting (bytesDone, bytesTotal) via <paramref name="progress"/>.</summary>
+    public void DownloadTo(string remote, string local, Action<long, long>? progress = null)
+    {
+        var err = default(NativeError);
+        var (fp, keepAlive) = MakeProgress(progress);
+        int rc = syno_download_to(_client, remote, local, fp, IntPtr.Zero, ref err);
+        GC.KeepAlive(keepAlive);
+        Check(rc, ref err);
+    }
+
+    /// <summary>Upload <paramref name="local"/> into the remote directory
+    /// <paramref name="remoteDir"/>. Progress is coarse (0 → total).</summary>
+    public void Upload(string local, string remoteDir, bool overwrite = true,
+        Action<long, long>? progress = null)
+    {
+        var err = default(NativeError);
+        var (fp, keepAlive) = MakeProgress(progress);
+        int rc = syno_upload(_client, local, remoteDir, overwrite, fp, IntPtr.Zero, ref err);
+        GC.KeepAlive(keepAlive);
+        Check(rc, ref err);
+    }
+
+    public void Delete(string path)
+    {
+        var err = default(NativeError);
+        Check(syno_delete(_client, path, ref err), ref err);
+    }
+
+    public void CreateFolder(string parent, string name)
+    {
+        var err = default(NativeError);
+        Check(syno_create_folder(_client, parent, name, ref err), ref err);
+    }
+
+    public void Rename(string path, string newName)
+    {
+        var err = default(NativeError);
+        Check(syno_rename(_client, path, newName, ref err), ref err);
+    }
+
+    // ── Mount lifecycle ──────────────────────────────────────────────────────────
+
+    /// <summary>Mount the share at <paramref name="mountpoint"/> in-process.
+    /// Returns once the mount is established (or throws on failure).</summary>
+    public void Mount(string mountpoint, ulong cacheTtl, ulong readCacheMb)
+    {
+        var err = default(NativeError);
+        int rc = syno_mount(_client, mountpoint, cacheTtl, readCacheMb, out var mount, ref err);
+        Check(rc, ref err);
+        _mount = mount;
+    }
+
+    /// <summary>Unmount, if mounted. Blocks until the background worker exits.</summary>
+    public void Unmount()
+    {
+        if (_mount != IntPtr.Zero)
+        {
+            syno_unmount(_mount);
+            _mount = IntPtr.Zero;
+        }
+    }
+
+    // ── Logging bridge ───────────────────────────────────────────────────────────
+
+    // Held to keep the delegate alive for as long as native code may call it.
+    private static LogCb? _logKeepAlive;
+
+    /// <summary>Route the library's log lines to <paramref name="onLine"/>
+    /// (level, text), or pass null to clear. Installed process-wide.</summary>
+    public static void SetLogCallback(Action<int, string>? onLine)
+    {
+        NativeMethods.EnsureResolver();
+        if (onLine is null)
+        {
+            _logKeepAlive = null;
+            syno_set_log_callback(IntPtr.Zero, IntPtr.Zero);
+            return;
+        }
+        _logKeepAlive = (level, line, _) =>
+        {
+            var text = line != IntPtr.Zero ? Marshal.PtrToStringUTF8(line) ?? "" : "";
+            onLine(level, text);
+        };
+        syno_set_log_callback(Marshal.GetFunctionPointerForDelegate(_logKeepAlive), IntPtr.Zero);
+    }
+
+    // ── Dispose ────────────────────────────────────────────────────────────────
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Unmount();
+        if (_client != IntPtr.Zero)
+        {
+            syno_logout(_client);
+            syno_client_free(_client);
+            _client = IntPtr.Zero;
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private static (IntPtr fp, ProgressCb? keepAlive) MakeProgress(Action<long, long>? progress)
+    {
+        if (progress is null) return (IntPtr.Zero, null);
+        ProgressCb cb = (done, total, _) => progress((long)done, (long)total);
+        return (Marshal.GetFunctionPointerForDelegate(cb), cb);
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    private static SynoFileInfo[] ParseArray(IntPtr json)
+    {
+        var s = TakeString(json);
+        return JsonSerializer.Deserialize<SynoFileInfo[]>(s, JsonOpts) ?? Array.Empty<SynoFileInfo>();
+    }
+
+    private static SynoFileInfo ParseObject(IntPtr json)
+    {
+        var s = TakeString(json);
+        return JsonSerializer.Deserialize<SynoFileInfo>(s, JsonOpts) ?? new SynoFileInfo();
+    }
+
+    /// <summary>Copy a native string to managed and free the native buffer.</summary>
+    private static string TakeString(IntPtr ptr)
+    {
+        if (ptr == IntPtr.Zero) return "";
+        var s = Marshal.PtrToStringUTF8(ptr) ?? "";
+        syno_string_free(ptr);
+        return s;
+    }
+
+    /// <summary>Throw a typed exception for any non-OK status, freeing the
+    /// native error message first.</summary>
+    private static void Check(int rc, ref NativeError err)
+    {
+        var status = (SynoStatus)rc;
+        if (status == SynoStatus.Ok) return;
+
+        var message = err.Message != IntPtr.Zero ? Marshal.PtrToStringUTF8(err.Message) ?? "" : "";
+        var dsm = err.DsmCode;
+        if (err.Message != IntPtr.Zero)
+        {
+            syno_string_free(err.Message);
+            err.Message = IntPtr.Zero;
+        }
+        if (message.Length == 0) message = $"native error {rc}";
+
+        throw status == SynoStatus.OtpRequired
+            ? new OtpRequiredException(message)
+            : new SynoException(status, dsm, message);
+    }
+}

--- a/SynologyFuse.Gui/SynologyFuse.Gui.csproj
+++ b/SynologyFuse.Gui/SynologyFuse.Gui.csproj
@@ -4,6 +4,8 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <!-- LibraryImport (source-generated P/Invoke for the Rust FFI) emits unsafe code. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
@@ -25,9 +27,9 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
   </ItemGroup>
 

--- a/SynologyFuse.Gui/SynologyFuse.Gui.csproj
+++ b/SynologyFuse.Gui/SynologyFuse.Gui.csproj
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
+    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
   </ItemGroup>
 

--- a/SynologyFuse.Gui/ViewModels/BrowserConverters.cs
+++ b/SynologyFuse.Gui/ViewModels/BrowserConverters.cs
@@ -13,13 +13,16 @@ public static class BrowserConverters
 
     /// <summary>Nullable byte count → human-readable size ("" for directories/unknown).</summary>
     public static readonly IValueConverter Size =
-        new FuncValueConverter<ulong?, string>(size =>
-        {
-            if (size is not { } n) return "";
-            string[] units = ["B", "KiB", "MiB", "GiB", "TiB"];
-            double v = n;
-            int u = 0;
-            while (v >= 1024 && u < units.Length - 1) { v /= 1024; u++; }
-            return $"{v:0.#} {units[u]}";
-        });
+        new FuncValueConverter<ulong?, string>(size => size is { } n ? HumanSize((long)n) : "");
+
+    /// <summary>Format a byte count as a human-readable size (binary units).
+    /// Shared by the listing's Size column and the transfer-progress label.</summary>
+    public static string HumanSize(long n)
+    {
+        string[] units = ["B", "KiB", "MiB", "GiB", "TiB"];
+        double v = n;
+        int u = 0;
+        while (v >= 1024 && u < units.Length - 1) { v /= 1024; u++; }
+        return $"{v:0.#} {units[u]}";
+    }
 }

--- a/SynologyFuse.Gui/ViewModels/BrowserConverters.cs
+++ b/SynologyFuse.Gui/ViewModels/BrowserConverters.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace SynologyFuse.Gui.ViewModels;
+
+/// <summary>Small value converters for the file-browser listing.</summary>
+public static class BrowserConverters
+{
+    /// <summary>bool IsDir → a folder/file glyph.</summary>
+    public static readonly IValueConverter DirGlyph =
+        new FuncValueConverter<bool, string>(isDir => isDir ? "📁" : "📄");
+
+    /// <summary>Nullable byte count → human-readable size ("" for directories/unknown).</summary>
+    public static readonly IValueConverter Size =
+        new FuncValueConverter<ulong?, string>(size =>
+        {
+            if (size is not { } n) return "";
+            string[] units = ["B", "KiB", "MiB", "GiB", "TiB"];
+            double v = n;
+            int u = 0;
+            while (v >= 1024 && u < units.Length - 1) { v /= 1024; u++; }
+            return $"{v:0.#} {units[u]}";
+        });
+}

--- a/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
+++ b/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -23,6 +24,12 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
     private readonly MountConfig _config;
     private SynoClient? _client;
     private bool _disposed;
+
+    // Serializes every native call against Dispose() so the handle is never
+    // freed while a P/Invoke is in flight. The gate is taken and released on
+    // the worker thread inside Task.Run (never the UI thread), so Dispose() can
+    // block on it without risking a deadlock.
+    private readonly SemaphoreSlim _gate = new(1, 1);
 
     /// <summary>Path stack for breadcrumb navigation; "" denotes the shares root.</summary>
     private readonly Stack<string> _history = new();
@@ -132,9 +139,8 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
         Status = path.Length == 0 ? "Loading shares…" : $"Loading {path}…";
         try
         {
-            var client = _client;
-            var entries = await Task.Run(() =>
-                path.Length == 0 ? client.ListShares() : client.ListDir(path));
+            var entries = await GatedAsync(c => path.Length == 0 ? c.ListShares() : c.ListDir(path));
+            if (entries is null) return; // client was disposed mid-call
 
             Items.Clear();
             foreach (var e in entries) Items.Add(e);
@@ -214,7 +220,6 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
     private async Task RunWithProgressAsync(string status, Action<SynoClient> op)
     {
         if (_client is null) return;
-        var client = _client;
         IsBusy = true;
         ShowProgress = true;
         ProgressValue = 0;
@@ -223,7 +228,7 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
         Status = status;
         try
         {
-            await Task.Run(() => op(client));
+            await GatedAsync(op);
             Status = "Done";
         }
         catch (Exception ex)
@@ -236,6 +241,33 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
             IsBusy = false;
         }
     }
+
+    /// <summary>Run a native call that returns a value under the gate, on a
+    /// worker thread. Returns null if the client was disposed.</summary>
+    private Task<T?> GatedAsync<T>(Func<SynoClient, T> op) where T : class =>
+        Task.Run<T?>(() =>
+        {
+            _gate.Wait();
+            try
+            {
+                var c = _client;
+                return c is null ? null : op(c);
+            }
+            finally { _gate.Release(); }
+        });
+
+    /// <summary>Run a native call with no return value under the gate.</summary>
+    private Task GatedAsync(Action<SynoClient> op) =>
+        Task.Run(() =>
+        {
+            _gate.Wait();
+            try
+            {
+                var c = _client;
+                if (c is not null) op(c);
+            }
+            finally { _gate.Release(); }
+        });
 
     // Marshals native-thread progress callbacks onto the UI thread.
     private void ReportProgress(long done, long total) =>
@@ -260,7 +292,18 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
     public void Dispose()
     {
         _disposed = true;
-        _client?.Dispose();
-        _client = null;
+        // Block until any in-flight native op (which holds the gate on a worker
+        // thread) finishes, so we never free the handle mid-P/Invoke. The gate
+        // is released off the UI thread, so this Wait can't deadlock.
+        _gate.Wait();
+        try
+        {
+            _client?.Dispose();
+            _client = null;
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
 }

--- a/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
+++ b/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
@@ -22,6 +22,7 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
 {
     private readonly MountConfig _config;
     private SynoClient? _client;
+    private bool _disposed;
 
     /// <summary>Path stack for breadcrumb navigation; "" denotes the shares root.</summary>
     private readonly Stack<string> _history = new();
@@ -81,8 +82,17 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
         Status = "Connecting…";
         try
         {
-            _client = await Task.Run(() => SynoClient.Connect(
+            var client = await Task.Run(() => SynoClient.Connect(
                 _config.Host, _config.Port, _config.UseHttps, _config.Username, _config.Password, otp));
+            // If the window was closed (Dispose ran) while the login was in
+            // flight, the handle would otherwise leak — dispose it and bail.
+            // The await resumed on the UI thread, so this can't race Dispose().
+            if (_disposed)
+            {
+                client.Dispose();
+                return;
+            }
+            _client = client;
             ShowOtpPrompt = false;
             OnPropertyChanged(nameof(IsConnected));
             await LoadAsync("");
@@ -247,5 +257,10 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
         return $"{v:0.#} {units[u]}";
     }
 
-    public void Dispose() => _client?.Dispose();
+    public void Dispose()
+    {
+        _disposed = true;
+        _client?.Dispose();
+        _client = null;
+    }
 }

--- a/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
+++ b/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
@@ -276,34 +276,27 @@ public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
             ProgressMax = total > 0 ? total : Math.Max(done, 1);
             ProgressValue = done;
             ProgressText = total > 0
-                ? $"{Bytes(done)} / {Bytes(total)}"
-                : Bytes(done);
+                ? $"{BrowserConverters.HumanSize(done)} / {BrowserConverters.HumanSize(total)}"
+                : BrowserConverters.HumanSize(done);
         });
-
-    private static string Bytes(long n)
-    {
-        string[] units = ["B", "KiB", "MiB", "GiB", "TiB"];
-        double v = n;
-        int u = 0;
-        while (v >= 1024 && u < units.Length - 1) { v /= 1024; u++; }
-        return $"{v:0.#} {units[u]}";
-    }
 
     public void Dispose()
     {
         _disposed = true;
-        // Block until any in-flight native op (which holds the gate on a worker
-        // thread) finishes, so we never free the handle mid-P/Invoke. The gate
-        // is released off the UI thread, so this Wait can't deadlock.
-        _gate.Wait();
-        try
+        var client = _client;
+        _client = null; // new GatedAsync calls now see null and bail
+        if (client is null) return;
+
+        // Free the handle off the UI thread: wait for any in-flight native op
+        // (which holds the gate on a worker thread) to finish, THEN dispose.
+        // Doing this on a background task keeps the window from freezing when
+        // it's closed mid-transfer, while the gate still prevents a
+        // dispose-during-P/Invoke use-after-free.
+        Task.Run(() =>
         {
-            _client?.Dispose();
-            _client = null;
-        }
-        finally
-        {
-            _gate.Release();
-        }
+            _gate.Wait();
+            try { client.Dispose(); }
+            finally { _gate.Release(); }
+        });
     }
 }

--- a/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
+++ b/SynologyFuse.Gui/ViewModels/FileBrowserViewModel.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using SynologyFuse.Gui.Interop;
+using SynologyFuse.Gui.Models;
+using SynologyFuse.Gui.Services;
+
+namespace SynologyFuse.Gui.ViewModels;
+
+/// <summary>
+/// Backs the pre-mount file browser. Owns its own <see cref="SynoClient"/>
+/// session (connect on open, dispose on close) and exercises the full client
+/// surface: list shares/dirs, download, upload, delete, create folder. Browse
+/// works without mounting anything.
+/// </summary>
+public sealed partial class FileBrowserViewModel : ObservableObject, IDisposable
+{
+    private readonly MountConfig _config;
+    private SynoClient? _client;
+
+    /// <summary>Path stack for breadcrumb navigation; "" denotes the shares root.</summary>
+    private readonly Stack<string> _history = new();
+
+    public FileBrowserViewModel(MountConfig config) => _config = config;
+
+    public ObservableCollection<SynoFileInfo> Items { get; } = new();
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(UpCommand))]
+    [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
+    private string _currentPath = "";
+
+    [ObservableProperty]
+    private SynoFileInfo? _selectedItem;
+
+    [ObservableProperty]
+    private string _status = "Connecting…";
+
+    [ObservableProperty]
+    private bool _isBusy;
+
+    // ── 2FA ─────────────────────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SubmitOtpCommand))]
+    private bool _showOtpPrompt;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SubmitOtpCommand))]
+    private string _pendingOtp = "";
+
+    // ── Transfer progress ─────────────────────────────────────────────────────
+
+    [ObservableProperty]
+    private bool _showProgress;
+
+    [ObservableProperty]
+    private double _progressValue;
+
+    [ObservableProperty]
+    private double _progressMax = 1;
+
+    [ObservableProperty]
+    private string _progressText = "";
+
+    public bool IsConnected => _client is not null;
+
+    // ── Connect ──────────────────────────────────────────────────────────────────
+
+    /// <summary>Connect the browser's session. Call once when the window opens.</summary>
+    public Task ConnectAsync() => ConnectAsync(null);
+
+    private async Task ConnectAsync(string? otp)
+    {
+        IsBusy = true;
+        Status = "Connecting…";
+        try
+        {
+            _client = await Task.Run(() => SynoClient.Connect(
+                _config.Host, _config.Port, _config.UseHttps, _config.Username, _config.Password, otp));
+            ShowOtpPrompt = false;
+            OnPropertyChanged(nameof(IsConnected));
+            await LoadAsync("");
+        }
+        catch (OtpRequiredException)
+        {
+            ShowOtpPrompt = true;
+            Status = "2FA code required";
+        }
+        catch (Exception ex)
+        {
+            Status = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSubmitOtp))]
+    private async Task SubmitOtp()
+    {
+        var code = PendingOtp.Trim();
+        ShowOtpPrompt = false;
+        PendingOtp = "";
+        await ConnectAsync(code);
+    }
+
+    private bool CanSubmitOtp() => ShowOtpPrompt && !string.IsNullOrWhiteSpace(PendingOtp);
+
+    // ── Navigation ───────────────────────────────────────────────────────────────
+
+    private async Task LoadAsync(string path)
+    {
+        if (_client is null) return;
+        IsBusy = true;
+        Status = path.Length == 0 ? "Loading shares…" : $"Loading {path}…";
+        try
+        {
+            var client = _client;
+            var entries = await Task.Run(() =>
+                path.Length == 0 ? client.ListShares() : client.ListDir(path));
+
+            Items.Clear();
+            foreach (var e in entries) Items.Add(e);
+            CurrentPath = path;
+            SelectedItem = null;
+            Status = $"{Items.Count} item(s)" + (path.Length == 0 ? " (shares)" : $" in {path}");
+        }
+        catch (Exception ex)
+        {
+            Status = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+            RefreshCommand.NotifyCanExecuteChanged();
+            UpCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    /// <summary>Descend into the selected directory (no-op for files).</summary>
+    [RelayCommand]
+    private async Task Open()
+    {
+        if (SelectedItem is not { IsDir: true } dir) return;
+        _history.Push(CurrentPath);
+        await LoadAsync(dir.Path);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanGoUp))]
+    private async Task Up()
+    {
+        var target = _history.Count > 0 ? _history.Pop() : "";
+        await LoadAsync(target);
+    }
+
+    private bool CanGoUp() => CurrentPath.Length != 0;
+
+    [RelayCommand(CanExecute = nameof(CanRefresh))]
+    private Task Refresh() => LoadAsync(CurrentPath);
+
+    private bool CanRefresh() => IsConnected;
+
+    // ── Operations (invoked by the view, which supplies file-picker paths) ──────
+
+    public async Task DownloadAsync(SynoFileInfo item, string localPath)
+    {
+        if (_client is null || item.IsDir) return;
+        await RunWithProgressAsync($"Downloading {item.Name}…", client =>
+            client.DownloadTo(item.Path, localPath, ReportProgress));
+    }
+
+    public async Task UploadAsync(string localPath)
+    {
+        if (_client is null || CurrentPath.Length == 0) return; // can't upload to the shares root
+        var name = System.IO.Path.GetFileName(localPath);
+        await RunWithProgressAsync($"Uploading {name}…", client =>
+            client.Upload(localPath, CurrentPath, overwrite: true, ReportProgress));
+        await LoadAsync(CurrentPath);
+    }
+
+    [RelayCommand]
+    private async Task Delete()
+    {
+        if (_client is null || SelectedItem is null) return;
+        var item = SelectedItem;
+        await RunWithProgressAsync($"Deleting {item.Name}…", client => client.Delete(item.Path));
+        await LoadAsync(CurrentPath);
+    }
+
+    public async Task CreateFolderAsync(string name)
+    {
+        if (_client is null || CurrentPath.Length == 0 || string.IsNullOrWhiteSpace(name)) return;
+        await RunWithProgressAsync($"Creating {name}…", client => client.CreateFolder(CurrentPath, name));
+        await LoadAsync(CurrentPath);
+    }
+
+    private async Task RunWithProgressAsync(string status, Action<SynoClient> op)
+    {
+        if (_client is null) return;
+        var client = _client;
+        IsBusy = true;
+        ShowProgress = true;
+        ProgressValue = 0;
+        ProgressMax = 1;
+        ProgressText = status;
+        Status = status;
+        try
+        {
+            await Task.Run(() => op(client));
+            Status = "Done";
+        }
+        catch (Exception ex)
+        {
+            Status = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            ShowProgress = false;
+            IsBusy = false;
+        }
+    }
+
+    // Marshals native-thread progress callbacks onto the UI thread.
+    private void ReportProgress(long done, long total) =>
+        Dispatcher.UIThread.Post(() =>
+        {
+            ProgressMax = total > 0 ? total : Math.Max(done, 1);
+            ProgressValue = done;
+            ProgressText = total > 0
+                ? $"{Bytes(done)} / {Bytes(total)}"
+                : Bytes(done);
+        });
+
+    private static string Bytes(long n)
+    {
+        string[] units = ["B", "KiB", "MiB", "GiB", "TiB"];
+        double v = n;
+        int u = 0;
+        while (v >= 1024 && u < units.Length - 1) { v /= 1024; u++; }
+        return $"{v:0.#} {units[u]}";
+    }
+
+    public void Dispose() => _client?.Dispose();
+}

--- a/SynologyFuse.Gui/ViewModels/MainWindowViewModel.cs
+++ b/SynologyFuse.Gui/ViewModels/MainWindowViewModel.cs
@@ -114,6 +114,7 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(IsIdle))]
     [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
     [NotifyCanExecuteChangedFor(nameof(TestConnectionCommand))]
+    [NotifyCanExecuteChangedFor(nameof(DisconnectCommand))]
     private bool _isConnecting;
 
     public bool IsIdle => !IsConnecting;
@@ -248,18 +249,33 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         !string.IsNullOrWhiteSpace(Mountpoint);
 
     [RelayCommand(CanExecute = nameof(CanDisconnect))]
-    private void Disconnect()
+    private async Task Disconnect()
     {
         AppendLog("Disconnecting…");
         StatusText = "Disconnecting…";
         ShowOtpPrompt = false;
-        _mountService.Stop();
-        IsConnected = false;
-        StatusText = "Disconnected";
-        AppendLog("Unmounted.");
+        IsConnecting = true;
+        try
+        {
+            // Stop() disposes the native client and blocks while unmounting and
+            // joining the background worker — keep it off the UI thread.
+            await Task.Run(() => _mountService.Stop());
+            IsConnected = false;
+            StatusText = "Disconnected";
+            AppendLog("Unmounted.");
+        }
+        catch (Exception ex)
+        {
+            StatusText = "Error";
+            AppendLog($"Error during disconnect: {ex.Message}");
+        }
+        finally
+        {
+            IsConnecting = false;
+        }
     }
 
-    private bool CanDisconnect() => IsConnected;
+    private bool CanDisconnect() => IsConnected && !IsConnecting;
 
     /// <summary>Retry the gated connect/test with the user-entered OTP code.</summary>
     [RelayCommand(CanExecute = nameof(CanSubmitOtp))]

--- a/SynologyFuse.Gui/ViewModels/MainWindowViewModel.cs
+++ b/SynologyFuse.Gui/ViewModels/MainWindowViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using SynologyFuse.Gui.Interop;
 using SynologyFuse.Gui.Models;
 using SynologyFuse.Gui.Services;
 
@@ -13,6 +14,14 @@ namespace SynologyFuse.Gui.ViewModels;
 public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 {
     private readonly MountService _mountService = new();
+
+    /// <summary>The action the OTP banner is gating: either a full mount or a
+    /// connection test. Set when a connect attempt reports OTP-required so
+    /// <see cref="SubmitOtp"/> knows which operation to retry.</summary>
+    private enum PendingAction { None, Mount, Test }
+
+    private PendingAction _pending = PendingAction.None;
+    private MountConfig? _pendingConfig;
 
     public MainWindowViewModel()
     {
@@ -25,6 +34,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         _cacheTtl = s.CacheTtl;
         _readCacheMb = s.ReadCacheMb;
         _logLevel = s.LogLevel;
+
+        _mountService.OutputReceived += OnOutput;
 
         var v = UpdateCheckService.CurrentVersion();
         Version = $"v{v.Major}.{v.Minor}.{v.Build}";
@@ -51,10 +62,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(TestConnectionCommand))]
     private string _host;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(TestConnectionCommand))]
     private string _username;
 
     [ObservableProperty]
@@ -90,9 +103,20 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(IsDisconnected))]
     [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
     [NotifyCanExecuteChangedFor(nameof(DisconnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(TestConnectionCommand))]
     private bool _isConnected;
 
     public bool IsDisconnected => !IsConnected;
+
+    /// <summary>True while a connect / test / mount attempt is in flight. Drives
+    /// the spinner and disables the action buttons.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsIdle))]
+    [NotifyCanExecuteChangedFor(nameof(ConnectCommand))]
+    [NotifyCanExecuteChangedFor(nameof(TestConnectionCommand))]
+    private bool _isConnecting;
+
+    public bool IsIdle => !IsConnecting;
 
     [ObservableProperty]
     private string _statusText = "Disconnected";
@@ -100,10 +124,8 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private string _logOutput = "";
 
-    /// <summary>
-    /// True when the CLI is blocked waiting for a 2FA code on stdin.
-    /// Shows an inline banner so the user can type the code without restarting.
-    /// </summary>
+    /// <summary>True when a 2FA code is required to finish connecting. Shows an
+    /// inline banner so the user can supply the code and retry.</summary>
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(SubmitOtpCommand))]
     private bool _showOtpPrompt;
@@ -150,67 +172,77 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
     [RelayCommand(CanExecute = nameof(CanConnect))]
     private async Task Connect()
     {
+        PersistSettings();
+        _pendingConfig = BuildConfig();
+        await RunConnectAsync(PendingAction.Mount, _pendingConfig, otp: null);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanConnect))]
+    private async Task TestConnection()
+    {
+        PersistSettings();
+        _pendingConfig = BuildConfig();
+        await RunConnectAsync(PendingAction.Test, _pendingConfig, otp: null);
+    }
+
+    /// <summary>Shared connect path for both Mount and Test. Handles the spinner,
+    /// the OTP-required banner, and error reporting uniformly.</summary>
+    private async Task RunConnectAsync(PendingAction action, MountConfig config, string? otp)
+    {
         ShowOtpPrompt = false;
-        PendingOtp = "";
-        AppendLog($"Connecting to {Host}…");
-        StatusText = "Connecting…";
-
-        SettingsService.Save(new PersistedSettings
-        {
-            Host = Host,
-            Username = Username,
-            Port = Port,
-            UseHttps = UseHttps,
-            Mountpoint = Mountpoint,
-            CacheTtl = CacheTtl,
-            ReadCacheMb = ReadCacheMb,
-            LogLevel = LogLevel,
-        });
-
-        _mountService.OutputReceived += OnOutput;
-        _mountService.PromptRequired += OnPromptRequired;
-        _mountService.Exited += OnExited;
+        IsConnecting = true;
+        StatusText = action == PendingAction.Test ? "Testing connection…" : "Connecting…";
+        AppendLog(action == PendingAction.Test
+            ? $"Testing connection to {config.Host}…"
+            : $"Connecting to {config.Host}…");
 
         try
         {
-            var config = new MountConfig
+            if (action == PendingAction.Test)
             {
-                Host = Host,
-                Username = Username,
-                Password = Password,
-                Port = (ushort)Port,
-                UseHttps = UseHttps,
-                Mountpoint = Mountpoint,
-                CacheTtl = (ulong)CacheTtl,
-                ReadCacheMb = (ulong)ReadCacheMb,
-                LogLevel = LogLevel,
-            };
-
-            await _mountService.StartAsync(config);
-
-            if (_mountService.IsRunning)
-            {
-                IsConnected = true;
-                StatusText = $"Mounted at {Mountpoint}";
-                AppendLog("Mount process started.");
+                await _mountService.TestConnectionAsync(config, otp);
+                StatusText = "Connection OK";
+                AppendLog("Connection succeeded.");
+                _pending = PendingAction.None;
             }
             else
             {
-                // Process already exited — OnExited has handled state.
-                DetachEvents();
+                await _mountService.ConnectAndMountAsync(config, otp);
+                IsConnected = true;
+                StatusText = $"Mounted at {config.Mountpoint}";
+                AppendLog("Mounted.");
+                _pending = PendingAction.None;
             }
+        }
+        catch (OtpRequiredException)
+        {
+            // Not an error: stash the in-flight action and prompt for the code.
+            _pending = action;
+            ShowOtpPrompt = true;
+            StatusText = "2FA code required";
+            AppendLog("[2FA] Two-factor authentication code required.");
+        }
+        catch (SynoException ex)
+        {
+            StatusText = "Error";
+            IsConnected = false;
+            AppendLog(ex.DsmCode != 0 ? $"Error (DSM {ex.DsmCode}): {ex.Message}" : $"Error: {ex.Message}");
         }
         catch (Exception ex)
         {
-            AppendLog($"Error: {ex.Message}");
             StatusText = "Error";
             IsConnected = false;
-            DetachEvents();
+            AppendLog($"Error: {ex.Message}");
+        }
+        finally
+        {
+            IsConnecting = false;
         }
     }
 
     private bool CanConnect() =>
         !IsConnected &&
+        !IsConnecting &&
         !string.IsNullOrWhiteSpace(Host) &&
         !string.IsNullOrWhiteSpace(Username) &&
         !string.IsNullOrWhiteSpace(Mountpoint);
@@ -222,59 +254,66 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
         StatusText = "Disconnecting…";
         ShowOtpPrompt = false;
         _mountService.Stop();
-        // IsConnected → false via OnExited.
+        IsConnected = false;
+        StatusText = "Disconnected";
+        AppendLog("Unmounted.");
     }
 
     private bool CanDisconnect() => IsConnected;
 
-    /// <summary>
-    /// Sends the user-entered OTP code to the waiting CLI process via stdin.
-    /// </summary>
+    /// <summary>Retry the gated connect/test with the user-entered OTP code.</summary>
     [RelayCommand(CanExecute = nameof(CanSubmitOtp))]
-    private void SubmitOtp()
+    private async Task SubmitOtp()
     {
         var code = PendingOtp.Trim();
-        AppendLog($"Sending 2FA code…");
+        var action = _pending;
+        var config = _pendingConfig;
         ShowOtpPrompt = false;
         PendingOtp = "";
-        _mountService.SendLine(code);
-        StatusText = "Verifying 2FA code…";
+        AppendLog("Submitting 2FA code…");
+
+        if (config is null || action == PendingAction.None) return;
+        await RunConnectAsync(action, config, code);
     }
 
     private bool CanSubmitOtp() =>
         ShowOtpPrompt && !string.IsNullOrWhiteSpace(PendingOtp);
 
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    /// <summary>Snapshot of the current form as a <see cref="MountConfig"/>,
+    /// used by the file browser window.</summary>
+    public MountConfig SnapshotConfig() => BuildConfig();
+
+    private MountConfig BuildConfig() => new()
+    {
+        Host = Host,
+        Username = Username,
+        Password = Password,
+        Port = (ushort)Port,
+        UseHttps = UseHttps,
+        Mountpoint = Mountpoint,
+        CacheTtl = (ulong)CacheTtl,
+        ReadCacheMb = (ulong)ReadCacheMb,
+        LogLevel = LogLevel,
+    };
+
+    private void PersistSettings() => SettingsService.Save(new PersistedSettings
+    {
+        Host = Host,
+        Username = Username,
+        Port = Port,
+        UseHttps = UseHttps,
+        Mountpoint = Mountpoint,
+        CacheTtl = CacheTtl,
+        ReadCacheMb = ReadCacheMb,
+        LogLevel = LogLevel,
+    });
+
     // ── Event handlers ────────────────────────────────────────────────────────
 
     private void OnOutput(string line) =>
         Dispatcher.UIThread.Post(() => AppendLog(line));
-
-    private void OnPromptRequired(string prompt) =>
-        Dispatcher.UIThread.Post(() =>
-        {
-            AppendLog($"[2FA] {prompt}");
-            ShowOtpPrompt = true;
-            StatusText = "2FA code required";
-        });
-
-    private void OnExited(int exitCode)
-    {
-        Dispatcher.UIThread.Post(() =>
-        {
-            DetachEvents();
-            IsConnected = false;
-            ShowOtpPrompt = false;
-            StatusText = exitCode == 0 ? "Disconnected" : $"Exited (code {exitCode})";
-            AppendLog($"Mount process exited with code {exitCode}.");
-        });
-    }
-
-    private void DetachEvents()
-    {
-        _mountService.OutputReceived -= OnOutput;
-        _mountService.PromptRequired -= OnPromptRequired;
-        _mountService.Exited -= OnExited;
-    }
 
     private void AppendLog(string line)
     {
@@ -283,5 +322,9 @@ public sealed partial class MainWindowViewModel : ObservableObject, IDisposable
             : LogOutput + Environment.NewLine + line;
     }
 
-    public void Dispose() => _mountService.Dispose();
+    public void Dispose()
+    {
+        _mountService.OutputReceived -= OnOutput;
+        _mountService.Dispose();
+    }
 }

--- a/SynologyFuse.Gui/Views/FileBrowserWindow.axaml
+++ b/SynologyFuse.Gui/Views/FileBrowserWindow.axaml
@@ -1,0 +1,76 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:SynologyFuse.Gui.ViewModels"
+        xmlns:models="using:SynologyFuse.Gui.Models"
+        x:Class="SynologyFuse.Gui.Views.FileBrowserWindow"
+        x:DataType="vm:FileBrowserViewModel"
+        Icon="/Assets/app.ico"
+        Title="Browse NAS"
+        Width="640" Height="480"
+        MinWidth="480" MinHeight="320">
+
+  <DockPanel>
+
+    <!-- Toolbar -->
+    <Border DockPanel.Dock="Top" Padding="10,8"
+            BorderThickness="0,0,0,1"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+      <Grid ColumnDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto">
+        <Button Grid.Column="0" Content="Up" Command="{Binding UpCommand}" Margin="0,0,6,0" />
+        <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,6,0" />
+        <TextBlock Grid.Column="2" VerticalAlignment="Center" Margin="6,0"
+                   Text="{Binding CurrentPath}" FontFamily="Consolas,Menlo,monospace" />
+        <Button Grid.Column="3" Content="New Folder" Click="OnNewFolder" Margin="0,0,6,0" />
+        <Button Grid.Column="4" Content="Upload" Click="OnUpload" Margin="0,0,6,0" />
+        <Button Grid.Column="5" Content="Download" Click="OnDownload" Margin="0,0,6,0" />
+        <Button Grid.Column="6" Content="Delete" Command="{Binding DeleteCommand}" />
+      </Grid>
+    </Border>
+
+    <!-- Status / progress -->
+    <Border DockPanel.Dock="Bottom" Padding="10,6"
+            BorderThickness="0,1,0,0"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+      <StackPanel Spacing="4">
+        <TextBlock Text="{Binding Status}" FontSize="12" />
+        <ProgressBar IsVisible="{Binding ShowProgress}"
+                     Minimum="0"
+                     Maximum="{Binding ProgressMax}"
+                     Value="{Binding ProgressValue}" />
+        <TextBlock IsVisible="{Binding ShowProgress}" Text="{Binding ProgressText}" FontSize="11" />
+      </StackPanel>
+    </Border>
+
+    <!-- 2FA banner -->
+    <Border DockPanel.Dock="Top"
+            IsVisible="{Binding ShowOtpPrompt}"
+            Background="#FFF3CD" Padding="10,8">
+      <Grid ColumnDefinitions="*,Auto">
+        <TextBox Grid.Column="0" Text="{Binding PendingOtp, UpdateSourceTrigger=PropertyChanged}"
+                 PlaceholderText="6-digit TOTP code" Margin="0,0,8,0">
+          <TextBox.KeyBindings>
+            <KeyBinding Gesture="Enter" Command="{Binding SubmitOtpCommand}" />
+          </TextBox.KeyBindings>
+        </TextBox>
+        <Button Grid.Column="1" Content="Submit" Command="{Binding SubmitOtpCommand}" Classes="accent" />
+      </Grid>
+    </Border>
+
+    <!-- Listing -->
+    <ListBox ItemsSource="{Binding Items}"
+             SelectedItem="{Binding SelectedItem}"
+             DoubleTapped="OnItemDoubleTapped">
+      <ListBox.ItemTemplate>
+        <DataTemplate x:DataType="models:SynoFileInfo">
+          <Grid ColumnDefinitions="20,*,Auto">
+            <TextBlock Grid.Column="0" Text="{Binding IsDir, Converter={x:Static vm:BrowserConverters.DirGlyph}}" />
+            <TextBlock Grid.Column="1" Text="{Binding Name}" Margin="6,0,0,0" />
+            <TextBlock Grid.Column="2" Text="{Binding Size, Converter={x:Static vm:BrowserConverters.Size}}"
+                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+          </Grid>
+        </DataTemplate>
+      </ListBox.ItemTemplate>
+    </ListBox>
+
+  </DockPanel>
+</Window>

--- a/SynologyFuse.Gui/Views/FileBrowserWindow.axaml.cs
+++ b/SynologyFuse.Gui/Views/FileBrowserWindow.axaml.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using SynologyFuse.Gui.Models;
+using SynologyFuse.Gui.ViewModels;
+
+namespace SynologyFuse.Gui.Views;
+
+public partial class FileBrowserWindow : Window
+{
+    public FileBrowserWindow() => InitializeComponent();
+
+    public FileBrowserWindow(MountConfig config) : this()
+    {
+        var vm = new FileBrowserViewModel(config);
+        DataContext = vm;
+        Opened += async (_, _) => await vm.ConnectAsync();
+        Closed += (_, _) => vm.Dispose();
+    }
+
+    private FileBrowserViewModel? Vm => DataContext as FileBrowserViewModel;
+
+    private async void OnItemDoubleTapped(object? sender, TappedEventArgs e)
+    {
+        if (Vm is { } vm && vm.OpenCommand.CanExecute(null))
+            await vm.OpenCommand.ExecuteAsync(null);
+    }
+
+    private async void OnDownload(object? sender, RoutedEventArgs e)
+    {
+        if (Vm is not { SelectedItem: { IsDir: false } item } vm) return;
+
+        var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Download to…",
+            SuggestedFileName = item.Name,
+        });
+        if (file?.TryGetLocalPath() is { } local)
+            await vm.DownloadAsync(item, local);
+    }
+
+    private async void OnUpload(object? sender, RoutedEventArgs e)
+    {
+        if (Vm is not { } vm) return;
+
+        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Upload file",
+            AllowMultiple = false,
+        });
+        if (files.FirstOrDefault()?.TryGetLocalPath() is { } local)
+            await vm.UploadAsync(local);
+    }
+
+    private async void OnNewFolder(object? sender, RoutedEventArgs e)
+    {
+        if (Vm is not { } vm) return;
+        var name = await PromptWindow.ShowAsync(this, "New folder", "Folder name:");
+        if (!string.IsNullOrWhiteSpace(name))
+            await vm.CreateFolderAsync(name.Trim());
+    }
+}

--- a/SynologyFuse.Gui/Views/MainWindow.axaml
+++ b/SynologyFuse.Gui/Views/MainWindow.axaml
@@ -83,7 +83,7 @@
         <Grid ColumnDefinitions="130,*" Margin="0,0,0,6">
           <TextBlock Grid.Column="0" Text="Host" VerticalAlignment="Center" />
           <TextBox   Grid.Column="1" Text="{Binding Host}"
-                     Watermark="192.168.1.100 or nas.local"
+                     PlaceholderText="192.168.1.100 or nas.local"
                      IsEnabled="{Binding IsDisconnected}" />
         </Grid>
 
@@ -91,7 +91,7 @@
         <Grid ColumnDefinitions="130,*" Margin="0,0,0,6">
           <TextBlock Grid.Column="0" Text="Username" VerticalAlignment="Center" />
           <TextBox   Grid.Column="1" Text="{Binding Username}"
-                     Watermark="admin"
+                     PlaceholderText="admin"
                      IsEnabled="{Binding IsDisconnected}" />
         </Grid>
 
@@ -131,7 +131,7 @@
         <Grid ColumnDefinitions="130,*" Margin="0,0,0,6">
           <TextBlock Grid.Column="0" Text="Mountpoint" VerticalAlignment="Center" />
           <TextBox   Grid.Column="1" Text="{Binding Mountpoint}"
-                     Watermark="/mnt/nas  •  /Volumes/nas  •  Z:\"
+                     PlaceholderText="/mnt/nas  •  /Volumes/nas  •  Z:\"
                      IsEnabled="{Binding IsDisconnected}" />
         </Grid>
 
@@ -167,7 +167,7 @@
           </StackPanel>
         </Expander>
 
-        <!-- 2FA banner: appears when the CLI is blocked waiting for the OTP on stdin -->
+        <!-- 2FA banner: appears when login reports that an OTP code is required -->
         <Border IsVisible="{Binding ShowOtpPrompt}"
                 Background="#FFF3CD"
                 CornerRadius="4"
@@ -177,12 +177,12 @@
             <TextBlock Text="Two-factor authentication code required."
                        FontWeight="SemiBold"
                        Foreground="#856404" />
-            <TextBlock Text="Enter your TOTP code below. The mount process is waiting."
+            <TextBlock Text="Enter your TOTP code below to finish connecting."
                        TextWrapping="Wrap"
                        Foreground="#856404" />
             <Grid ColumnDefinitions="*,Auto">
               <TextBox Grid.Column="0" Text="{Binding PendingOtp, UpdateSourceTrigger=PropertyChanged}"
-                       Watermark="6-digit TOTP code"
+                       PlaceholderText="6-digit TOTP code"
                        Margin="0,0,8,0">
                 <TextBox.KeyBindings>
                   <KeyBinding Gesture="Enter" Command="{Binding SubmitOtpCommand}" />
@@ -197,17 +197,40 @@
         </Border>
 
         <!-- Buttons -->
-        <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,20,0,4"
-                    HorizontalAlignment="Right">
-          <Button Content="Connect"
+        <Grid ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="0,20,0,4">
+          <!-- Connecting spinner -->
+          <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8"
+                      VerticalAlignment="Center"
+                      IsVisible="{Binding IsConnecting}">
+            <ProgressBar IsIndeterminate="True" Width="120" Height="4"
+                         VerticalAlignment="Center" />
+            <TextBlock Text="Working…" VerticalAlignment="Center" FontSize="12"
+                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+          </StackPanel>
+
+          <Button Grid.Column="1"
+                  Content="Browse…"
+                  Click="OnBrowse"
+                  IsEnabled="{Binding IsIdle}"
+                  HorizontalAlignment="Left"
+                  Width="100" />
+          <Button Grid.Column="2"
+                  Content="Test Connection"
+                  Command="{Binding TestConnectionCommand}"
+                  Margin="0,0,10,0"
+                  Width="130" />
+          <Button Grid.Column="3"
+                  Content="Connect"
                   Command="{Binding ConnectCommand}"
                   Classes="accent"
                   IsDefault="True"
+                  Margin="0,0,10,0"
                   Width="110" />
-          <Button Content="Disconnect"
+          <Button Grid.Column="4"
+                  Content="Disconnect"
                   Command="{Binding DisconnectCommand}"
                   Width="110" />
-        </StackPanel>
+        </Grid>
 
       </StackPanel>
     </ScrollViewer>

--- a/SynologyFuse.Gui/Views/MainWindow.axaml.cs
+++ b/SynologyFuse.Gui/Views/MainWindow.axaml.cs
@@ -1,8 +1,17 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SynologyFuse.Gui.ViewModels;
 
 namespace SynologyFuse.Gui.Views;
 
 public partial class MainWindow : Window
 {
     public MainWindow() => InitializeComponent();
+
+    private void OnBrowse(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        var browser = new FileBrowserWindow(vm.SnapshotConfig());
+        browser.Show(this);
+    }
 }

--- a/SynologyFuse.Gui/Views/PromptWindow.axaml
+++ b/SynologyFuse.Gui/Views/PromptWindow.axaml
@@ -1,0 +1,17 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="SynologyFuse.Gui.Views.PromptWindow"
+        Title="Input"
+        Width="360"
+        SizeToContent="Height"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner">
+  <StackPanel Margin="16" Spacing="10">
+    <TextBlock x:Name="PromptLabel" />
+    <TextBox x:Name="Input" />
+    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+      <Button Content="OK" Classes="accent" IsDefault="True" Click="OnOk" Width="80" />
+      <Button Content="Cancel" IsCancel="True" Click="OnCancel" Width="80" />
+    </StackPanel>
+  </StackPanel>
+</Window>

--- a/SynologyFuse.Gui/Views/PromptWindow.axaml.cs
+++ b/SynologyFuse.Gui/Views/PromptWindow.axaml.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace SynologyFuse.Gui.Views;
+
+/// <summary>Minimal modal text-input dialog. Returns the entered string, or
+/// null if cancelled.</summary>
+public partial class PromptWindow : Window
+{
+    private string? _result;
+
+    public PromptWindow() => InitializeComponent();
+
+    public static async Task<string?> ShowAsync(Window owner, string title, string label)
+    {
+        var dlg = new PromptWindow { Title = title };
+        dlg.PromptLabel.Text = label;
+        return await dlg.ShowDialog<string?>(owner);
+    }
+
+    private void OnOk(object? sender, RoutedEventArgs e)
+    {
+        _result = Input.Text;
+        Close(_result);
+    }
+
+    private void OnCancel(object? sender, RoutedEventArgs e) => Close(null);
+}

--- a/SynologyFuse.Gui/Views/PromptWindow.axaml.cs
+++ b/SynologyFuse.Gui/Views/PromptWindow.axaml.cs
@@ -8,8 +8,6 @@ namespace SynologyFuse.Gui.Views;
 /// null if cancelled.</summary>
 public partial class PromptWindow : Window
 {
-    private string? _result;
-
     public PromptWindow() => InitializeComponent();
 
     public static async Task<string?> ShowAsync(Window owner, string title, string label)
@@ -19,11 +17,7 @@ public partial class PromptWindow : Window
         return await dlg.ShowDialog<string?>(owner);
     }
 
-    private void OnOk(object? sender, RoutedEventArgs e)
-    {
-        _result = Input.Text;
-        Close(_result);
-    }
+    private void OnOk(object? sender, RoutedEventArgs e) => Close(Input.Text);
 
     private void OnCancel(object? sender, RoutedEventArgs e) => Close(null);
 }

--- a/SynologyFuse.Installer/Package.wxs
+++ b/SynologyFuse.Installer/Package.wxs
@@ -61,6 +61,8 @@
       <ComponentGroupRef Id="GuiComponents" />
       <!-- Rust CLI binary -->
       <ComponentRef Id="CliComponent" />
+      <!-- Native FFI library used by the GUI -->
+      <ComponentRef Id="FfiComponent" />
       <!-- System PATH entry -->
       <ComponentRef Id="PathComponent" />
       <!-- Start Menu shortcut -->
@@ -104,6 +106,19 @@
     <Component Id="CliComponent" Directory="INSTALLFOLDER" Guid="*">
       <File Id="CliExe"
             Source="$(var.RustBin)\synology-filestation-fuse.exe"
+            KeyPath="yes" />
+    </Component>
+  </Fragment>
+
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       Native FFI library — the GUI calls the Rust core through this directly
+       (the resolver in NativeMethods.cs finds it beside the GUI executable).
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <Fragment>
+    <Component Id="FfiComponent" Directory="INSTALLFOLDER" Guid="*">
+      <File Id="FfiDll"
+            Source="$(var.RustBin)\synology_filestation_ffi.dll"
             KeyPath="yes" />
     </Component>
   </Fragment>

--- a/SynologyFuse.MacInstaller/Build-Installer.sh
+++ b/SynologyFuse.MacInstaller/Build-Installer.sh
@@ -139,10 +139,19 @@ echo "Assembling ${APP_NAME}.app..."
 # Copy all GUI publish output into MacOS/
 cp -R "${GUI_PUBLISH_DIR}/"* "${APP_CONTENTS}/MacOS/"
 
-# Place CLI binary beside the GUI executable so MountService.FindBinary()
-# finds it at the "deployed layout" path without needing PATH.
+# Place CLI binary beside the GUI executable (standalone terminal use).
 cp "${RUST_RELEASE_DIR}/${CLI_BINARY}" "${APP_CONTENTS}/MacOS/"
 chmod +x "${APP_CONTENTS}/MacOS/${CLI_BINARY}"
+
+# The GUI calls the Rust core directly through this native library; the
+# resolver in NativeMethods.cs finds it beside the GUI executable.
+FFI_LIB="libsynology_filestation_ffi.dylib"
+if [[ ! -f "${RUST_RELEASE_DIR}/${FFI_LIB}" ]]; then
+    echo "Error: FFI library not found at '${RUST_RELEASE_DIR}/${FFI_LIB}'." >&2
+    echo "Build it first: cargo build --release -p synology-filestation-ffi" >&2
+    exit 1
+fi
+cp "${RUST_RELEASE_DIR}/${FFI_LIB}" "${APP_CONTENTS}/MacOS/"
 chmod +x "${APP_CONTENTS}/MacOS/${GUI_BINARY}"
 
 # Convert PNG icon to .icns (skipped gracefully if iconutil or PNG unavailable)

--- a/SynologyFuse.Tests/MountServiceTests.cs
+++ b/SynologyFuse.Tests/MountServiceTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using SynologyFuse.Gui.Models;
+using SynologyFuse.Gui.Interop;
 using SynologyFuse.Gui.Services;
 using Xunit;
 
@@ -8,60 +8,6 @@ namespace SynologyFuse.Tests;
 
 public class MountServiceTests
 {
-    // ── StripAnsi ─────────────────────────────────────────────────────────────
-
-    [Fact]
-    public void StripAnsi_PlainText_Unchanged()
-    {
-        Assert.Equal("hello world", MountService.StripAnsi("hello world"));
-    }
-
-    [Fact]
-    public void StripAnsi_RemovesSgrColorCode()
-    {
-        // ESC[32m = green, ESC[0m = reset
-        Assert.Equal("green text", MountService.StripAnsi("\x1b[32mgreen text\x1b[0m"));
-    }
-
-    [Fact]
-    public void StripAnsi_RemovesBoldAndDim()
-    {
-        Assert.Equal("bold", MountService.StripAnsi("\x1b[1mbold\x1b[22m"));
-    }
-
-    [Fact]
-    public void StripAnsi_RemovesMultipleSequences()
-    {
-        var input = "\x1b[1m\x1b[32mIMPORTANT\x1b[0m: message";
-        Assert.Equal("IMPORTANT: message", MountService.StripAnsi(input));
-    }
-
-    [Fact]
-    public void StripAnsi_EmptyString_ReturnsEmpty()
-    {
-        Assert.Equal("", MountService.StripAnsi(""));
-    }
-
-    // ── Quote ─────────────────────────────────────────────────────────────────
-
-    [Fact]
-    public void Quote_NoSpaces_ReturnsOriginal()
-    {
-        Assert.Equal("nas.local", MountService.Quote("nas.local"));
-    }
-
-    [Fact]
-    public void Quote_ContainsSpace_WrapsInDoubleQuotes()
-    {
-        Assert.Equal("\"My NAS\"", MountService.Quote("My NAS"));
-    }
-
-    [Fact]
-    public void Quote_EmptyString_ReturnsEmpty()
-    {
-        Assert.Equal("", MountService.Quote(""));
-    }
-
     // ── ExpandEnvVars ─────────────────────────────────────────────────────────
 
     [Fact]
@@ -146,98 +92,7 @@ public class MountServiceTests
         Assert.Equal("/mnt/nas", MountService.ExpandPath("/mnt/nas"));
     }
 
-    // ── BuildArgs ─────────────────────────────────────────────────────────────
-
-    [Fact]
-    public void BuildArgs_IncludesHostUsernamePortLogLevel()
-    {
-        var config = new MountConfig
-        {
-            Host = "nas.local",
-            Username = "alice",
-            Port = 5001,
-            UseHttps = true,
-            Mountpoint = "/mnt/nas",
-            LogLevel = "info",
-        };
-
-        var args = MountService.BuildArgs(config);
-
-        Assert.Contains("--host nas.local", args);
-        Assert.Contains("--username alice", args);
-        Assert.Contains("--port 5001", args);
-        Assert.Contains("--log-level info", args);
-    }
-
-    [Fact]
-    public void BuildArgs_MountpointIsLastArg()
-    {
-        var config = new MountConfig
-        {
-            Host = "nas.local",
-            Username = "alice",
-            Port = 5001,
-            UseHttps = true,
-            Mountpoint = "/mnt/nas",
-            LogLevel = "info",
-        };
-
-        var args = MountService.BuildArgs(config);
-        Assert.EndsWith("/mnt/nas", args);
-    }
-
-    [Fact]
-    public void BuildArgs_HttpsDisabled_AddsHttpsFalse()
-    {
-        var config = new MountConfig
-        {
-            Host = "nas.local",
-            Username = "alice",
-            Port = 5000,
-            UseHttps = false,
-            Mountpoint = "/mnt/nas",
-            LogLevel = "warn",
-        };
-
-        var args = MountService.BuildArgs(config);
-        Assert.Contains("--https false", args);
-    }
-
-    [Fact]
-    public void BuildArgs_HttpsEnabled_DoesNotAddHttpsFlag()
-    {
-        var config = new MountConfig
-        {
-            Host = "nas.local",
-            Username = "alice",
-            Port = 5001,
-            UseHttps = true,
-            Mountpoint = "/mnt/nas",
-            LogLevel = "info",
-        };
-
-        var args = MountService.BuildArgs(config);
-        Assert.DoesNotContain("--https", args);
-    }
-
-    [Fact]
-    public void BuildArgs_HostWithSpaces_IsQuoted()
-    {
-        var config = new MountConfig
-        {
-            Host = "my nas",
-            Username = "alice",
-            Port = 5001,
-            UseHttps = true,
-            Mountpoint = "/mnt/nas",
-            LogLevel = "info",
-        };
-
-        var args = MountService.BuildArgs(config);
-        Assert.Contains("--host \"my nas\"", args);
-    }
-
-    // ── FindRepoRoot ──────────────────────────────────────────────────────────
+    // ── NativeMethods.FindRepoRoot (native-library resolver) ────────────────────
 
     [Fact]
     public void FindRepoRoot_FindsCargoTomlInParent()
@@ -248,33 +103,12 @@ public class MountServiceTests
         File.WriteAllText(Path.Combine(root, "Cargo.toml"), "[package]");
         try
         {
-            var found = MountService.FindRepoRoot(subDir);
+            var found = NativeMethods.FindRepoRoot(subDir);
             Assert.Equal(root, found);
         }
         finally
         {
             Directory.Delete(root, recursive: true);
-        }
-    }
-
-    [Fact]
-    public void FindRepoRoot_NoCargoToml_ReturnsNull()
-    {
-        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        Directory.CreateDirectory(dir);
-        try
-        {
-            // Temp dir tree won't have Cargo.toml, so result should be null
-            // (unless a Cargo.toml happens to be somewhere above %TEMP% — very unlikely).
-            var found = MountService.FindRepoRoot(dir);
-            // We can't assert null absolutely (unlikely but possible), just that if
-            // found it points to a directory containing Cargo.toml.
-            if (found is not null)
-                Assert.True(File.Exists(Path.Combine(found, "Cargo.toml")));
-        }
-        finally
-        {
-            Directory.Delete(dir, recursive: true);
         }
     }
 
@@ -286,7 +120,7 @@ public class MountServiceTests
         File.WriteAllText(Path.Combine(dir, "Cargo.toml"), "[package]");
         try
         {
-            var found = MountService.FindRepoRoot(dir);
+            var found = NativeMethods.FindRepoRoot(dir);
             Assert.Equal(dir, found);
         }
         finally

--- a/SynologyFuse.Tests/SynoFileInfoTests.cs
+++ b/SynologyFuse.Tests/SynoFileInfoTests.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using SynologyFuse.Gui.Models;
+using Xunit;
+
+namespace SynologyFuse.Tests;
+
+/// <summary>
+/// Verifies the C# side deserializes the flat JSON shape the FFI emits
+/// (<c>fileinfo_json</c> in the Rust crate): keys always present, nulls for
+/// missing metadata.
+/// </summary>
+public class SynoFileInfoTests
+{
+    private static readonly JsonSerializerOptions Opts = new() { PropertyNameCaseInsensitive = true };
+
+    [Fact]
+    public void Deserializes_FullEntry()
+    {
+        const string json = """
+            {"name":"report.pdf","path":"/home/report.pdf","isdir":false,
+             "size":2048,"mtime":1700000000,"atime":1700000001,"ctime":1700000002,"perm":420}
+            """;
+
+        var info = JsonSerializer.Deserialize<SynoFileInfo>(json, Opts)!;
+
+        Assert.Equal("report.pdf", info.Name);
+        Assert.Equal("/home/report.pdf", info.Path);
+        Assert.False(info.IsDir);
+        Assert.Equal(2048UL, info.Size);
+        Assert.Equal(1700000000L, info.Mtime);
+        Assert.Equal(420U, info.Perm);
+    }
+
+    [Fact]
+    public void Deserializes_DirectoryWithNullMetadata()
+    {
+        const string json = """
+            {"name":"home","path":"/home","isdir":true,
+             "size":null,"mtime":null,"atime":null,"ctime":null,"perm":null}
+            """;
+
+        var info = JsonSerializer.Deserialize<SynoFileInfo>(json, Opts)!;
+
+        Assert.Equal("home", info.Name);
+        Assert.True(info.IsDir);
+        Assert.Null(info.Size);
+        Assert.Null(info.Mtime);
+        Assert.Null(info.Perm);
+    }
+
+    [Fact]
+    public void Deserializes_Array()
+    {
+        const string json = """
+            [{"name":"a","path":"/a","isdir":true,"size":null,"mtime":null,"atime":null,"ctime":null,"perm":null},
+             {"name":"b.txt","path":"/b.txt","isdir":false,"size":10,"mtime":null,"atime":null,"ctime":null,"perm":null}]
+            """;
+
+        var items = JsonSerializer.Deserialize<SynoFileInfo[]>(json, Opts)!;
+
+        Assert.Equal(2, items.Length);
+        Assert.True(items[0].IsDir);
+        Assert.Equal(10UL, items[1].Size);
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -106,6 +106,27 @@
             }
           );
 
+          # ── Native FFI library (C ABI consumed by the GUI) ────────────────
+          # Built as a cdylib; crane installs it to $out/lib. The GUI loads it
+          # at runtime via SYNOFS_NATIVE_DIR (see the wrapper below).
+          ffiArgs = commonArgs // {
+            pname = "synology-filestation-ffi";
+            cargoExtraArgs = "--package synology-filestation-ffi";
+          };
+          synology-filestation-ffi = craneLib.buildPackage (
+            ffiArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = false;
+              meta = {
+                description = "C ABI bindings for the Synology FileStation client and mount driver";
+                homepage = "https://github.com/UCSD-E4E/synology-filestation";
+                license = lib.licenses.mit;
+                platforms = lib.platforms.linux ++ lib.platforms.darwin;
+              };
+            }
+          );
+
           # ── .NET 10 GUI (Avalonia) ────────────────────────────────────────
           dotnet = pkgs.dotnetCorePackages.sdk_10_0;
 
@@ -149,12 +170,13 @@
             selfContainedBuild = true;
             runtimeDeps = guiRuntimeDeps;
 
-            # The GUI shells out to the CLI, which MountService.FindBinary()
-            # resolves via PATH (the CLI is a separate derivation, so it is not
-            # beside the GUI binary). Put it on the launcher's PATH so the GUI is
-            # self-sufficient — `nix run .#gui` can mount without the user also
-            # installing synology-filestation-fuse separately.
+            # The GUI calls the Rust core directly through the native FFI
+            # library (no subprocess). The resolver in NativeMethods.cs honours
+            # SYNOFS_NATIVE_DIR, so point it at the cdylib's output dir to make
+            # `nix run .#gui` self-sufficient. The CLI is also placed on PATH for
+            # users who want the standalone terminal tool.
             makeWrapperArgs = [
+              "--set SYNOFS_NATIVE_DIR ${synology-filestation-ffi}/lib"
               "--prefix PATH : ${lib.makeBinPath [ synology-filestation-fuse ]}"
             ];
 
@@ -169,7 +191,7 @@
         in
         {
           packages = {
-            inherit synology-filestation-fuse synologyfuse-gui;
+            inherit synology-filestation-fuse synology-filestation-ffi synologyfuse-gui;
             default = synology-filestation-fuse;
           };
 
@@ -184,13 +206,15 @@
           };
 
           checks = {
-            inherit synology-filestation-fuse synologyfuse-gui;
+            inherit synology-filestation-fuse synology-filestation-ffi synologyfuse-gui;
 
             clippy = craneLib.cargoClippy (
               commonArgs
               // {
                 inherit cargoArtifacts;
-                cargoClippyExtraArgs = "--all-targets -- -D warnings";
+                # Lint the FFI crate alongside the CLI + core.
+                cargoClippyExtraArgs =
+                  "--package synology-filestation-fuse --package synology-filestation-ffi --all-targets -- -D warnings";
               }
             );
 

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,18 +1,13 @@
 [
   {
     "pname": "Avalonia",
-    "version": "11.2.3",
-    "hash": "sha256-NUoyXJkIsgbkcKFVb10VRafM4ViHs801c/7vhu3ssUY="
-  },
-  {
-    "pname": "Avalonia",
     "version": "12.0.2",
     "hash": "sha256-Ht2h4cBtnVhrk9VWsHDOEvU1wd/y80CxMDWn8W0lHKk="
   },
   {
     "pname": "Avalonia.Angle.Windows.Natives",
-    "version": "2.1.22045.20230930",
-    "hash": "sha256-RxPcWUT3b/+R3Tu5E5ftpr5ppCLZrhm+OTsi0SwW3pc="
+    "version": "2.1.25547.20250602",
+    "hash": "sha256-LE/lENAHptmz6t3T/AoJwnhpda+xs7PqriNGzdcfg8M="
   },
   {
     "pname": "Avalonia.BuildServices",
@@ -21,23 +16,33 @@
   },
   {
     "pname": "Avalonia.Desktop",
-    "version": "11.2.3",
-    "hash": "sha256-srtZi+kDbhRtMl33l91zssBWETU5oHodKbbWyfEsb/I="
+    "version": "12.0.2",
+    "hash": "sha256-ydFDRX0zTEtJJzjn+TTpcSYL49xBJ3vFi9v3NSOyPww="
   },
   {
     "pname": "Avalonia.Fonts.Inter",
-    "version": "11.2.3",
-    "hash": "sha256-ySsCXVpjqjCX/uYkwluSfrAoBtuq9k7fC1bFjxKC9/Q="
+    "version": "12.0.2",
+    "hash": "sha256-23iKfc71xCy+vaHlxSRi19ZsJ48Dey6mdOx9CGzg2SA="
   },
   {
     "pname": "Avalonia.FreeDesktop",
-    "version": "11.2.3",
-    "hash": "sha256-3sNemBmZE06w2ul87T5HrEeHUxXMOa9MfQhpI4AoxDY="
+    "version": "12.0.2",
+    "hash": "sha256-raEQGX8Vwr+c7W5SzkEZ/phEEs/a5N0xeUfAWKEpl6A="
+  },
+  {
+    "pname": "Avalonia.FreeDesktop.AtSpi",
+    "version": "12.0.2",
+    "hash": "sha256-5AQPlWW6g7G6pm7qI8RHR/MQ45VGd7iAFWseXUitIVI="
+  },
+  {
+    "pname": "Avalonia.HarfBuzz",
+    "version": "12.0.2",
+    "hash": "sha256-FUYKVfweWiFix+LJZt9scI7HYiIl3C+8j9K0/yKsOIE="
   },
   {
     "pname": "Avalonia.Native",
-    "version": "11.2.3",
-    "hash": "sha256-2Gp98NGWcrILqF+P5PDMPRdsMby/lZiT3eWAUskFim8="
+    "version": "12.0.2",
+    "hash": "sha256-E1uQvsvnVBIyzAyV3803LXMpitPvaoJezCedz6ZeV1A="
   },
   {
     "pname": "Avalonia.Remote.Protocol",
@@ -46,8 +51,8 @@
   },
   {
     "pname": "Avalonia.Skia",
-    "version": "11.2.3",
-    "hash": "sha256-QBp8wTA92hGwbmNSVL4gsjrqA9CfwDPgdTiOEqcogGA="
+    "version": "12.0.2",
+    "hash": "sha256-ZzNoO/8/SYG4xN0RmPz9AC6N1RtPTnSaTVrQ0+NNvGU="
   },
   {
     "pname": "Avalonia.Themes.Fluent",
@@ -56,13 +61,13 @@
   },
   {
     "pname": "Avalonia.Win32",
-    "version": "11.2.3",
-    "hash": "sha256-xKFKObvqdJaQjphEktRJvzmAoDEsKg3WqlEG31V3qLE="
+    "version": "12.0.2",
+    "hash": "sha256-yHcePPF2tKc9oussntmAr/4LX3FEkGRRFuzdmlE+NHQ="
   },
   {
     "pname": "Avalonia.X11",
-    "version": "11.2.3",
-    "hash": "sha256-SD4dmpKx4l8YOyUnrA0fnf2Bb+tHSNyARh7GAtHyg60="
+    "version": "12.0.2",
+    "hash": "sha256-not3Qv87nbN6Bi8sE49WKDSNzUTISBdcNR3rcFqgwHE="
   },
   {
     "pname": "CommunityToolkit.Mvvm",
@@ -71,28 +76,28 @@
   },
   {
     "pname": "HarfBuzzSharp",
-    "version": "7.3.0.3",
-    "hash": "sha256-1vDIcG1aVwVABOfzV09eAAbZLFJqibip9LaIx5k+JxM="
+    "version": "8.3.1.3",
+    "hash": "sha256-/+ZEhjpOs8B4tMPw3vDyuQqGGZHJEWvy3WaKMaDwmrU="
   },
   {
     "pname": "HarfBuzzSharp.NativeAssets.Linux",
-    "version": "7.3.0.3",
-    "hash": "sha256-HW5r16wdlgDMbE/IfE5AQGDVFJ6TS6oipldfMztx+LM="
+    "version": "8.3.1.3",
+    "hash": "sha256-feWOna/8ncvmrq7CxnDczv1facV2poZV5R+OyCtocpU="
   },
   {
     "pname": "HarfBuzzSharp.NativeAssets.macOS",
-    "version": "7.3.0.3",
-    "hash": "sha256-UpAVfRIYY8Wh8xD4wFjrXHiJcvlBLuc2Xdm15RwQ76w="
+    "version": "8.3.1.3",
+    "hash": "sha256-6WKsJ/jF9pHnaWcQvaezc5AV6flu3XsOxQs7i4BGYJs="
   },
   {
     "pname": "HarfBuzzSharp.NativeAssets.WebAssembly",
-    "version": "7.3.0.3",
-    "hash": "sha256-jHrU70rOADAcsVfVfozU33t/5B5Tk0CurRTf4fVQe3I="
+    "version": "8.3.1.3",
+    "hash": "sha256-arBiI82fXPjAqftqnG7Wc3BRzZ6+vKd7b58vQSWJVk0="
   },
   {
     "pname": "HarfBuzzSharp.NativeAssets.Win32",
-    "version": "7.3.0.3",
-    "hash": "sha256-v/PeEfleJcx9tsEQAo5+7Q0XPNgBqiSLNnB2nnAGp+I="
+    "version": "8.3.1.3",
+    "hash": "sha256-WNUQmLWVFSwBKT9x7UdhSz9T2FA7wibvwjuPew/3yUM="
   },
   {
     "pname": "MicroCom.Runtime",
@@ -126,33 +131,33 @@
   },
   {
     "pname": "SkiaSharp",
-    "version": "2.88.9",
-    "hash": "sha256-jZ/4nVXYJtrz9SBf6sYc/s0FxS7ReIYM4kMkrhZS+24="
+    "version": "3.119.4-preview.1.1",
+    "hash": "sha256-yUHsoau6WVQkzYV5UVnKcgpABiapa9aoTDd1pw/J5r8="
   },
   {
     "pname": "SkiaSharp.NativeAssets.Linux",
-    "version": "2.88.9",
-    "hash": "sha256-mQ/oBaqRR71WfS66mJCvcc3uKW7CNEHoPN2JilDbw/A="
+    "version": "3.119.4-preview.1.1",
+    "hash": "sha256-jcf0FhUgOzxpJ4ENn1q5uPe8dT+kXl0/yUWJs+hDYNA="
   },
   {
     "pname": "SkiaSharp.NativeAssets.macOS",
-    "version": "2.88.9",
-    "hash": "sha256-qvGuAmjXGjGKMzOPBvP9VWRVOICSGb7aNVejU0lLe/g="
+    "version": "3.119.4-preview.1.1",
+    "hash": "sha256-olbqFOHmkiCdlnXHU4l1lTb04yAPn21CvLNMP4AGncs="
   },
   {
     "pname": "SkiaSharp.NativeAssets.WebAssembly",
-    "version": "2.88.9",
-    "hash": "sha256-vgFL4Pdy3O1RKBp+T9N3W4nkH9yurZ0suo8u3gPmmhY="
+    "version": "3.119.4-preview.1.1",
+    "hash": "sha256-R+67ADA6luDa9b7xvsE4PSL6GWwQTaNYzw2WYou/ofQ="
   },
   {
     "pname": "SkiaSharp.NativeAssets.Win32",
-    "version": "2.88.9",
-    "hash": "sha256-kP5XM5GgwHGfNJfe4T2yO5NIZtiF71Ddp0pd1vG5V/4="
+    "version": "3.119.4-preview.1.1",
+    "hash": "sha256-Sd+KnMezIKbc4OLklHsfeM7EVZERtmawWuSCoaySteM="
   },
   {
     "pname": "Tmds.DBus.Protocol",
-    "version": "0.20.0",
-    "hash": "sha256-CRW/tkgsuBiBJfRwou12ozRQsWhHDooeP88E5wWpWJw="
+    "version": "0.92.0",
+    "hash": "sha256-WZSB9eqSOIzsBfnpOJDIIopIhNxAH+UcZuD6W94PIN4="
   },
   {
     "pname": "xunit",

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,13 +1,13 @@
 [
   {
     "pname": "Avalonia",
-    "version": "12.0.2",
-    "hash": "sha256-Ht2h4cBtnVhrk9VWsHDOEvU1wd/y80CxMDWn8W0lHKk="
+    "version": "12.0.4",
+    "hash": "sha256-sHu0eifno4DJ0Tnl3v4e3OZY1oy41OO482UfKVkQfK0="
   },
   {
     "pname": "Avalonia.Angle.Windows.Natives",
-    "version": "2.1.25547.20250602",
-    "hash": "sha256-LE/lENAHptmz6t3T/AoJwnhpda+xs7PqriNGzdcfg8M="
+    "version": "2.1.27548.20260419",
+    "hash": "sha256-dtZ5AQl+kXPRVe/EwrfSyOMSLywuBBUCjrDIhHijhvk="
   },
   {
     "pname": "Avalonia.BuildServices",
@@ -16,58 +16,58 @@
   },
   {
     "pname": "Avalonia.Desktop",
-    "version": "12.0.2",
-    "hash": "sha256-ydFDRX0zTEtJJzjn+TTpcSYL49xBJ3vFi9v3NSOyPww="
+    "version": "12.0.4",
+    "hash": "sha256-6FeeNofcrLVgMyxT8j37CxVNUHIe1BfDIeAES1SChBA="
   },
   {
     "pname": "Avalonia.Fonts.Inter",
-    "version": "12.0.2",
-    "hash": "sha256-23iKfc71xCy+vaHlxSRi19ZsJ48Dey6mdOx9CGzg2SA="
+    "version": "12.0.4",
+    "hash": "sha256-h0Nlzl9gpvt2z24lsJBD7l56ceCcZfOQKSzGOARgNV8="
   },
   {
     "pname": "Avalonia.FreeDesktop",
-    "version": "12.0.2",
-    "hash": "sha256-raEQGX8Vwr+c7W5SzkEZ/phEEs/a5N0xeUfAWKEpl6A="
+    "version": "12.0.4",
+    "hash": "sha256-mj1icR/oMR4b6AygR3/ycq39DMuEpXHPy/fWeuwLYs8="
   },
   {
     "pname": "Avalonia.FreeDesktop.AtSpi",
-    "version": "12.0.2",
-    "hash": "sha256-5AQPlWW6g7G6pm7qI8RHR/MQ45VGd7iAFWseXUitIVI="
+    "version": "12.0.4",
+    "hash": "sha256-FgfModA3bLccR6HM91A/+0198SR4NWg8zZIA3EE4wW8="
   },
   {
     "pname": "Avalonia.HarfBuzz",
-    "version": "12.0.2",
-    "hash": "sha256-FUYKVfweWiFix+LJZt9scI7HYiIl3C+8j9K0/yKsOIE="
+    "version": "12.0.4",
+    "hash": "sha256-tpTETc9r5b0CtXiYZEVgV57Tubqh3BS22+oq/ZU4YRQ="
   },
   {
     "pname": "Avalonia.Native",
-    "version": "12.0.2",
-    "hash": "sha256-E1uQvsvnVBIyzAyV3803LXMpitPvaoJezCedz6ZeV1A="
+    "version": "12.0.4",
+    "hash": "sha256-MzirvFnZFV3qddBUgEDzf8TwbmIrH3tWujUWKOdXAzc="
   },
   {
     "pname": "Avalonia.Remote.Protocol",
-    "version": "12.0.2",
-    "hash": "sha256-19hc0GSsa9JujiZlHxLKn7x6fUjAeJSH3lO43hL0bD0="
+    "version": "12.0.4",
+    "hash": "sha256-uuc61RM/WBfRmWCcBkoenLCreOxEGcF8U4t8RptrxiE="
   },
   {
     "pname": "Avalonia.Skia",
-    "version": "12.0.2",
-    "hash": "sha256-ZzNoO/8/SYG4xN0RmPz9AC6N1RtPTnSaTVrQ0+NNvGU="
+    "version": "12.0.4",
+    "hash": "sha256-ba80KHyzW0NdoDK3iPntbi3NKEnh2c1rbrv4mu2xWcI="
   },
   {
     "pname": "Avalonia.Themes.Fluent",
-    "version": "12.0.2",
-    "hash": "sha256-H8AXau1gV8m33lKYrSzxp0GDmoCuyx7+B93gTfcpXXU="
+    "version": "12.0.4",
+    "hash": "sha256-8b0+L0zU8J0csMkuRzeebsU/BENxD0iP2y5rSRmeMMk="
   },
   {
     "pname": "Avalonia.Win32",
-    "version": "12.0.2",
-    "hash": "sha256-yHcePPF2tKc9oussntmAr/4LX3FEkGRRFuzdmlE+NHQ="
+    "version": "12.0.4",
+    "hash": "sha256-ZP1+man3HnJDh9vdEQBfa1W94t56BRkQ2feWqVJBm34="
   },
   {
     "pname": "Avalonia.X11",
-    "version": "12.0.2",
-    "hash": "sha256-not3Qv87nbN6Bi8sE49WKDSNzUTISBdcNR3rcFqgwHE="
+    "version": "12.0.4",
+    "hash": "sha256-r6cV/4kqiZ6lBNgN2HrYagG41JFZrOe7GZzbSelBT2g="
   },
   {
     "pname": "CommunityToolkit.Mvvm",
@@ -131,28 +131,28 @@
   },
   {
     "pname": "SkiaSharp",
-    "version": "3.119.4-preview.1.1",
-    "hash": "sha256-yUHsoau6WVQkzYV5UVnKcgpABiapa9aoTDd1pw/J5r8="
+    "version": "3.119.4",
+    "hash": "sha256-4ypEnTGUXAudFp61vGduHj9YmqtpiI5J1wP9wcOEwXY="
   },
   {
     "pname": "SkiaSharp.NativeAssets.Linux",
-    "version": "3.119.4-preview.1.1",
-    "hash": "sha256-jcf0FhUgOzxpJ4ENn1q5uPe8dT+kXl0/yUWJs+hDYNA="
+    "version": "3.119.4",
+    "hash": "sha256-+uBVQFmxEH73iI5GwgvftUhAHvenpvc5GtT63HQy1Qo="
   },
   {
     "pname": "SkiaSharp.NativeAssets.macOS",
-    "version": "3.119.4-preview.1.1",
-    "hash": "sha256-olbqFOHmkiCdlnXHU4l1lTb04yAPn21CvLNMP4AGncs="
+    "version": "3.119.4",
+    "hash": "sha256-9/L1Oc5bujN6pKjW6sJcr1jL3RLt8/Mt3MmClOcwzyw="
   },
   {
     "pname": "SkiaSharp.NativeAssets.WebAssembly",
-    "version": "3.119.4-preview.1.1",
-    "hash": "sha256-R+67ADA6luDa9b7xvsE4PSL6GWwQTaNYzw2WYou/ofQ="
+    "version": "3.119.4",
+    "hash": "sha256-xLfsWBsFFpv5Qg79GIMi+5CM6YDfcg//oywNlB5Y3J0="
   },
   {
     "pname": "SkiaSharp.NativeAssets.Win32",
-    "version": "3.119.4-preview.1.1",
-    "hash": "sha256-Sd+KnMezIKbc4OLklHsfeM7EVZERtmawWuSCoaySteM="
+    "version": "3.119.4",
+    "hash": "sha256-WlaYsbTh/cn/6YaN9odNtfpp8hpN52unGgGlQum0M5E="
   },
   {
     "pname": "Tmds.DBus.Protocol",

--- a/python/synology_filestation/src/lib.rs
+++ b/python/synology_filestation/src/lib.rs
@@ -7,7 +7,7 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
-use synology_filestation_core::error::SynoFsError;
+use synology_filestation_core::error::{dsm_code_to_category, ErrorCategory, SynoFsError};
 use synology_filestation_core::types::SynoFileInfo;
 use synology_filestation_core::SynologyClient;
 use tokio::runtime::Runtime;
@@ -133,15 +133,22 @@ fn synofs_to_pyerr(py: Python<'_>, err: SynoFsError) -> PyErr {
             (py.get_type::<AuthError>().into_any(), inner_code)
         }
         SynoFsError::ApiError(c) => {
-            let cls = match *c {
-                119 => py.get_type::<SidNotFound>().into_any(),
-                400 => py.get_type::<InvalidArg>().into_any(),
-                403 | 414 | 415 => py.get_type::<NoSuchFile>().into_any(),
-                408 | 1805 => py.get_type::<PermissionDenied>().into_any(),
-                416 => py.get_type::<NotEmpty>().into_any(),
-                418 | 1101 => py.get_type::<AlreadyExists>().into_any(),
-                419 | 1804 => py.get_type::<NoSpace>().into_any(),
-                _ => py.get_type::<DSMError>().into_any(),
+            // Classify via the core's shared category table so the Python
+            // exceptions and the FFI status codes agree on every DSM code.
+            let cls = match dsm_code_to_category(*c) {
+                ErrorCategory::SidExpired => py.get_type::<SidNotFound>().into_any(),
+                ErrorCategory::InvalidArg => py.get_type::<InvalidArg>().into_any(),
+                ErrorCategory::NotFound => py.get_type::<NoSuchFile>().into_any(),
+                ErrorCategory::PermissionDenied => py.get_type::<PermissionDenied>().into_any(),
+                ErrorCategory::NotEmpty => py.get_type::<NotEmpty>().into_any(),
+                ErrorCategory::AlreadyExists => py.get_type::<AlreadyExists>().into_any(),
+                ErrorCategory::NoSpace => py.get_type::<NoSpace>().into_any(),
+                ErrorCategory::NotSupported => py.get_type::<NotSupported>().into_any(),
+                // Busy (402) and any unmapped code stay a generic DSMError, as
+                // before; Transport never originates from an ApiError code.
+                ErrorCategory::Busy | ErrorCategory::Transport | ErrorCategory::Other => {
+                    py.get_type::<DSMError>().into_any()
+                }
             };
             (cls, Some(*c))
         }

--- a/rust/synology-filestation-core/src/error.rs
+++ b/rust/synology-filestation-core/src/error.rs
@@ -21,49 +21,87 @@ pub enum SynoFsError {
     LoginFailed(Box<SynoFsError>),
 }
 
+/// Platform-agnostic classification of a Synology error. This is the **single
+/// source of truth** every binding derives from: the FUSE errno map (below),
+/// the FFI status codes (`synology-filestation-ffi`), and the PyO3 exception
+/// hierarchy (`python/synology_filestation`) all map *from* `ErrorCategory`, so
+/// a DSM code lands in the same place across all three.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCategory {
+    NotFound,
+    PermissionDenied,
+    AlreadyExists,
+    NotEmpty,
+    InvalidArg,
+    NoSpace,
+    NotSupported,
+    /// DSM session id expired or unknown (code 119).
+    SidExpired,
+    /// System too busy / try again (code 402).
+    Busy,
+    /// Network/transport/parse failure with no DSM code.
+    Transport,
+    /// A DSM code with no more specific mapping.
+    Other,
+}
+
+/// Canonical map from a raw DSM/FileStation API error code to a category.
+pub fn dsm_code_to_category(code: u32) -> ErrorCategory {
+    match code {
+        400 => ErrorCategory::InvalidArg,              // Invalid parameter
+        402 => ErrorCategory::Busy,                    // System too busy
+        403 | 414 | 415 => ErrorCategory::NotFound,    // Invalid path / no such file or folder
+        408 | 1805 => ErrorCategory::PermissionDenied, // No permission (list / upload)
+        416 => ErrorCategory::NotEmpty,                // Directory not empty
+        418 | 1101 => ErrorCategory::AlreadyExists,    // Already exists (entry / folder)
+        419 | 1804 => ErrorCategory::NoSpace,          // Not enough quota
+        119 => ErrorCategory::SidExpired, // Session id expired / insufficient privilege
+        // 401 (unknown), 404 (indexing disabled), 1100 (create failed),
+        // 1800 (upload failed), and anything unrecognised fall through.
+        _ => ErrorCategory::Other,
+    }
+}
+
 impl SynoFsError {
+    /// The platform-agnostic [`ErrorCategory`] of this error.
+    pub fn category(&self) -> ErrorCategory {
+        match self {
+            Self::NotFound => ErrorCategory::NotFound,
+            Self::PermissionDenied => ErrorCategory::PermissionDenied,
+            Self::AlreadyExists => ErrorCategory::AlreadyExists,
+            Self::NotEmpty => ErrorCategory::NotEmpty,
+            Self::InvalidArg => ErrorCategory::InvalidArg,
+            Self::NoSpace => ErrorCategory::NoSpace,
+            Self::NotSupported => ErrorCategory::NotSupported,
+            Self::Io(_) => ErrorCategory::Transport,
+            Self::ApiError(code) => dsm_code_to_category(*code),
+            Self::LoginFailed(inner) => inner.category(),
+        }
+    }
+
     #[cfg(target_os = "linux")]
     pub fn to_errno(&self) -> i32 {
-        match self {
-            Self::NotFound => ENOENT,
-            Self::PermissionDenied => EACCES,
-            Self::AlreadyExists => EEXIST,
-            Self::NotEmpty => ENOTEMPTY,
-            Self::InvalidArg => EINVAL,
-            Self::NoSpace => ENOSPC,
-            Self::NotSupported => ENOSYS,
-            Self::Io(_) => EIO,
-            Self::ApiError(code) => syno_code_to_errno(*code),
-            Self::LoginFailed(_) => EACCES,
+        // A failed (re)login is always a permission/auth problem to the kernel,
+        // regardless of the inner DSM code.
+        if matches!(self, Self::LoginFailed(_)) {
+            return EACCES;
         }
+        category_to_errno(self.category())
     }
 }
 
 #[cfg(target_os = "linux")]
-fn syno_code_to_errno(code: u32) -> i32 {
-    match code {
-        // Common FileStation errors
-        400 => EINVAL,    // Invalid parameter
-        401 => EIO,       // Unknown error
-        402 => EAGAIN,    // System too busy
-        403 => ENOENT,    // Invalid path
-        404 => EIO,       // File indexing disabled
-        408 => EACCES,    // No permission
-        414 => ENOENT,    // No such file
-        415 => ENOENT,    // No such folder
-        416 => ENOTEMPTY, // Directory not empty
-        418 => EEXIST,    // Already exists
-        419 => ENOSPC,    // Not enough quota
-        // CreateFolder-specific errors
-        1100 => EIO,    // Failed to create folder
-        1101 => EEXIST, // Folder already exists
-        // Generic session/privilege errors
-        119 => EACCES, // Insufficient privilege / session does not have write access
-        // Upload-specific errors
-        1800 => EIO,    // Upload failed
-        1804 => ENOSPC, // Not enough quota
-        1805 => EACCES, // No permission to upload
-        _ => EIO,
+fn category_to_errno(category: ErrorCategory) -> i32 {
+    match category {
+        ErrorCategory::NotFound => ENOENT,
+        ErrorCategory::PermissionDenied | ErrorCategory::SidExpired => EACCES,
+        ErrorCategory::AlreadyExists => EEXIST,
+        ErrorCategory::NotEmpty => ENOTEMPTY,
+        ErrorCategory::InvalidArg => EINVAL,
+        ErrorCategory::NoSpace => ENOSPC,
+        ErrorCategory::NotSupported => ENOSYS,
+        ErrorCategory::Busy => EAGAIN,
+        ErrorCategory::Transport | ErrorCategory::Other => EIO,
     }
 }
 
@@ -121,6 +159,29 @@ mod display_tests {
         assert_eq!(
             SynoFsError::ApiError(408).to_string(),
             "Synology API error 408"
+        );
+    }
+
+    #[test]
+    fn dsm_codes_map_to_expected_categories() {
+        // The single source of truth shared by errno / FFI / PyO3. 119 in
+        // particular must be SidExpired so all three bindings agree.
+        assert_eq!(dsm_code_to_category(119), ErrorCategory::SidExpired);
+        assert_eq!(dsm_code_to_category(400), ErrorCategory::InvalidArg);
+        assert_eq!(dsm_code_to_category(402), ErrorCategory::Busy);
+        assert_eq!(dsm_code_to_category(403), ErrorCategory::NotFound);
+        assert_eq!(dsm_code_to_category(408), ErrorCategory::PermissionDenied);
+        assert_eq!(dsm_code_to_category(416), ErrorCategory::NotEmpty);
+        assert_eq!(dsm_code_to_category(418), ErrorCategory::AlreadyExists);
+        assert_eq!(dsm_code_to_category(419), ErrorCategory::NoSpace);
+        assert_eq!(dsm_code_to_category(9999), ErrorCategory::Other);
+        assert_eq!(
+            SynoFsError::ApiError(119).category(),
+            ErrorCategory::SidExpired
+        );
+        assert_eq!(
+            SynoFsError::NotSupported.category(),
+            ErrorCategory::NotSupported
         );
     }
 

--- a/rust/synology-filestation-ffi/Cargo.toml
+++ b/rust/synology-filestation-ffi/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "synology-filestation-ffi"
+version = "0.1.19"
+edition = "2021"
+license = "MIT"
+description = "C ABI bindings for the Synology FileStation client and mount driver (consumed by the desktop GUI)."
+repository = "https://github.com/UCSD-E4E/synology-filestation"
+
+[lib]
+name = "synology_filestation_ffi"
+crate-type = ["cdylib"]
+
+[dependencies]
+synology-filestation-core = { path = "../synology-filestation-core", version = "0.1.19" }
+synology-filestation-fuse = { path = "../synology-filestation-fuse", version = "0.1.19" }
+
+tokio       = { version = "1", features = ["rt", "rt-multi-thread"] }
+serde_json  = "1"
+tracing     = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
+
+[dev-dependencies]
+tokio    = { version = "1", features = ["full"] }
+wiremock = "0.6"

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -522,7 +522,10 @@ pub unsafe extern "C" fn syno_download_to(
                 file.write_all(&bytes)
                     .map_err(|e| SynoFsError::Io(format!("write {}: {e}", part.display())))?;
                 offset += bytes.len() as u64;
-                report(progress, user_data, offset, total.max(offset));
+                // Report `total` as-is: 0 means "unknown" (the documented
+                // contract). Using total.max(offset) would make an unknown-size
+                // transfer report done == total every chunk, i.e. always 100%.
+                report(progress, user_data, offset, total);
                 // Stop at EOF: a short final chunk, or — when the size is known
                 // and is an exact multiple of the chunk — having read it all
                 // (avoids a spurious past-EOF range request).

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -1,0 +1,958 @@
+//! C ABI bindings for the Synology FileStation client and mount driver.
+//!
+//! Consumed by the desktop GUI via P/Invoke. The design mirrors the PyO3
+//! binding ([`python/synology_filestation`]): an opaque [`SynoClient`] wraps an
+//! `Arc<SynologyClient>` plus a per-client Tokio runtime, and every blocking
+//! call funnels through `runtime.block_on`. Errors are reported through a
+//! [`SynoError`] out-param carrying a typed `kind`, the raw DSM code, and a
+//! human-readable message; the `kind`/`dsm_code` classification mirrors the
+//! PyO3 exception mapping so both bindings agree.
+//!
+//! Every exported function wraps its body in `catch_unwind`: a panic in the
+//! Rust core (or, for the mount, the WinFsp worker thread) is converted to a
+//! `Panic` status rather than unwinding across the FFI boundary (UB).
+
+use std::ffi::{c_void, CStr, CString};
+use std::os::raw::c_char;
+use std::panic::AssertUnwindSafe;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use synology_filestation_core::client::SynologyClient;
+use synology_filestation_core::error::SynoFsError;
+use synology_filestation_core::types::SynoFileInfo;
+use synology_filestation_fuse::{is_otp_required, spawn_mount, MountOptions};
+use tokio::runtime::Runtime;
+
+mod logging;
+
+const DOWNLOAD_CHUNK: u64 = 4 * 1024 * 1024;
+
+// ─── Status / error reporting ────────────────────────────────────────────────
+
+/// Status codes returned by every fallible export. `Ok` is 0; the rest mirror
+/// the `SynoFsError` variants, plus a few FFI-specific cases.
+#[repr(i32)]
+#[derive(Clone, Copy)]
+pub enum SynoStatus {
+    Ok = 0,
+    NotFound = 1,
+    PermissionDenied = 2,
+    AlreadyExists = 3,
+    NotEmpty = 4,
+    InvalidArg = 5,
+    NoSpace = 6,
+    NotSupported = 7,
+    Io = 8,
+    Api = 9,
+    LoginFailed = 10,
+    /// Login needs a 2FA / OTP code — the GUI should prompt and retry connect.
+    OtpRequired = 11,
+    /// A required pointer argument was null.
+    NullArg = 12,
+    /// A panic was caught at the FFI boundary.
+    Panic = 13,
+}
+
+/// Out-param filled on error. `message` is a heap UTF-8 C string owned by the
+/// caller; free it with [`syno_string_free`]. `dsm_code` is the raw Synology
+/// API code when applicable, else 0.
+#[repr(C)]
+pub struct SynoError {
+    pub kind: i32,
+    pub dsm_code: u32,
+    pub message: *mut c_char,
+}
+
+/// Map a core error to (typed status, raw DSM code). Mirrors the PyO3
+/// `synofs_to_pyerr` routing so the GUI sees the same classes the Python
+/// bindings expose.
+fn classify(err: &SynoFsError) -> (SynoStatus, u32) {
+    use SynoStatus as S;
+    match err {
+        SynoFsError::NotFound => (S::NotFound, 0),
+        SynoFsError::PermissionDenied => (S::PermissionDenied, 0),
+        SynoFsError::AlreadyExists => (S::AlreadyExists, 0),
+        SynoFsError::NotEmpty => (S::NotEmpty, 0),
+        SynoFsError::InvalidArg => (S::InvalidArg, 0),
+        SynoFsError::NoSpace => (S::NoSpace, 0),
+        SynoFsError::NotSupported => (S::NotSupported, 0),
+        SynoFsError::Io(_) => (S::Io, 0),
+        SynoFsError::LoginFailed(inner) => {
+            let code = match inner.as_ref() {
+                SynoFsError::ApiError(c) => *c,
+                _ => 0,
+            };
+            (S::LoginFailed, code)
+        }
+        SynoFsError::ApiError(c) => {
+            let s = match *c {
+                400 => S::InvalidArg,
+                403 | 414 | 415 => S::NotFound,
+                408 | 1805 => S::PermissionDenied,
+                416 => S::NotEmpty,
+                418 | 1101 => S::AlreadyExists,
+                419 | 1804 => S::NoSpace,
+                _ => S::Api,
+            };
+            (s, *c)
+        }
+    }
+}
+
+/// Write a status + message into `*err` (if non-null) and return the status as
+/// an `i32`. Always returns the numeric status so callers can `return set_err(…)`.
+unsafe fn set_err(err: *mut SynoError, status: SynoStatus, dsm: u32, message: &str) -> i32 {
+    if !err.is_null() {
+        let msg = CString::new(message).unwrap_or_default().into_raw();
+        (*err).kind = status as i32;
+        (*err).dsm_code = dsm;
+        (*err).message = msg;
+    }
+    status as i32
+}
+
+unsafe fn set_core_err(err: *mut SynoError, e: &SynoFsError) -> i32 {
+    let (status, dsm) = classify(e);
+    set_err(err, status, dsm, &e.to_string())
+}
+
+/// Run `f`, converting any panic into a `Panic` status written to `err`.
+fn guard<F: FnOnce() -> i32>(err: *mut SynoError, f: F) -> i32 {
+    match std::panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(code) => code,
+        Err(_) => unsafe { set_err(err, SynoStatus::Panic, 0, "panic in native code") },
+    }
+}
+
+/// Borrow a required C string; returns `Err(status)` (already written to `err`)
+/// when null or non-UTF-8.
+unsafe fn req_str<'a>(p: *const c_char, name: &str, err: *mut SynoError) -> Result<&'a str, i32> {
+    if p.is_null() {
+        return Err(set_err(
+            err,
+            SynoStatus::NullArg,
+            0,
+            &format!("`{name}` must not be null"),
+        ));
+    }
+    CStr::from_ptr(p).to_str().map_err(|_| {
+        set_err(
+            err,
+            SynoStatus::InvalidArg,
+            0,
+            &format!("`{name}` is not UTF-8"),
+        )
+    })
+}
+
+/// Borrow an optional C string (null → `None`).
+unsafe fn opt_str<'a>(p: *const c_char) -> Option<&'a str> {
+    if p.is_null() {
+        None
+    } else {
+        CStr::from_ptr(p).to_str().ok()
+    }
+}
+
+// ─── JSON marshalling of file info ───────────────────────────────────────────
+
+/// Flatten a `SynoFileInfo` into a stable, documented JSON shape. Keys are
+/// always present (null when absent) so the C# side can deserialize into a
+/// fixed record. Mirrors the PyO3 `fileinfo_to_pydict` contract.
+fn fileinfo_json(info: &SynoFileInfo) -> serde_json::Value {
+    let (size, mtime, atime, ctime, perm) = match &info.additional {
+        Some(a) => (
+            a.size,
+            a.time.as_ref().map(|t| t.mtime),
+            a.time.as_ref().map(|t| t.atime),
+            a.time.as_ref().map(|t| t.ctime),
+            a.perm.as_ref().map(|p| p.posix),
+        ),
+        None => (None, None, None, None, None),
+    };
+    serde_json::json!({
+        "name": info.name,
+        "path": info.path,
+        "isdir": info.isdir,
+        "size": size,
+        "mtime": mtime,
+        "atime": atime,
+        "ctime": ctime,
+        "perm": perm,
+    })
+}
+
+unsafe fn emit_json(out: *mut *mut c_char, value: &serde_json::Value, err: *mut SynoError) -> i32 {
+    if out.is_null() {
+        return set_err(
+            err,
+            SynoStatus::NullArg,
+            0,
+            "output pointer must not be null",
+        );
+    }
+    match CString::new(value.to_string()) {
+        Ok(s) => {
+            *out = s.into_raw();
+            SynoStatus::Ok as i32
+        }
+        Err(_) => set_err(
+            err,
+            SynoStatus::Io,
+            0,
+            "result contained an interior NUL byte",
+        ),
+    }
+}
+
+// ─── Opaque handles ──────────────────────────────────────────────────────────
+
+/// Opaque authenticated client handle.
+pub struct SynoClient {
+    inner: Arc<SynologyClient>,
+    runtime: Arc<Runtime>,
+}
+
+/// Opaque live-mount handle.
+pub struct SynoMount {
+    handle: Option<synology_filestation_fuse::MountHandle>,
+    // Keeps the runtime alive for the duration of the mount (the FUSE/WinFsp
+    // callbacks block on it). Dropped after the mount is torn down.
+    _runtime: Arc<Runtime>,
+}
+
+// ─── Connect / session lifecycle ─────────────────────────────────────────────
+
+/// Log in and return an opaque client handle in `*out`.
+///
+/// Returns [`SynoStatus::OtpRequired`] (no client created) when the account
+/// needs a 2FA code; the caller should prompt and call again with `otp` set.
+///
+/// # Safety
+/// All string args must be valid NUL-terminated UTF-8 or null where optional.
+#[no_mangle]
+pub unsafe extern "C" fn syno_connect(
+    host: *const c_char,
+    port: u16,
+    https: bool,
+    username: *const c_char,
+    password: *const c_char,
+    otp: *const c_char,
+    auto_relogin: bool,
+    out: *mut *mut SynoClient,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let host = match req_str(host, "host", err) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let username = match req_str(username, "username", err) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let password = match req_str(password, "password", err) {
+            Ok(v) => v,
+            Err(c) => return c,
+        };
+        let otp = opt_str(otp);
+        if out.is_null() {
+            return set_err(err, SynoStatus::NullArg, 0, "out pointer must not be null");
+        }
+
+        let runtime = match tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => Arc::new(rt),
+            Err(e) => {
+                return set_err(
+                    err,
+                    SynoStatus::Io,
+                    0,
+                    &format!("failed to start runtime: {e}"),
+                )
+            }
+        };
+
+        let client = if auto_relogin {
+            SynologyClient::with_auto_relogin(host, port, https)
+        } else {
+            SynologyClient::new(host, port, https)
+        };
+
+        match runtime.block_on(client.login(username, password, otp)) {
+            Ok(()) => {
+                let handle = Box::new(SynoClient {
+                    inner: Arc::new(client),
+                    runtime,
+                });
+                *out = Box::into_raw(handle);
+                SynoStatus::Ok as i32
+            }
+            Err(e) if is_otp_required(&e) => set_err(
+                err,
+                SynoStatus::OtpRequired,
+                0,
+                "two-factor authentication code required",
+            ),
+            Err(e) => {
+                // Present as a login failure regardless of the underlying code,
+                // but preserve the DSM code in `dsm_code` for diagnostics.
+                set_core_err(err, &SynoFsError::LoginFailed(Box::new(e)))
+            }
+        }
+    })
+}
+
+/// Best-effort logout. Safe to call once; does not free the handle.
+///
+/// # Safety
+/// `client` must be a live handle from [`syno_connect`] (or null).
+#[no_mangle]
+pub unsafe extern "C" fn syno_logout(client: *mut SynoClient) {
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        if let Some(c) = client.as_ref() {
+            let _ = c.runtime.block_on(c.inner.logout());
+        }
+    }));
+}
+
+/// Free a client handle. After this the pointer is invalid.
+///
+/// # Safety
+/// `client` must have come from [`syno_connect`] and not been freed already.
+#[no_mangle]
+pub unsafe extern "C" fn syno_client_free(client: *mut SynoClient) {
+    if !client.is_null() {
+        drop(Box::from_raw(client));
+    }
+}
+
+/// Free a string returned by this library (e.g. `SynoError::message` or any
+/// `out_json`).
+///
+/// # Safety
+/// `s` must have come from this library and not been freed already.
+#[no_mangle]
+pub unsafe extern "C" fn syno_string_free(s: *mut c_char) {
+    if !s.is_null() {
+        drop(CString::from_raw(s));
+    }
+}
+
+// ─── Helpers shared by the client ops ────────────────────────────────────────
+
+/// Run an async op on the client's runtime with SID-expiry relogin retry.
+unsafe fn run_op<F, Fut, T>(client: *mut SynoClient, op: F) -> Result<T, RunErr<SynoFsError>>
+where
+    F: Fn(Arc<SynologyClient>) -> Fut,
+    Fut: std::future::Future<Output = Result<T, SynoFsError>>,
+{
+    let c = client.as_ref().ok_or(RunErr::Null)?;
+    let inner = c.inner.clone();
+    c.runtime
+        .block_on(async { inner.with_relogin_retry(|| op(inner.clone())).await })
+        .map_err(RunErr::Op)
+}
+
+enum RunErr<E> {
+    Null,
+    Op(E),
+}
+
+unsafe fn finish<T>(
+    res: Result<T, RunErr<SynoFsError>>,
+    err: *mut SynoError,
+    on_ok: impl FnOnce(T) -> i32,
+) -> i32 {
+    match res {
+        Ok(v) => on_ok(v),
+        Err(RunErr::Null) => set_err(err, SynoStatus::NullArg, 0, "client must not be null"),
+        Err(RunErr::Op(e)) => set_core_err(err, &e),
+    }
+}
+
+// ─── Browse ──────────────────────────────────────────────────────────────────
+
+/// List the top-level shares as a JSON array of file-info objects.
+///
+/// # Safety
+/// `client` must be live; `out_json` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_list_shares(
+    client: *mut SynoClient,
+    out_json: *mut *mut c_char,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let res = run_op(client, |c| async move { c.list_shares().await });
+        finish(res, err, |items| {
+            let arr: Vec<_> = items.iter().map(fileinfo_json).collect();
+            emit_json(out_json, &serde_json::Value::Array(arr), err)
+        })
+    })
+}
+
+/// List a directory as a JSON array of file-info objects.
+///
+/// # Safety
+/// `client` must be live; `path`/`out_json` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_list_dir(
+    client: *mut SynoClient,
+    path: *const c_char,
+    out_json: *mut *mut c_char,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let path = match req_str(path, "path", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let res = run_op(client, move |c| {
+            let path = path.clone();
+            async move { c.list_dir(&path).await }
+        });
+        finish(res, err, |items| {
+            let arr: Vec<_> = items.iter().map(fileinfo_json).collect();
+            emit_json(out_json, &serde_json::Value::Array(arr), err)
+        })
+    })
+}
+
+/// Get info for a single path as a JSON file-info object.
+///
+/// # Safety
+/// `client` must be live; `path`/`out_json` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_get_info(
+    client: *mut SynoClient,
+    path: *const c_char,
+    out_json: *mut *mut c_char,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let path = match req_str(path, "path", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let res = run_op(client, move |c| {
+            let path = path.clone();
+            async move { c.get_info(&path).await }
+        });
+        finish(res, err, |info| {
+            emit_json(out_json, &fileinfo_json(&info), err)
+        })
+    })
+}
+
+// ─── Transfers ───────────────────────────────────────────────────────────────
+
+/// Progress callback: `(bytes_done, bytes_total, user_data)`. `total` is 0 when
+/// the size is unknown.
+pub type ProgressCb = extern "C" fn(done: u64, total: u64, user_data: *mut c_void);
+
+fn report(cb: Option<ProgressCb>, user_data: *mut c_void, done: u64, total: u64) {
+    if let Some(cb) = cb {
+        cb(done, total, user_data);
+    }
+}
+
+/// Download `remote` to `local`, reporting progress via the optional callback.
+/// Streams the file in chunks so progress is fine-grained; writes to a
+/// `.part` sidecar and renames on success for atomicity.
+///
+/// # Safety
+/// `client` must be live; `remote`/`local` must be non-null. `progress` (if
+/// non-null) and `user_data` must remain valid for the duration of the call.
+#[no_mangle]
+pub unsafe extern "C" fn syno_download_to(
+    client: *mut SynoClient,
+    remote: *const c_char,
+    local: *const c_char,
+    progress: Option<ProgressCb>,
+    user_data: *mut c_void,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let remote = match req_str(remote, "remote", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let local = match req_str(local, "local", err) {
+            Ok(v) => PathBuf::from(v),
+            Err(c) => return c,
+        };
+        let c = match client.as_ref() {
+            Some(c) => c,
+            None => return set_err(err, SynoStatus::NullArg, 0, "client must not be null"),
+        };
+        let inner = c.inner.clone();
+
+        let result: Result<(), SynoFsError> = c.runtime.block_on(async {
+            use std::io::Write as _;
+
+            // Determine total size up front for progress reporting.
+            let total = inner
+                .with_relogin_retry(|| inner.get_info(&remote))
+                .await
+                .ok()
+                .and_then(|i| i.additional.and_then(|a| a.size))
+                .unwrap_or(0);
+            report(progress, user_data, 0, total);
+
+            let part = local.with_extension("part");
+            let mut file = std::fs::File::create(&part)
+                .map_err(|e| SynoFsError::Io(format!("create {}: {e}", part.display())))?;
+
+            let mut offset = 0u64;
+            loop {
+                let bytes = inner
+                    .with_relogin_retry(|| inner.download(&remote, offset, DOWNLOAD_CHUNK))
+                    .await?;
+                if bytes.is_empty() {
+                    break;
+                }
+                file.write_all(&bytes)
+                    .map_err(|e| SynoFsError::Io(format!("write {}: {e}", part.display())))?;
+                offset += bytes.len() as u64;
+                report(progress, user_data, offset, total.max(offset));
+                // Stop at EOF: a short final chunk, or — when the size is known
+                // and is an exact multiple of the chunk — having read it all
+                // (avoids a spurious past-EOF range request).
+                if (bytes.len() as u64) < DOWNLOAD_CHUNK || (total > 0 && offset >= total) {
+                    break;
+                }
+            }
+            file.flush()
+                .map_err(|e| SynoFsError::Io(format!("flush {}: {e}", part.display())))?;
+            drop(file);
+            std::fs::rename(&part, &local)
+                .map_err(|e| SynoFsError::Io(format!("rename into {}: {e}", local.display())))?;
+            report(progress, user_data, offset, offset);
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => SynoStatus::Ok as i32,
+            Err(e) => set_core_err(err, &e),
+        }
+    })
+}
+
+/// Upload `local` into the remote directory `remote_dir`. Progress is coarse
+/// (0 → total) because the core upload is single-shot.
+///
+/// # Safety
+/// `client` must be live; `local`/`remote_dir` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_upload(
+    client: *mut SynoClient,
+    local: *const c_char,
+    remote_dir: *const c_char,
+    overwrite: bool,
+    progress: Option<ProgressCb>,
+    user_data: *mut c_void,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let local = match req_str(local, "local", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let remote_dir = match req_str(remote_dir, "remote_dir", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let c = match client.as_ref() {
+            Some(c) => c,
+            None => return set_err(err, SynoStatus::NullArg, 0, "client must not be null"),
+        };
+
+        let data = match std::fs::read(&local) {
+            Ok(d) => d,
+            Err(e) => return set_err(err, SynoStatus::Io, 0, &format!("read {local}: {e}")),
+        };
+        let filename = match std::path::Path::new(&local)
+            .file_name()
+            .and_then(|n| n.to_str())
+        {
+            Some(n) => n.to_string(),
+            None => return set_err(err, SynoStatus::InvalidArg, 0, "local path has no filename"),
+        };
+        let total = data.len() as u64;
+        report(progress, user_data, 0, total);
+
+        let inner = c.inner.clone();
+        let result = c.runtime.block_on(async {
+            inner
+                .with_relogin_retry(|| {
+                    inner.upload(&remote_dir, &filename, data.clone(), overwrite)
+                })
+                .await
+        });
+        match result {
+            Ok(()) => {
+                report(progress, user_data, total, total);
+                SynoStatus::Ok as i32
+            }
+            Err(e) => set_core_err(err, &e),
+        }
+    })
+}
+
+/// Delete a file or directory.
+///
+/// # Safety
+/// `client` must be live; `path` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_delete(
+    client: *mut SynoClient,
+    path: *const c_char,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let path = match req_str(path, "path", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let res = run_op(client, move |c| {
+            let path = path.clone();
+            async move { c.delete(&path).await }
+        });
+        finish(res, err, |()| SynoStatus::Ok as i32)
+    })
+}
+
+/// Create a folder named `name` under `parent`.
+///
+/// # Safety
+/// `client` must be live; `parent`/`name` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_create_folder(
+    client: *mut SynoClient,
+    parent: *const c_char,
+    name: *const c_char,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let parent = match req_str(parent, "parent", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let name = match req_str(name, "name", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let res = run_op(client, move |c| {
+            let parent = parent.clone();
+            let name = name.clone();
+            async move { c.create_folder(&parent, &name).await.map(|_| ()) }
+        });
+        finish(res, err, |()| SynoStatus::Ok as i32)
+    })
+}
+
+/// Rename a file or directory (same-directory rename only).
+///
+/// # Safety
+/// `client` must be live; `path`/`new_name` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_rename(
+    client: *mut SynoClient,
+    path: *const c_char,
+    new_name: *const c_char,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let path = match req_str(path, "path", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let new_name = match req_str(new_name, "new_name", err) {
+            Ok(v) => v.to_string(),
+            Err(c) => return c,
+        };
+        let res = run_op(client, move |c| {
+            let path = path.clone();
+            let new_name = new_name.clone();
+            async move { c.rename(&path, &new_name).await.map(|_| ()) }
+        });
+        finish(res, err, |()| SynoStatus::Ok as i32)
+    })
+}
+
+// ─── Mount lifecycle ─────────────────────────────────────────────────────────
+
+/// Mount the FileStation share at `mountpoint`, in-process, on a background
+/// thread. Returns immediately with a [`SynoMount`] handle in `*out` once the
+/// mount is established (or an error if it fails to come up).
+///
+/// # Safety
+/// `client` must be live; `mountpoint`/`out` must be non-null.
+#[no_mangle]
+pub unsafe extern "C" fn syno_mount(
+    client: *mut SynoClient,
+    mountpoint: *const c_char,
+    cache_ttl: u64,
+    read_cache_mb: u64,
+    out: *mut *mut SynoMount,
+    err: *mut SynoError,
+) -> i32 {
+    guard(err, || {
+        let mountpoint = match req_str(mountpoint, "mountpoint", err) {
+            Ok(v) => PathBuf::from(v),
+            Err(c) => return c,
+        };
+        if out.is_null() {
+            return set_err(err, SynoStatus::NullArg, 0, "out pointer must not be null");
+        }
+        let c = match client.as_ref() {
+            Some(c) => c,
+            None => return set_err(err, SynoStatus::NullArg, 0, "client must not be null"),
+        };
+
+        let opts = MountOptions {
+            cache_ttl,
+            read_cache_mb,
+        };
+        match spawn_mount(
+            c.inner.clone(),
+            c.runtime.handle().clone(),
+            mountpoint,
+            opts,
+        ) {
+            Ok(handle) => {
+                let mount = Box::new(SynoMount {
+                    handle: Some(handle),
+                    _runtime: c.runtime.clone(),
+                });
+                *out = Box::into_raw(mount);
+                SynoStatus::Ok as i32
+            }
+            Err(e) => set_core_err(err, &e),
+        }
+    })
+}
+
+/// Unmount and free a mount handle. Blocks until the background worker exits.
+/// After this the pointer is invalid.
+///
+/// # Safety
+/// `mount` must have come from [`syno_mount`] and not been freed already.
+#[no_mangle]
+pub unsafe extern "C" fn syno_unmount(mount: *mut SynoMount) {
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        if mount.is_null() {
+            return;
+        }
+        let mut mount = Box::from_raw(mount);
+        if let Some(handle) = mount.handle.take() {
+            handle.stop();
+        }
+    }));
+}
+
+// ─── Logging ─────────────────────────────────────────────────────────────────
+
+/// Register a callback that receives the library's log lines. Pass a null
+/// `cb` to clear it. Installs the tracing subscriber on first call.
+///
+/// # Safety
+/// `cb`/`user_data` must remain valid until cleared with a null `cb`.
+#[no_mangle]
+pub unsafe extern "C" fn syno_set_log_callback(cb: Option<logging::LogCb>, user_data: *mut c_void) {
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        logging::set_callback(cb, user_data);
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn cstr(s: &str) -> CString {
+        CString::new(s).unwrap()
+    }
+
+    fn empty_err() -> SynoError {
+        SynoError {
+            kind: 0,
+            dsm_code: 0,
+            message: ptr::null_mut(),
+        }
+    }
+
+    unsafe fn err_message(err: &SynoError) -> String {
+        if err.message.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(err.message).to_string_lossy().into_owned()
+        }
+    }
+
+    /// Host/port for the FFI from a mock server URI ("http://127.0.0.1:PORT").
+    fn host_port(server: &MockServer) -> (CString, u16) {
+        let uri = server.uri();
+        let without = uri.trim_start_matches("http://");
+        let (host, port) = without.rsplit_once(':').unwrap();
+        (cstr(host), port.parse().unwrap())
+    }
+
+    /// A multi-thread runtime that outlives the test so the mock server's
+    /// background task keeps running while the (separate) FFI runtime drives
+    /// blocking calls on the test's main thread.
+    fn server_with<F>(setup: F) -> (Runtime, MockServer)
+    where
+        F: std::future::Future<Output = MockServer>,
+    {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let server = rt.block_on(setup);
+        (rt, server)
+    }
+
+    fn login_ok() -> ResponseTemplate {
+        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "success": true, "data": {"sid": "sid-123"}
+        }))
+    }
+
+    #[test]
+    fn connect_then_list_shares() {
+        let (_rt, server) = server_with(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/webapi/auth.cgi"))
+                .respond_with(login_ok())
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/webapi/entry.cgi"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "success": true,
+                    "data": {"shares": [{"name": "home", "path": "/home", "isdir": true}]}
+                })))
+                .mount(&server)
+                .await;
+            server
+        });
+
+        unsafe {
+            let (host, port) = host_port(&server);
+            let mut client: *mut SynoClient = ptr::null_mut();
+            let mut err = empty_err();
+            let rc = syno_connect(
+                host.as_ptr(),
+                port,
+                false,
+                cstr("alice").as_ptr(),
+                cstr("secret").as_ptr(),
+                ptr::null(),
+                false,
+                &mut client,
+                &mut err,
+            );
+            assert_eq!(rc, SynoStatus::Ok as i32, "connect: {}", err_message(&err));
+            assert!(!client.is_null());
+
+            let mut out_json: *mut c_char = ptr::null_mut();
+            let rc = syno_list_shares(client, &mut out_json, &mut err);
+            assert_eq!(rc, SynoStatus::Ok as i32, "list: {}", err_message(&err));
+            let json = CStr::from_ptr(out_json).to_string_lossy().into_owned();
+            let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(value[0]["name"], "home");
+            assert_eq!(value[0]["isdir"], true);
+
+            syno_string_free(out_json);
+            syno_logout(client);
+            syno_client_free(client);
+        }
+    }
+
+    #[test]
+    fn connect_reports_otp_required() {
+        let (_rt, server) = server_with(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/webapi/auth.cgi"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "success": false, "error": {"code": 403}
+                })))
+                .mount(&server)
+                .await;
+            server
+        });
+
+        unsafe {
+            let (host, port) = host_port(&server);
+            let mut client: *mut SynoClient = ptr::null_mut();
+            let mut err = empty_err();
+            let rc = syno_connect(
+                host.as_ptr(),
+                port,
+                false,
+                cstr("alice").as_ptr(),
+                cstr("secret").as_ptr(),
+                ptr::null(),
+                false,
+                &mut client,
+                &mut err,
+            );
+            assert_eq!(rc, SynoStatus::OtpRequired as i32);
+            assert!(client.is_null());
+            syno_string_free(err.message);
+        }
+    }
+
+    #[test]
+    fn connect_bad_credentials_is_login_failed() {
+        let (_rt, server) = server_with(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/webapi/auth.cgi"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "success": false, "error": {"code": 400}
+                })))
+                .mount(&server)
+                .await;
+            server
+        });
+
+        unsafe {
+            let (host, port) = host_port(&server);
+            let mut client: *mut SynoClient = ptr::null_mut();
+            let mut err = empty_err();
+            let rc = syno_connect(
+                host.as_ptr(),
+                port,
+                false,
+                cstr("alice").as_ptr(),
+                cstr("wrong").as_ptr(),
+                ptr::null(),
+                false,
+                &mut client,
+                &mut err,
+            );
+            assert_eq!(rc, SynoStatus::LoginFailed as i32);
+            assert_eq!(err.dsm_code, 400, "DSM code preserved on `.dsm_code`");
+            syno_string_free(err.message);
+        }
+    }
+
+    #[test]
+    fn null_client_is_null_arg_not_panic() {
+        unsafe {
+            let mut out_json: *mut c_char = ptr::null_mut();
+            let mut err = empty_err();
+            let rc = syno_list_shares(ptr::null_mut(), &mut out_json, &mut err);
+            assert_eq!(rc, SynoStatus::NullArg as i32);
+            syno_string_free(err.message);
+        }
+    }
+}

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -492,6 +492,10 @@ pub unsafe extern "C" fn syno_download_to(
         };
         let inner = c.inner.clone();
 
+        // Stream into a `.part` sidecar, renamed on success for atomicity.
+        // Computed out here so failure paths can clean it up (see below).
+        let part = local.with_extension("part");
+
         let result: Result<(), SynoFsError> = c.runtime.block_on(async {
             use std::io::Write as _;
 
@@ -504,7 +508,6 @@ pub unsafe extern "C" fn syno_download_to(
                 .unwrap_or(0);
             report(progress, user_data, 0, total);
 
-            let part = local.with_extension("part");
             let mut file = std::fs::File::create(&part)
                 .map_err(|e| SynoFsError::Io(format!("create {}: {e}", part.display())))?;
 
@@ -538,7 +541,12 @@ pub unsafe extern "C" fn syno_download_to(
 
         match result {
             Ok(()) => SynoStatus::Ok as i32,
-            Err(e) => set_core_err(err, &e),
+            Err(e) => {
+                // Best-effort: don't leave a stale partial file behind on
+                // failure (range error mid-transfer, rename failure, etc.).
+                let _ = std::fs::remove_file(&part);
+                set_core_err(err, &e)
+            }
         }
     })
 }
@@ -572,6 +580,11 @@ pub unsafe extern "C" fn syno_upload(
             None => return set_err(err, SynoStatus::NullArg, 0, "client must not be null"),
         };
 
+        // The core Upload API is single-shot (takes a full `Vec<u8>`), so the
+        // whole file is buffered in memory — the same documented "write
+        // buffering" limitation the CLI and PyO3 binding share. There is no
+        // streaming path to prefer here; a streaming upload would have to land
+        // in the core crate first.
         let data = match std::fs::read(&local) {
             Ok(d) => d,
             Err(e) => return set_err(err, SynoStatus::Io, 0, &format!("read {local}: {e}")),

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -52,6 +52,8 @@ pub enum SynoStatus {
     NullArg = 12,
     /// A panic was caught at the FFI boundary.
     Panic = 13,
+    /// DSM session id expired or unknown (DSM code 119).
+    SidNotFound = 14,
 }
 
 /// Out-param filled on error. `message` is a heap UTF-8 C string owned by the
@@ -64,40 +66,42 @@ pub struct SynoError {
     pub message: *mut c_char,
 }
 
-/// Map a core error to (typed status, raw DSM code). Mirrors the PyO3
-/// `synofs_to_pyerr` routing so the GUI sees the same classes the Python
-/// bindings expose.
+/// Map a core error to (typed status, raw DSM code). Both this and the PyO3
+/// exception mapping derive from the core's shared [`ErrorCategory`], so the
+/// GUI and the Python bindings classify every DSM code identically.
 fn classify(err: &SynoFsError) -> (SynoStatus, u32) {
+    use synology_filestation_core::error::ErrorCategory as C;
     use SynoStatus as S;
-    match err {
-        SynoFsError::NotFound => (S::NotFound, 0),
-        SynoFsError::PermissionDenied => (S::PermissionDenied, 0),
-        SynoFsError::AlreadyExists => (S::AlreadyExists, 0),
-        SynoFsError::NotEmpty => (S::NotEmpty, 0),
-        SynoFsError::InvalidArg => (S::InvalidArg, 0),
-        SynoFsError::NoSpace => (S::NoSpace, 0),
-        SynoFsError::NotSupported => (S::NotSupported, 0),
-        SynoFsError::Io(_) => (S::Io, 0),
-        SynoFsError::LoginFailed(inner) => {
-            let code = match inner.as_ref() {
-                SynoFsError::ApiError(c) => *c,
-                _ => 0,
-            };
-            (S::LoginFailed, code)
-        }
-        SynoFsError::ApiError(c) => {
-            let s = match *c {
-                400 => S::InvalidArg,
-                403 | 414 | 415 => S::NotFound,
-                408 | 1805 => S::PermissionDenied,
-                416 => S::NotEmpty,
-                418 | 1101 => S::AlreadyExists,
-                419 | 1804 => S::NoSpace,
-                _ => S::Api,
-            };
-            (s, *c)
-        }
+
+    // A failed (re)login always presents as LoginFailed, but we preserve the
+    // underlying DSM code on `dsm_code` so callers can inspect what failed.
+    if let SynoFsError::LoginFailed(inner) = err {
+        let code = match inner.as_ref() {
+            SynoFsError::ApiError(c) => *c,
+            _ => 0,
+        };
+        return (S::LoginFailed, code);
     }
+
+    let dsm = match err {
+        SynoFsError::ApiError(c) => *c,
+        _ => 0,
+    };
+    let status = match err.category() {
+        C::NotFound => S::NotFound,
+        C::PermissionDenied => S::PermissionDenied,
+        C::AlreadyExists => S::AlreadyExists,
+        C::NotEmpty => S::NotEmpty,
+        C::InvalidArg => S::InvalidArg,
+        C::NoSpace => S::NoSpace,
+        C::NotSupported => S::NotSupported,
+        C::SidExpired => S::SidNotFound,
+        C::Transport => S::Io,
+        // No dedicated FFI status for "busy"; surface as a generic API error
+        // (the raw DSM code is still on `dsm_code`).
+        C::Busy | C::Other => S::Api,
+    };
+    (status, dsm)
 }
 
 /// Write a status + message into `*err` (if non-null) and return the status as
@@ -261,12 +265,21 @@ pub unsafe extern "C" fn syno_connect(
             return set_err(err, SynoStatus::NullArg, 0, "out pointer must not be null");
         }
 
-        let runtime = match tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
+        let client = if auto_relogin {
+            SynologyClient::with_auto_relogin(host, port, https)
+        } else {
+            SynologyClient::new(host, port, https)
+        };
+
+        // Attempt login on a cheap current-thread runtime that spawns no worker
+        // threads. Only on success do we build the persistent multi-thread
+        // runtime the client/mount will use — so a wrong password or an
+        // OTP-required first call doesn't churn OS threads per attempt.
+        let probe_rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
         {
-            Ok(rt) => Arc::new(rt),
+            Ok(rt) => rt,
             Err(e) => {
                 return set_err(
                     err,
@@ -277,14 +290,24 @@ pub unsafe extern "C" fn syno_connect(
             }
         };
 
-        let client = if auto_relogin {
-            SynologyClient::with_auto_relogin(host, port, https)
-        } else {
-            SynologyClient::new(host, port, https)
-        };
-
-        match runtime.block_on(client.login(username, password, otp)) {
+        match probe_rt.block_on(client.login(username, password, otp)) {
             Ok(()) => {
+                drop(probe_rt);
+                let runtime = match tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => Arc::new(rt),
+                    Err(e) => {
+                        return set_err(
+                            err,
+                            SynoStatus::Io,
+                            0,
+                            &format!("failed to start runtime: {e}"),
+                        )
+                    }
+                };
                 let handle = Box::new(SynoClient {
                     inner: Arc::new(client),
                     runtime,
@@ -493,8 +516,14 @@ pub unsafe extern "C" fn syno_download_to(
         let inner = c.inner.clone();
 
         // Stream into a `.part` sidecar, renamed on success for atomicity.
-        // Computed out here so failure paths can clean it up (see below).
-        let part = local.with_extension("part");
+        // Append (rather than replace the extension) so `a.txt` and `a.csv`
+        // get distinct sidecars and we never collide with an unrelated
+        // `<stem>.part`. Computed out here so failure paths can clean it up.
+        let part = {
+            let mut p = local.clone().into_os_string();
+            p.push(".syno-part");
+            PathBuf::from(p)
+        };
 
         let result: Result<(), SynoFsError> = c.runtime.block_on(async {
             use std::io::Write as _;
@@ -786,6 +815,18 @@ pub unsafe extern "C" fn syno_set_log_callback(cb: Option<logging::LogCb>, user_
     }));
 }
 
+/// Set the log verbosity: one of "error", "warn", "info", "debug", "trace"
+/// (anything else falls back to "info"). No-op until a callback is registered.
+///
+/// # Safety
+/// `level` must be a valid NUL-terminated UTF-8 string, or null (treated as "info").
+#[no_mangle]
+pub unsafe extern "C" fn syno_set_log_level(level: *const c_char) {
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        logging::set_level(opt_str(level).unwrap_or("info"));
+    }));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -958,6 +999,54 @@ mod tests {
             assert_eq!(rc, SynoStatus::LoginFailed as i32);
             assert_eq!(err.dsm_code, 400, "DSM code preserved on `.dsm_code`");
             syno_string_free(err.message);
+        }
+    }
+
+    #[test]
+    fn dsm_119_classifies_as_sid_not_found() {
+        let (_rt, server) = server_with(async {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/webapi/auth.cgi"))
+                .respond_with(login_ok())
+                .mount(&server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/webapi/entry.cgi"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "success": false, "error": {"code": 119}
+                })))
+                .mount(&server)
+                .await;
+            server
+        });
+
+        unsafe {
+            let (host, port) = host_port(&server);
+            let mut client: *mut SynoClient = ptr::null_mut();
+            let mut err = empty_err();
+            // auto_relogin = false so the 119 surfaces instead of triggering a retry.
+            let rc = syno_connect(
+                host.as_ptr(),
+                port,
+                false,
+                cstr("alice").as_ptr(),
+                cstr("secret").as_ptr(),
+                ptr::null(),
+                false,
+                &mut client,
+                &mut err,
+            );
+            assert_eq!(rc, SynoStatus::Ok as i32, "connect: {}", err_message(&err));
+
+            let mut out_json: *mut c_char = ptr::null_mut();
+            let rc = syno_list_dir(client, cstr("/home").as_ptr(), &mut out_json, &mut err);
+            assert_eq!(rc, SynoStatus::SidNotFound as i32);
+            assert_eq!(err.dsm_code, 119);
+
+            syno_string_free(err.message);
+            syno_logout(client);
+            syno_client_free(client);
         }
     }
 

--- a/rust/synology-filestation-ffi/src/logging.rs
+++ b/rust/synology-filestation-ffi/src/logging.rs
@@ -99,13 +99,19 @@ fn level_of(line: &str) -> i32 {
 }
 
 fn dispatch(line: &str) {
-    let guard = match sink().lock() {
-        Ok(g) => g,
-        Err(_) => return,
+    // Copy the callback + user_data out while holding the lock, then release it
+    // *before* calling into foreign code. Calling under the lock risks a
+    // deadlock if the callback re-enters logging or tries to swap/clear itself.
+    let target = {
+        let guard = match sink().lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        guard.as_ref().map(|s| (s.cb, s.user_data))
     };
-    if let Some(s) = guard.as_ref() {
+    if let Some((cb, user_data)) = target {
         if let Ok(c) = CString::new(line) {
-            (s.cb)(level_of(line), c.as_ptr(), s.user_data as *mut c_void);
+            cb(level_of(line), c.as_ptr(), user_data as *mut c_void);
         }
     }
 }

--- a/rust/synology-filestation-ffi/src/logging.rs
+++ b/rust/synology-filestation-ffi/src/logging.rs
@@ -1,0 +1,111 @@
+//! Bridge from the crate's `tracing` events to a C callback.
+//!
+//! The GUI installs a callback via `syno_set_log_callback`; we lazily install a
+//! `tracing_subscriber::fmt` subscriber whose writer formats each event line
+//! and hands it to whatever callback is currently registered. Installing the
+//! subscriber is one-shot (a global default can only be set once), but the
+//! callback target behind it can be swapped or cleared at any time.
+
+use std::ffi::{c_void, CString};
+use std::io::{self, Write};
+use std::os::raw::c_char;
+use std::sync::{Mutex, Once, OnceLock};
+
+/// C callback signature: `(level, line, user_data)`. `level` mirrors the
+/// `tracing::Level` ordering (1=ERROR … 5=TRACE); `line` is a NUL-terminated
+/// UTF-8 string valid only for the duration of the call.
+pub type LogCb = extern "C" fn(level: i32, line: *const c_char, user_data: *mut c_void);
+
+/// A registered callback plus its opaque user-data pointer. The pointers are
+/// only ever called/observed; we never deref `user_data` ourselves. The C#
+/// side guarantees both stay valid until it clears the callback.
+struct Sink {
+    cb: LogCb,
+    user_data: usize,
+}
+
+// SAFETY: the callback is a plain function pointer and `user_data` is treated
+// as an opaque token; the foreign caller owns its lifetime and thread-safety.
+unsafe impl Send for Sink {}
+
+static SINK: OnceLock<Mutex<Option<Sink>>> = OnceLock::new();
+static INIT: Once = Once::new();
+
+fn sink() -> &'static Mutex<Option<Sink>> {
+    SINK.get_or_init(|| Mutex::new(None))
+}
+
+/// Register (or, with `cb == None`, clear) the log callback, installing the
+/// tracing subscriber on first use.
+///
+/// # Safety
+/// `cb`/`user_data` must remain valid until a subsequent call clears them.
+pub unsafe fn set_callback(cb: Option<LogCb>, user_data: *mut c_void) {
+    {
+        let mut guard = sink().lock().unwrap();
+        *guard = cb.map(|cb| Sink {
+            cb,
+            user_data: user_data as usize,
+        });
+    }
+    INIT.call_once(|| {
+        // INFO-and-above by default; the GUI doesn't need DEBUG/TRACE spam in
+        // its log pane. (We avoid the `env-filter` feature to keep the cdylib
+        // lean — a static max level is all the GUI needs.)
+        let _ = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .with_ansi(false)
+            .with_writer(|| CallbackWriter)
+            .try_init();
+    });
+}
+
+/// A `Write` sink that buffers a line and dispatches complete lines to the
+/// registered callback. Lines are level-tagged best-effort by scanning the
+/// formatted prefix.
+struct CallbackWriter;
+
+impl Write for CallbackWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let text = String::from_utf8_lossy(buf);
+        for line in text.split_inclusive('\n') {
+            let trimmed = line.trim_end_matches(['\n', '\r']);
+            if trimmed.is_empty() {
+                continue;
+            }
+            dispatch(trimmed);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn level_of(line: &str) -> i32 {
+    // The fmt layer prints e.g. "...  INFO synology...: message".
+    if line.contains("ERROR") {
+        1
+    } else if line.contains(" WARN") {
+        2
+    } else if line.contains(" INFO") {
+        3
+    } else if line.contains("DEBUG") {
+        4
+    } else {
+        5
+    }
+}
+
+fn dispatch(line: &str) {
+    let guard = match sink().lock() {
+        Ok(g) => g,
+        Err(_) => return,
+    };
+    if let Some(s) = guard.as_ref() {
+        if let Ok(c) = CString::new(line) {
+            (s.cb)(level_of(line), c.as_ptr(), s.user_data as *mut c_void);
+        }
+    }
+}

--- a/rust/synology-filestation-ffi/src/logging.rs
+++ b/rust/synology-filestation-ffi/src/logging.rs
@@ -11,6 +11,9 @@ use std::io::{self, Write};
 use std::os::raw::c_char;
 use std::sync::{Mutex, Once, OnceLock};
 
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{fmt, prelude::*, reload, Registry};
+
 /// C callback signature: `(level, line, user_data)`. `level` mirrors the
 /// `tracing::Level` ordering (1=ERROR … 5=TRACE); `line` is a NUL-terminated
 /// UTF-8 string valid only for the duration of the call.
@@ -30,9 +33,31 @@ unsafe impl Send for Sink {}
 
 static SINK: OnceLock<Mutex<Option<Sink>>> = OnceLock::new();
 static INIT: Once = Once::new();
+/// Handle to the reloadable level filter, so `set_level` can change verbosity
+/// after the subscriber is installed.
+static RELOAD: OnceLock<reload::Handle<LevelFilter, Registry>> = OnceLock::new();
 
 fn sink() -> &'static Mutex<Option<Sink>> {
     SINK.get_or_init(|| Mutex::new(None))
+}
+
+fn parse_level(level: &str) -> LevelFilter {
+    match level.trim().to_ascii_lowercase().as_str() {
+        "error" => LevelFilter::ERROR,
+        "warn" => LevelFilter::WARN,
+        "info" => LevelFilter::INFO,
+        "debug" => LevelFilter::DEBUG,
+        "trace" => LevelFilter::TRACE,
+        _ => LevelFilter::INFO,
+    }
+}
+
+/// Change the active log verbosity. No-op until the subscriber is installed
+/// (the GUI registers a callback at startup, before any connect).
+pub fn set_level(level: &str) {
+    if let Some(handle) = RELOAD.get() {
+        let _ = handle.reload(parse_level(level));
+    }
 }
 
 /// Register (or, with `cb == None`, clear) the log callback, installing the
@@ -49,13 +74,14 @@ pub unsafe fn set_callback(cb: Option<LogCb>, user_data: *mut c_void) {
         });
     }
     INIT.call_once(|| {
-        // INFO-and-above by default; the GUI doesn't need DEBUG/TRACE spam in
-        // its log pane. (We avoid the `env-filter` feature to keep the cdylib
-        // lean — a static max level is all the GUI needs.)
-        let _ = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
-            .with_ansi(false)
-            .with_writer(|| CallbackWriter)
+        // INFO by default, reloadable via `set_level` so the GUI's log-level
+        // control actually takes effect. Build the reload handle first so it is
+        // available even if `try_init` later loses the global-default race.
+        let (filter, handle) = reload::Layer::new(LevelFilter::INFO);
+        let _ = RELOAD.set(handle);
+        let _ = tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt::layer().with_ansi(false).with_writer(|| CallbackWriter))
             .try_init();
     });
 }
@@ -84,18 +110,21 @@ impl Write for CallbackWriter {
 }
 
 fn level_of(line: &str) -> i32 {
-    // The fmt layer prints e.g. "...  INFO synology...: message".
-    if line.contains("ERROR") {
-        1
-    } else if line.contains(" WARN") {
-        2
-    } else if line.contains(" INFO") {
-        3
-    } else if line.contains("DEBUG") {
-        4
-    } else {
-        5
+    // The fmt layer prints "<timestamp> <LEVEL> <target>: <message>". The level
+    // is the first whitespace-delimited token that exactly equals a level name;
+    // returning on the first exact match means message text containing the word
+    // "ERROR"/"DEBUG" (which comes after the level) can't misclassify the line.
+    for tok in line.split_whitespace() {
+        match tok {
+            "ERROR" => return 1,
+            "WARN" => return 2,
+            "INFO" => return 3,
+            "DEBUG" => return 4,
+            "TRACE" => return 5,
+            _ => {}
+        }
     }
+    3 // default to INFO if no level token is found
 }
 
 fn dispatch(line: &str) {

--- a/rust/synology-filestation-fuse/Cargo.toml
+++ b/rust/synology-filestation-fuse/Cargo.toml
@@ -6,6 +6,10 @@ license = "MIT"
 description = "Cross-platform filesystem driver mounting Synology FileStation as a local directory."
 repository = "https://github.com/UCSD-E4E/synology-filestation"
 
+[lib]
+name = "synology_filestation_fuse"
+path = "src/lib.rs"
+
 [[bin]]
 name = "synology-filestation-fuse"
 path = "src/main.rs"

--- a/rust/synology-filestation-fuse/src/lib.rs
+++ b/rust/synology-filestation-fuse/src/lib.rs
@@ -1,0 +1,534 @@
+//! Reusable mount library for the Synology FileStation driver.
+//!
+//! This crate is built as both a library and a binary. The binary
+//! ([`main.rs`](../main.rs)) is the CLI; this library exposes the platform
+//! mount backends (`fs`/`cache` on Linux, `webdav` on macOS, `winfs` on
+//! Windows) behind a single **spawnable** API so the CLI *and* the FFI binding
+//! ([`synology-filestation-ffi`]) can drive a mount without blocking the
+//! caller's thread.
+//!
+//! The key difference from the old in-`main` mount code is that
+//! [`spawn_mount`] returns a [`MountHandle`] immediately and the filesystem
+//! runs on a background thread/task; [`MountHandle::stop`] unmounts and joins.
+//! The CLI re-creates its previous blocking behaviour by simply parking on
+//! `ctrl_c()` and then calling `stop()`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use synology_filestation_core::client::SynologyClient;
+use synology_filestation_core::error::SynoFsError;
+
+#[cfg(target_os = "linux")]
+mod cache;
+#[cfg(target_os = "linux")]
+mod fs;
+
+#[cfg(target_os = "macos")]
+mod webdav;
+
+#[cfg(target_os = "windows")]
+mod winfs;
+
+/// Tunables that only the Linux/FUSE backend currently honours, but which are
+/// accepted on every platform so callers can pass one uniform struct.
+#[derive(Debug, Clone, Copy)]
+pub struct MountOptions {
+    /// Metadata cache TTL in seconds (Linux/FUSE only).
+    pub cache_ttl: u64,
+    /// Read cache size in MiB (Linux/FUSE only).
+    pub read_cache_mb: u64,
+}
+
+impl Default for MountOptions {
+    fn default() -> Self {
+        Self {
+            cache_ttl: 30,
+            read_cache_mb: 256,
+        }
+    }
+}
+
+/// Returns `true` when a *login* error means the account requires a 2FA / OTP
+/// code (DSM reports this as API error 403 or 404 on the auth call). Shared by
+/// the CLI's interactive prompt and the FFI binding's `OTP_REQUIRED` result so
+/// both agree on what "needs an OTP" means.
+pub fn is_otp_required(e: &SynoFsError) -> bool {
+    matches!(e, SynoFsError::ApiError(403 | 404))
+}
+
+/// A live mount. Dropping or calling [`MountHandle::stop`] unmounts the
+/// filesystem and joins the background worker. The handle keeps the Tokio
+/// runtime handle and client alive for the lifetime of the mount.
+pub struct MountHandle {
+    // The client is held so the session's strong reference outlives the caller
+    // dropping theirs; the FUSE/WebDAV/WinFsp callbacks all clone from it.
+    #[allow(dead_code)]
+    client: Arc<SynologyClient>,
+    inner: PlatformMount,
+}
+
+impl MountHandle {
+    /// Unmount the filesystem and wait for the background worker to finish.
+    /// Errors during unmount are logged and swallowed — there is nothing the
+    /// caller can usefully do, and a best-effort unmount is the right contract.
+    pub fn stop(self) {
+        self.inner.stop();
+    }
+}
+
+// ─── Linux (FUSE) ────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+struct PlatformMount {
+    session: Option<fuser::BackgroundSession>,
+}
+
+#[cfg(target_os = "linux")]
+impl PlatformMount {
+    fn stop(mut self) {
+        if let Some(session) = self.session.take() {
+            if let Err(e) = session.umount_and_join() {
+                tracing::warn!("error during unmount: {e}");
+            }
+        }
+    }
+}
+
+/// Returns `true` when `/etc/fuse.conf` contains an uncommented
+/// `user_allow_other` line, meaning a non-root user is permitted to pass the
+/// `allow_other` option to `fusermount`/`fusermount3`.
+#[cfg(target_os = "linux")]
+fn fuse_conf_allows_other() -> bool {
+    let contents = match std::fs::read_to_string("/etc/fuse.conf") {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    contents.lines().any(|line| {
+        let trimmed = line.trim();
+        !trimmed.starts_with('#') && trimmed == "user_allow_other"
+    })
+}
+
+#[cfg(target_os = "linux")]
+pub fn spawn_mount(
+    client: Arc<SynologyClient>,
+    rt: tokio::runtime::Handle,
+    mountpoint: PathBuf,
+    opts: MountOptions,
+) -> Result<MountHandle, SynoFsError> {
+    use cache::{InodeCache, ReadCache, READ_BLOCK_SIZE};
+    use fs::SynologyFS;
+    use fuser::{Config, MountOption, SessionACL};
+    use tracing::info;
+
+    let cache = Arc::new(InodeCache::new(opts.cache_ttl));
+    let max_blocks = (opts.read_cache_mb * 1024 * 1024) / READ_BLOCK_SIZE;
+    let read_cache = Arc::new(ReadCache::new(READ_BLOCK_SIZE, max_blocks.max(1)));
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+
+    info!(
+        "Read cache: {} MiB ({} blocks × {} MiB)",
+        opts.read_cache_mb,
+        max_blocks,
+        READ_BLOCK_SIZE / (1024 * 1024)
+    );
+
+    let fs = SynologyFS::new(client.clone(), cache, read_cache, rt, uid, gid);
+
+    // `allow_other` (kernel-level access for other users) moved off MountOption
+    // in fuser 0.17 — it's now expressed via Config::acl: SessionACL::All.
+    // As a non-root user this requires `user_allow_other` in /etc/fuse.conf;
+    // running as root always permits it.
+    let allow_other = uid == 0 || fuse_conf_allows_other();
+    let acl = if allow_other {
+        SessionACL::All
+    } else {
+        tracing::warn!(
+            "allow_other is not enabled: only the mounting user can access the \
+             filesystem. To allow other users, add or uncomment \
+             `user_allow_other` in /etc/fuse.conf."
+        );
+        SessionACL::Owner
+    };
+
+    let mut mount_options = vec![
+        MountOption::RW,
+        MountOption::FSName("synology-fuse".to_string()),
+    ];
+    // AutoUnmount requires AllowOther or AllowRoot per libfuse / fuser docs.
+    // Without that, the mount would fail. Skip AutoUnmount when allow_other is
+    // unavailable so the mount still succeeds (the user just has to unmount
+    // manually with `fusermount -u <mountpoint>`).
+    if allow_other {
+        mount_options.push(MountOption::AutoUnmount);
+    }
+
+    let mut config = Config::default();
+    config.mount_options = mount_options;
+    config.acl = acl;
+
+    info!("Mounting shares on {}", mountpoint.display());
+    let session = fuser::spawn_mount2(fs, &mountpoint, &config).map_err(|e| {
+        SynoFsError::Io(format!("failed to mount on {}: {e}", mountpoint.display()))
+    })?;
+    info!("Mounted at {}", mountpoint.display());
+
+    Ok(MountHandle {
+        client,
+        inner: PlatformMount {
+            session: Some(session),
+        },
+    })
+}
+
+// ─── macOS (WebDAV via Finder) ─────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+struct PlatformMount {
+    rt: tokio::runtime::Handle,
+    mountpoint: PathBuf,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    server: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[cfg(target_os = "macos")]
+impl PlatformMount {
+    fn stop(mut self) {
+        use tracing::info;
+        info!("Unmounting {}…", self.mountpoint.display());
+        let mp = self.mountpoint.clone();
+        // Ask macOS to unmount the WebDAV volume, then tear down the server.
+        self.rt.block_on(async {
+            let _ = tokio::process::Command::new("diskutil")
+                .args(["unmount", &mp.to_string_lossy()])
+                .status()
+                .await;
+        });
+        // macOS does not always remove the /Volumes/<name> directory after
+        // unmounting a WebDAV volume. Remove it ourselves if it is now empty.
+        let _ = std::fs::remove_dir(&mp);
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(server) = self.server.take() {
+            let _ = self.rt.block_on(server);
+        }
+    }
+}
+
+/// On macOS we mount via Finder which always places volumes under `/Volumes/`.
+/// Reject paths elsewhere so the user gets a predictable volume name.
+#[cfg(target_os = "macos")]
+fn validate_macos_mountpoint(mountpoint: &std::path::Path) -> Result<(), SynoFsError> {
+    if !mountpoint.starts_with("/Volumes/") {
+        return Err(SynoFsError::Io(format!(
+            "On macOS the mountpoint must be under /Volumes/ (e.g. /Volumes/nas), got: {}",
+            mountpoint.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+pub fn spawn_mount(
+    client: Arc<SynologyClient>,
+    rt: tokio::runtime::Handle,
+    mountpoint: PathBuf,
+    _opts: MountOptions,
+) -> Result<MountHandle, SynoFsError> {
+    use std::convert::Infallible;
+
+    use dav_server::{fakels::FakeLs, DavHandler};
+    use hyper::server::conn::http1;
+    use hyper_util::rt::TokioIo;
+    use tracing::info;
+    use webdav::SynologyDavFs;
+
+    validate_macos_mountpoint(&mountpoint)?;
+
+    // Extract the desired volume name from the last component of the path
+    // (e.g. "/Volumes/nas" → "nas") and use it as a URL path prefix so that
+    // macOS names the mounted volume correctly.
+    let volume_name = mountpoint
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let path_prefix = format!("/{}", volume_name);
+
+    let handler = Arc::new(
+        DavHandler::builder()
+            .filesystem(Box::new(SynologyDavFs::new(
+                client.clone(),
+                path_prefix.clone(),
+            )))
+            .locksystem(FakeLs::new())
+            .build_handler(),
+    );
+
+    // All the async setup that must complete before we return runs on the
+    // provided runtime. The accept loop is left running as a spawned task.
+    let setup = rt.block_on(async move {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(|e| SynoFsError::Io(format!("failed to bind WebDAV listener: {e}")))?;
+        let port = listener
+            .local_addr()
+            .map_err(|e| SynoFsError::Io(e.to_string()))?
+            .port();
+        let url = format!("http://127.0.0.1:{}{}/", port, path_prefix);
+        info!("WebDAV server listening on {}", url);
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+        let handler_srv = handler.clone();
+        let server = tokio::spawn(async move {
+            let mut shutdown_rx = shutdown_rx;
+            loop {
+                tokio::select! {
+                    result = listener.accept() => {
+                        let (stream, _addr) = match result {
+                            Ok(r) => r,
+                            Err(e) => { tracing::debug!("accept error: {}", e); break; }
+                        };
+                        let io = TokioIo::new(stream);
+                        let h = handler_srv.clone();
+                        tokio::spawn(async move {
+                            let svc = hyper::service::service_fn(move |req| {
+                                let h = h.clone();
+                                async move { Ok::<_, Infallible>(h.handle(req).await) }
+                            });
+                            if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+                                tracing::debug!("WebDAV connection closed: {}", e);
+                            }
+                        });
+                    }
+                    _ = &mut shutdown_rx => {
+                        info!("WebDAV server shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok::<_, SynoFsError>((url, shutdown_tx, server))
+    });
+
+    let (url, shutdown_tx, server) = setup?;
+
+    // Remove a stale mount-point directory left over from a previous run. If
+    // the directory is actually still mounted this fails (EBUSY/EPERM), which
+    // is fine — we leave it and let osascript fail with a clear message.
+    if mountpoint.is_dir() && !mountpoint.is_symlink() {
+        let _ = std::fs::remove_dir(&mountpoint);
+    }
+
+    // Ask Finder to mount the volume via AppleScript.
+    let script = format!("mount volume \"{}\"", url);
+    let out = rt
+        .block_on(
+            tokio::process::Command::new("osascript")
+                .args(["-e", &script])
+                .output(),
+        )
+        .map_err(|e| SynoFsError::Io(format!("failed to run osascript: {e}")))?;
+
+    if !out.status.success() {
+        let _ = shutdown_tx.send(());
+        let _ = rt.block_on(server);
+        return Err(SynoFsError::Io(format!(
+            "osascript mount failed ({}): {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+
+    info!("Mounted at {}", mountpoint.display());
+
+    Ok(MountHandle {
+        client,
+        inner: PlatformMount {
+            rt,
+            mountpoint,
+            shutdown: Some(shutdown_tx),
+            server: Some(server),
+        },
+    })
+}
+
+// ─── Windows (WinFsp) ───────────────────────────────────────────────────────
+
+/// Add WinFsp's bin directory to PATH so the Windows loader can find
+/// winfsp-x64.dll when the delay-load triggers on the first WinFsp call.
+/// WinFsp installs to a non-standard location and does not add itself to PATH.
+#[cfg(target_os = "windows")]
+fn ensure_winfsp_in_path() {
+    let candidates = [
+        r"C:\Program Files (x86)\WinFsp\bin",
+        r"C:\Program Files\WinFsp\bin",
+    ];
+    for dir in &candidates {
+        if std::path::Path::new(dir).join("winfsp-x64.dll").exists() {
+            let current = std::env::var_os("PATH").unwrap_or_default();
+            let current_str = current.to_string_lossy();
+            if !current_str.to_lowercase().contains(&dir.to_lowercase()) {
+                std::env::set_var("PATH", format!("{};{}", dir, current_str));
+            }
+            return;
+        }
+    }
+}
+
+/// WinFsp's `FileSystemHost` is not `Send`, so the mount lives on a dedicated
+/// thread that owns it: the thread mounts, starts the dispatcher, parks until
+/// signalled, then stops and unmounts. This mirrors the Linux background-thread
+/// model and keeps the non-`Send` host confined to one thread.
+#[cfg(target_os = "windows")]
+struct PlatformMount {
+    shutdown: Option<std::sync::mpsc::Sender<()>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(target_os = "windows")]
+impl PlatformMount {
+    fn stop(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+/// On Windows WinFsp creates the mountpoint directory itself and deletes it on
+/// unmount, so the directory must not exist (but its parent must) when mounting.
+#[cfg(target_os = "windows")]
+fn prepare_windows_mountpoint(mountpoint: &std::path::Path) -> Result<(), SynoFsError> {
+    if let Some(parent) = mountpoint.parent() {
+        if !parent.as_os_str().is_empty() && !parent.is_dir() {
+            return Err(SynoFsError::Io(format!(
+                "On Windows the mountpoint's parent directory must exist, got: {}",
+                mountpoint.display()
+            )));
+        }
+    }
+    if mountpoint.exists() {
+        std::fs::remove_dir(mountpoint).map_err(|e| {
+            SynoFsError::Io(format!(
+                "Mountpoint {} already exists and could not be removed (is it still mounted?): {e}",
+                mountpoint.display()
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub fn spawn_mount(
+    client: Arc<SynologyClient>,
+    rt: tokio::runtime::Handle,
+    mountpoint: PathBuf,
+    _opts: MountOptions,
+) -> Result<MountHandle, SynoFsError> {
+    use std::sync::mpsc;
+    use tracing::info;
+
+    prepare_windows_mountpoint(&mountpoint)?;
+    ensure_winfsp_in_path();
+
+    // The worker reports the outcome of mount setup back over this channel so
+    // spawn_mount can return a structured error if mounting fails.
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+    let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
+
+    let worker_client = client.clone();
+    let worker_mp = mountpoint.clone();
+    let worker = std::thread::Builder::new()
+        .name("synofs-winfsp".to_string())
+        .spawn(move || {
+            use winfsp::host::{FileSystemHost, FileSystemParams, VolumeParams};
+
+            let init = match winfsp::winfsp_init() {
+                Ok(i) => i,
+                Err(e) => {
+                    let _ = ready_tx.send(Err(format!(
+                        "Failed to initialise WinFsp ({e:?}). Ensure WinFsp is installed from \
+                         https://winfsp.dev/rel/ and the WinFsp.Launcher service is running."
+                    )));
+                    return;
+                }
+            };
+            let _fsp = init;
+
+            let mut volume_params = VolumeParams::new();
+            volume_params.filesystem_name("SynoFS");
+            volume_params.sector_size(512);
+            volume_params.sectors_per_allocation_unit(1);
+            volume_params.max_component_length(255);
+            volume_params.file_info_timeout(1000);
+            volume_params.case_sensitive_search(false);
+            volume_params.unicode_on_disk(true);
+            volume_params.persistent_acls(false);
+            // Unique serial per mount so the Windows MountManager never reuses a
+            // stale Volume GUID from a previous (now-dead) WinFsp mount, which
+            // would cause STATUS_OBJECT_NAME_COLLISION on the next mount attempt.
+            let serial = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0xdeadbeef);
+            volume_params.volume_serial_number(serial);
+
+            let fs_params = FileSystemParams::default_params(volume_params);
+            let fs_ctx = winfs::SynologyWinFs::new(worker_client, rt.clone());
+            let mut host = match FileSystemHost::new_with_options(fs_params, fs_ctx) {
+                Ok(h) => h,
+                Err(e) => {
+                    let _ =
+                        ready_tx.send(Err(format!("Failed to create WinFsp filesystem ({e:?})")));
+                    return;
+                }
+            };
+            if let Err(e) = host.mount(&worker_mp) {
+                let _ = ready_tx.send(Err(format!(
+                    "Failed to mount on {} ({e:?}): ensure the drive letter is not already in use",
+                    worker_mp.display()
+                )));
+                return;
+            }
+            if let Err(e) = host.start() {
+                let _ = ready_tx.send(Err(format!("Failed to start WinFsp dispatcher ({e:?})")));
+                return;
+            }
+
+            info!("Mounted at {}", worker_mp.display());
+            let _ = ready_tx.send(Ok(()));
+
+            // Park until stop() signals (or the sender is dropped), then tear down.
+            let _ = shutdown_rx.recv();
+            info!("Unmounting {}…", worker_mp.display());
+            host.stop();
+            host.unmount();
+        })
+        .map_err(|e| SynoFsError::Io(format!("failed to spawn WinFsp worker: {e}")))?;
+
+    match ready_rx.recv() {
+        Ok(Ok(())) => Ok(MountHandle {
+            client,
+            inner: PlatformMount {
+                shutdown: Some(shutdown_tx),
+                worker: Some(worker),
+            },
+        }),
+        Ok(Err(msg)) => {
+            let _ = worker.join();
+            Err(SynoFsError::Io(msg))
+        }
+        Err(_) => {
+            let _ = worker.join();
+            Err(SynoFsError::Io(
+                "WinFsp worker exited before mounting".to_string(),
+            ))
+        }
+    }
+}

--- a/rust/synology-filestation-fuse/src/lib.rs
+++ b/rust/synology-filestation-fuse/src/lib.rs
@@ -57,23 +57,27 @@ pub fn is_otp_required(e: &SynoFsError) -> bool {
     matches!(e, SynoFsError::ApiError(403 | 404))
 }
 
-/// A live mount. Dropping or calling [`MountHandle::stop`] unmounts the
-/// filesystem and joins the background worker. The handle keeps the Tokio
-/// runtime handle and client alive for the lifetime of the mount.
+/// A live mount. Dropping the handle — or calling [`MountHandle::stop`], which
+/// is just an explicit drop — unmounts the filesystem and joins the background
+/// worker (the real work lives in `impl Drop for PlatformMount`, per platform).
+/// The handle keeps the Tokio runtime handle and client alive for the lifetime
+/// of the mount.
 pub struct MountHandle {
     // The client is held so the session's strong reference outlives the caller
     // dropping theirs; the FUSE/WebDAV/WinFsp callbacks all clone from it.
     #[allow(dead_code)]
     client: Arc<SynologyClient>,
+    #[allow(dead_code)]
     inner: PlatformMount,
 }
 
 impl MountHandle {
     /// Unmount the filesystem and wait for the background worker to finish.
-    /// Errors during unmount are logged and swallowed — there is nothing the
-    /// caller can usefully do, and a best-effort unmount is the right contract.
+    /// Equivalent to dropping the handle; provided as an explicit, readable
+    /// call site. Errors during unmount are logged and swallowed — a
+    /// best-effort unmount is the right contract.
     pub fn stop(self) {
-        self.inner.stop();
+        // Cleanup happens in `PlatformMount`'s `Drop` as `self` goes out of scope.
     }
 }
 
@@ -85,8 +89,8 @@ struct PlatformMount {
 }
 
 #[cfg(target_os = "linux")]
-impl PlatformMount {
-    fn stop(mut self) {
+impl Drop for PlatformMount {
+    fn drop(&mut self) {
         if let Some(session) = self.session.take() {
             if let Err(e) = session.umount_and_join() {
                 tracing::warn!("error during unmount: {e}");
@@ -194,8 +198,8 @@ struct PlatformMount {
 }
 
 #[cfg(target_os = "macos")]
-impl PlatformMount {
-    fn stop(mut self) {
+impl Drop for PlatformMount {
+    fn drop(&mut self) {
         use tracing::info;
         info!("Unmounting {}…", self.mountpoint.display());
         let mp = self.mountpoint.clone();
@@ -390,8 +394,8 @@ struct PlatformMount {
 }
 
 #[cfg(target_os = "windows")]
-impl PlatformMount {
-    fn stop(mut self) {
+impl Drop for PlatformMount {
+    fn drop(&mut self) {
         if let Some(tx) = self.shutdown.take() {
             let _ = tx.send(());
         }

--- a/rust/synology-filestation-fuse/src/main.rs
+++ b/rust/synology-filestation-fuse/src/main.rs
@@ -1,54 +1,12 @@
-use synology_filestation_core::{client, error};
-
-#[cfg(target_os = "linux")]
-mod cache;
-#[cfg(target_os = "linux")]
-mod fs;
-
-#[cfg(target_os = "macos")]
-mod webdav;
-
-#[cfg(target_os = "windows")]
-mod winfs;
-
-/// Add WinFsp's bin directory to PATH so the Windows loader can find
-/// winfsp-x64.dll when the delay-load triggers on the first WinFsp call.
-/// WinFsp installs to a non-standard location and does not add itself to PATH.
-#[cfg(target_os = "windows")]
-fn ensure_winfsp_in_path() {
-    let candidates = [
-        r"C:\Program Files (x86)\WinFsp\bin",
-        r"C:\Program Files\WinFsp\bin",
-    ];
-    for dir in &candidates {
-        if std::path::Path::new(dir).join("winfsp-x64.dll").exists() {
-            let current = std::env::var_os("PATH").unwrap_or_default();
-            let current_str = current.to_string_lossy();
-            if !current_str.to_lowercase().contains(&dir.to_lowercase()) {
-                std::env::set_var("PATH", format!("{};{}", dir, current_str));
-            }
-            return;
-        }
-    }
-}
-
 use std::io::{self, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-#[cfg(target_os = "windows")]
-use anyhow::Context;
 use clap::Parser;
 use tracing::info;
 
-use client::SynologyClient;
-
-#[cfg(target_os = "linux")]
-use cache::{InodeCache, ReadCache, READ_BLOCK_SIZE};
-#[cfg(target_os = "linux")]
-use fs::SynologyFS;
-#[cfg(target_os = "linux")]
-use fuser::{Config, MountOption, SessionACL};
+use synology_filestation_core::client::SynologyClient;
+use synology_filestation_fuse::{is_otp_required, spawn_mount, MountOptions};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -97,31 +55,12 @@ struct Args {
     log_level: String,
 }
 
-fn is_otp_required(e: &error::SynoFsError) -> bool {
-    matches!(e, error::SynoFsError::ApiError(403 | 404))
-}
-
 fn prompt(label: &str) -> anyhow::Result<String> {
     eprint!("{}: ", label);
     io::stderr().flush()?;
     let mut value = String::new();
     io::stdin().read_line(&mut value)?;
     Ok(value.trim().to_string())
-}
-
-/// Returns `true` when `/etc/fuse.conf` contains an uncommented
-/// `user_allow_other` line, meaning a non-root user is permitted to pass the
-/// `allow_other` option to `fusermount`/`fusermount3`.
-#[cfg(target_os = "linux")]
-fn fuse_conf_allows_other() -> bool {
-    let contents = match std::fs::read_to_string("/etc/fuse.conf") {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    contents.lines().any(|line| {
-        let trimmed = line.trim();
-        !trimmed.starts_with('#') && trimmed == "user_allow_other"
-    })
 }
 
 fn main() -> anyhow::Result<()> {
@@ -134,41 +73,6 @@ fn main() -> anyhow::Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?;
-
-    // On Windows, WinFsp creates the mountpoint directory itself (FILE_CREATE
-    // disposition) and deletes it on unmount.  The parent must exist but the
-    // directory itself must NOT exist when mounting.
-    #[cfg(target_os = "windows")]
-    {
-        if let Some(parent) = args.mountpoint.parent() {
-            if !parent.as_os_str().is_empty() && !parent.is_dir() {
-                anyhow::bail!(
-                    "On Windows the mountpoint's parent directory must exist, got: {}",
-                    args.mountpoint.display()
-                );
-            }
-        }
-        if args.mountpoint.exists() {
-            std::fs::remove_dir(&args.mountpoint).with_context(|| {
-                format!(
-                    "Mountpoint {} already exists and could not be removed \
-                     (is it still mounted?)",
-                    args.mountpoint.display()
-                )
-            })?;
-        }
-    }
-
-    // On macOS we mount via Finder which always places volumes under /Volumes/.
-    // Require that the user provides a path there so they get a predictable name.
-    #[cfg(target_os = "macos")]
-    if !args.mountpoint.starts_with("/Volumes/") {
-        anyhow::bail!(
-            "On macOS the mountpoint must be under /Volumes/ (e.g. /Volumes/nas), \
-             got: {}",
-            args.mountpoint.display()
-        );
-    }
 
     info!(
         "Connecting to Synology NAS at {}://{}:{}",
@@ -198,252 +102,20 @@ fn main() -> anyhow::Result<()> {
 
     info!("Logged in successfully");
 
-    #[cfg(target_os = "linux")]
-    {
-        let cache = Arc::new(InodeCache::new(args.cache_ttl));
-        let max_blocks = (args.read_cache_mb * 1024 * 1024) / READ_BLOCK_SIZE;
-        let read_cache = Arc::new(ReadCache::new(READ_BLOCK_SIZE, max_blocks.max(1)));
-        let handle = rt.handle().clone();
-        let uid = unsafe { libc::getuid() };
-        let gid = unsafe { libc::getgid() };
+    let opts = MountOptions {
+        cache_ttl: args.cache_ttl,
+        read_cache_mb: args.read_cache_mb,
+    };
+    let handle = spawn_mount(client.clone(), rt.handle().clone(), args.mountpoint, opts)?;
 
-        info!(
-            "Read cache: {} MiB ({} blocks × {} MiB)",
-            args.read_cache_mb,
-            max_blocks,
-            READ_BLOCK_SIZE / (1024 * 1024)
-        );
+    // Block until Ctrl-C, then unmount and log out — preserving the previous
+    // foreground CLI behaviour now that the mount itself runs in the background.
+    rt.block_on(tokio::signal::ctrl_c())?;
+    info!("Signal received, unmounting…");
+    handle.stop();
 
-        let fs = SynologyFS::new(client.clone(), cache, read_cache, handle, uid, gid);
-
-        // `allow_other` (kernel-level access for other users) moved off MountOption
-        // in fuser 0.17 — it's now expressed via Config::acl: SessionACL::All.
-        // As a non-root user this requires `user_allow_other` in /etc/fuse.conf;
-        // running as root always permits it.
-        let allow_other = uid == 0 || fuse_conf_allows_other();
-        let acl = if allow_other {
-            SessionACL::All
-        } else {
-            tracing::warn!(
-                "allow_other is not enabled: only the mounting user can access the \
-                 filesystem. To allow other users, add or uncomment \
-                 `user_allow_other` in /etc/fuse.conf."
-            );
-            SessionACL::Owner
-        };
-
-        let mut mount_options = vec![
-            MountOption::RW,
-            MountOption::FSName("synology-fuse".to_string()),
-        ];
-        // AutoUnmount requires AllowOther or AllowRoot per libfuse / fuser docs.
-        // Without that, mount2() will fail. Skip AutoUnmount when allow_other
-        // is unavailable so the mount still succeeds (the user just has to
-        // unmount manually with `fusermount -u <mountpoint>`).
-        if allow_other {
-            mount_options.push(MountOption::AutoUnmount);
-        }
-
-        let mut config = Config::default();
-        config.mount_options = mount_options;
-        config.acl = acl;
-
-        info!("Mounting shares on {}", args.mountpoint.display());
-        fuser::mount2(fs, &args.mountpoint, &config)?;
-    }
-
-    #[cfg(target_os = "macos")]
-    {
-        info!(
-            "Mounting shares on {} via WebDAV",
-            args.mountpoint.display()
-        );
-        rt.block_on(serve_and_mount(client.clone(), &args.mountpoint))?;
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        use winfsp::host::{FileSystemHost, FileSystemParams, VolumeParams};
-
-        info!(
-            "Mounting shares on {} via WinFsp",
-            args.mountpoint.display()
-        );
-
-        ensure_winfsp_in_path();
-        let _fsp = winfsp::winfsp_init().map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to initialise WinFsp ({:?}). \
-                 Ensure WinFsp is installed from https://winfsp.dev/rel/ \
-                 and the WinFsp.Launcher service is running.",
-                e
-            )
-        })?;
-
-        let mut volume_params = VolumeParams::new();
-        volume_params.filesystem_name("SynoFS");
-        volume_params.sector_size(512);
-        volume_params.sectors_per_allocation_unit(1);
-        volume_params.max_component_length(255);
-        volume_params.file_info_timeout(1000);
-        volume_params.case_sensitive_search(false);
-        volume_params.unicode_on_disk(true);
-        volume_params.persistent_acls(false);
-        // Unique serial per mount so the Windows MountManager never reuses a
-        // stale Volume GUID from a previous (now-dead) WinFsp mount, which
-        // would cause STATUS_OBJECT_NAME_COLLISION on the next mount attempt.
-        let serial = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos())
-            .unwrap_or(0xdeadbeef);
-        volume_params.volume_serial_number(serial);
-
-        let fs_params = FileSystemParams::default_params(volume_params);
-        let fs_ctx = winfs::SynologyWinFs::new(client.clone(), rt.handle().clone());
-        let mut host = FileSystemHost::new_with_options(fs_params, fs_ctx)
-            .map_err(|e| anyhow::anyhow!("Failed to create WinFsp filesystem ({:?})", e))?;
-        host.mount(&args.mountpoint).map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to mount on {} ({:?}): ensure the drive letter is not already in use",
-                args.mountpoint.display(),
-                e
-            )
-        })?;
-        host.start()
-            .map_err(|e| anyhow::anyhow!("Failed to start WinFsp dispatcher ({:?})", e))?;
-
-        info!("Mounted at {}", args.mountpoint.display());
-        rt.block_on(tokio::signal::ctrl_c())?;
-
-        info!("Signal received, unmounting {}…", args.mountpoint.display());
-        host.stop();
-        host.unmount();
-    }
-
-    info!("Unmounted, logging out");
+    info!("Logging out");
     rt.block_on(client.logout())?;
 
-    Ok(())
-}
-
-/// Start a local WebDAV server, then ask macOS Finder to mount it via
-/// AppleScript `mount volume`.  This works for regular users on any modern
-/// macOS version without root or kernel extensions.
-///
-/// The WebDAV server advertises the last path component of `mountpoint` as its
-/// `DAV:displayname`, which macOS Finder uses as the volume name.  The volume
-/// therefore appears at exactly the `/Volumes/<name>` path the user requested.
-#[cfg(target_os = "macos")]
-async fn serve_and_mount(
-    client: Arc<SynologyClient>,
-    mountpoint: &std::path::Path,
-) -> anyhow::Result<()> {
-    use std::convert::Infallible;
-
-    use dav_server::{fakels::FakeLs, DavHandler};
-    use hyper::server::conn::http1;
-    use hyper_util::rt::TokioIo;
-    use webdav::SynologyDavFs;
-
-    // Extract the desired volume name from the last component of the path
-    // (e.g. "/Volumes/nas" → "nas") and use it as a URL path prefix so that
-    // macOS names the mounted volume correctly.
-    let volume_name = mountpoint
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let path_prefix = format!("/{}", volume_name);
-
-    let handler = Arc::new(
-        DavHandler::builder()
-            .filesystem(Box::new(SynologyDavFs::new(client, path_prefix.clone())))
-            .locksystem(FakeLs::new())
-            .build_handler(),
-    );
-
-    // Bind to a kernel-assigned port on localhost.
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
-    let port = listener.local_addr()?.port();
-    // Include the volume name as a path component so macOS uses it as the
-    // volume name when mounting (e.g. http://127.0.0.1:PORT/nas/ → /Volumes/nas).
-    let url = format!("http://127.0.0.1:{}{}/", port, path_prefix);
-
-    info!("WebDAV server listening on {}", url);
-
-    // Start the accept loop BEFORE calling osascript so that Finder's probe
-    // requests are answered immediately.
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let handler_srv = handler.clone();
-    let server_task = tokio::spawn(async move {
-        let mut shutdown_rx = shutdown_rx;
-        loop {
-            tokio::select! {
-                result = listener.accept() => {
-                    let (stream, _addr) = match result {
-                        Ok(r) => r,
-                        Err(e) => { tracing::debug!("accept error: {}", e); break; }
-                    };
-                    let io = TokioIo::new(stream);
-                    let h = handler_srv.clone();
-                    tokio::spawn(async move {
-                        let svc = hyper::service::service_fn(move |req| {
-                            let h = h.clone();
-                            async move { Ok::<_, Infallible>(h.handle(req).await) }
-                        });
-                        if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
-                            tracing::debug!("WebDAV connection closed: {}", e);
-                        }
-                    });
-                }
-                _ = &mut shutdown_rx => {
-                    info!("WebDAV server shutting down");
-                    break;
-                }
-            }
-        }
-    });
-
-    // Remove a stale mount-point directory left over from a previous run.
-    // If the directory is actually still mounted this will fail (EBUSY/EPERM),
-    // which is fine — we leave it alone and let osascript fail with a clear message.
-    if mountpoint.is_dir() && !mountpoint.is_symlink() {
-        let _ = std::fs::remove_dir(mountpoint);
-    }
-
-    // Ask Finder to mount the volume via AppleScript.
-    let script = format!("mount volume \"{}\"", url);
-    let out = tokio::process::Command::new("osascript")
-        .args(["-e", &script])
-        .output()
-        .await?;
-
-    if !out.status.success() {
-        let _ = shutdown_tx.send(());
-        server_task.await.ok();
-        anyhow::bail!(
-            "osascript mount failed ({}): {}",
-            out.status,
-            String::from_utf8_lossy(&out.stderr).trim()
-        );
-    }
-
-    info!("Mounted at {}", mountpoint.display());
-
-    // Ctrl-C → unmount and stop serving.
-    let mp = mountpoint.to_path_buf();
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        info!("Signal received, unmounting {}…", mp.display());
-        let _ = tokio::process::Command::new("diskutil")
-            .args(["unmount", &mp.to_string_lossy()])
-            .status()
-            .await;
-        // macOS does not always remove the /Volumes/<name> directory after
-        // unmounting a WebDAV volume.  Remove it ourselves if it is now empty.
-        let _ = std::fs::remove_dir(&mp);
-        let _ = shutdown_tx.send(());
-    });
-
-    server_task.await.ok();
     Ok(())
 }


### PR DESCRIPTION
## Summary

Replaces the GUI's **CLI-subprocess** model with an **in-process C ABI binding**. The Avalonia GUI now P/Invokes a new `synology-filestation-ffi` cdylib instead of spawning `synology-filestation-fuse` and scraping its stdout/stderr.

This unlocks the things the subprocess model couldn't do: a real connecting **spinner**, a **Test Connection** button, **typed errors** (with DSM codes) instead of log scraping, a clean OTP flow (login once, reused for the mount), and a **pre-mount file browser** with transfer progress.

> **Design trade-off (intentional):** the mount now runs in-process, so a panic/hang in the FUSE/WinFsp layer can affect the GUI. Mitigated with `catch_unwind` at every FFI entry point and on the Windows worker thread. The standalone CLI is unchanged and still ships for terminal users.

## What changed

**Rust**
- `rust/synology-filestation-fuse` gains a **library target**: non-blocking `spawn_mount`/`MountHandle` (Linux `BackgroundSession`, macOS WebDAV task + oneshot, Windows host worker thread). `main.rs` is now a thin CLI shell with **identical behaviour**.
- New **`rust/synology-filestation-ffi`** cdylib — the C ABI: `syno_connect` (returns `OtpRequired` so the GUI prompts and retries), browse, ranged-streaming download + coarse upload with progress callbacks, delete/mkdir/rename, mount/unmount, and a `tracing`→C log callback. Typed `SynoError` (status + DSM code) mirrors the PyO3 mapping; every export wraps `catch_unwind`. Integration-tested against a mock DSM.

**.NET GUI**
- `Interop/NativeMethods.cs` (`LibraryImport` + native-library resolver) and `Services/SynoClient.cs` (typed `SynoException`/`OtpRequiredException`, JSON → `SynoFileInfo`); `MountService` rewritten over the FFI.
- `IsConnecting` spinner, **Test Connection**, typed OTP retry, and a pre-mount **file browser** with transfer progress (`FileBrowserWindow`/`ViewModel`, `PromptWindow`).

**Packaging / CI**
- Build & bundle the cdylib in CI, the `.deb`/`.pkg`/`.msi`, and the Nix flake (`SYNOFS_NATIVE_DIR` on the GUI wrapper).

**Incidental fix**
- Align `Avalonia.Desktop`/`Fonts.Inter` to **12.0.2** to match the core (fixes a startup `TypeLoadException` from the mixed 11.2.3/12.0.2 set); switch deprecated `Watermark` → `PlaceholderText`.

## Testing

- Rust: `cargo clippy --workspace -D warnings`, `cargo fmt --check`, all tests (52 core + 4 FFI) ✅
- .NET: `dotnet test` (46) ✅, `dotnet format --verify-no-changes` ✅
- Nix: `nix build .#synology-filestation-ffi` and `.#synologyfuse-gui` ✅; launcher exports `SYNOFS_NATIVE_DIR` at the cdylib ✅

**Verified on Linux.** The macOS/Windows mount paths and FFI compile only on those OSes — written to mirror the original code, exercised by the matrix CI runners. GUI runtime behaviour (spinner/OTP/browse) needs a display + a real NAS and wasn't exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
