### PR TITLE
build(deps): bump winfsp to 0.13 (+ FineGuard fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,9 +2714,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winfsp"
-version = "0.12.4+winfsp-2.1"
+version = "0.13.0+winfsp-2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51325fc20d218567a903cd5c382ad7d5a765f6860043f9c7d9ee1e907c5b75f6"
+checksum = "86829821fff6ed3bc1ace8a0c9a67a5a63a121a9f0a025929ffd5428bad1fa62"
 dependencies = [
  "bytemuck",
  "parking_lot",

--- a/rust/synology-filestation-fuse/Cargo.toml
+++ b/rust/synology-filestation-fuse/Cargo.toml
@@ -40,11 +40,11 @@ hyper-util   = { version = "0.1", features = ["tokio"] }
 futures-util = "0.3"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winfsp     = "0.12"
+winfsp     = "0.13"
 widestring = "1"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
-winfsp = "0.12"
+winfsp = "0.13"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/rust/synology-filestation-fuse/src/lib.rs
+++ b/rust/synology-filestation-fuse/src/lib.rs
@@ -451,7 +451,7 @@ pub fn spawn_mount(
     let worker = std::thread::Builder::new()
         .name("synofs-winfsp".to_string())
         .spawn(move || {
-            use winfsp::host::{FileSystemHost, FileSystemParams, VolumeParams};
+            use winfsp::host::{FileSystemHost, FileSystemParams, FineGuard, VolumeParams};
 
             let init = match winfsp::winfsp_init() {
                 Ok(i) => i,
@@ -485,14 +485,20 @@ pub fn spawn_mount(
 
             let fs_params = FileSystemParams::default_params(volume_params);
             let fs_ctx = winfs::SynologyWinFs::new(worker_client, rt.clone());
-            let mut host = match FileSystemHost::new_with_options(fs_params, fs_ctx) {
-                Ok(h) => h,
-                Err(e) => {
-                    let _ =
-                        ready_tx.send(Err(format!("Failed to create WinFsp filesystem ({e:?})")));
-                    return;
-                }
-            };
+            // winfsp 0.13 made FileSystemHost generic over an operation-guard
+            // strategy and split start() across the FineGuard/CoarseGuard impls,
+            // so the guard must be named to disambiguate. FineGuard (the default)
+            // dispatches callbacks concurrently — matching 0.12's behaviour — and
+            // both SynologyWinFs and its FileContext are Sync, as it requires.
+            let mut host: FileSystemHost<winfs::SynologyWinFs, FineGuard> =
+                match FileSystemHost::new_with_options(fs_params, fs_ctx) {
+                    Ok(h) => h,
+                    Err(e) => {
+                        let _ = ready_tx
+                            .send(Err(format!("Failed to create WinFsp filesystem ({e:?})")));
+                        return;
+                    }
+                };
             if let Err(e) = host.mount(&worker_mp) {
                 let _ = ready_tx.send(Err(format!(
                     "Failed to mount on {} ({e:?}): ensure the drive letter is not already in use",


### PR DESCRIPTION
Bumps winfsp 0.12 → 0.13 **and** applies the code change 0.13 requires, which dependabot #75 (version-only) was missing.

winfsp 0.13 parameterised `FileSystemHost<T, S: OperationGuardStrategy = FineGuard>` and split `start()` across the `FineGuard`/`CoarseGuard` impls, so `host.start()` became ambiguous (E0034) — the `build-windows` failure on #75. This pins the host to `FineGuard` (concurrent dispatch, matching 0.12; `SynologyWinFs` + its `FileContext` are `Sync`).

Supersedes #75. Windows-only change, verified via CI build-windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)