### PR TITLE
feat: add in-process SMB read transport (synology-filestation-smb)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +131,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +176,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -146,6 +192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -174,6 +229,18 @@ checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "ccm"
+version = "0.6.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edea5ea70a1285565ac264767613d6c88351a9a0557e7af793a0942590baaed"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -206,6 +273,17 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout",
 ]
 
 [[package]]
@@ -250,7 +328,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -260,10 +338,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac78aa94ce13e432b332a4d1bf2eff167d3a2520188ee05b337180a42fd2e62e"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -272,10 +373,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -315,6 +431,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "dav-server"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +488,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d7a944e61df464668c5f51f56cc667396a8821434273112948ea0b66e405d7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,7 +522,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -377,8 +531,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -389,7 +555,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -523,7 +689,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -601,8 +767,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -657,7 +833,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -680,6 +856,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "htmlescape"
@@ -731,6 +916,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -949,6 +1143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,12 +1254,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "md4"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd76fb0fd6b2e4be62a73f8e0858ca97f81babcb1af322dcaca196f735f17f80"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1194,7 +1425,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1249,6 +1480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,6 +1512,17 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1303,7 +1555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1395,7 +1647,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1408,7 +1660,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1494,7 +1746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1504,7 +1756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1515,6 +1767,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1542,7 +1800,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1741,7 +1999,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1776,8 +2034,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1816,6 +2096,33 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smb2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b40c52123c3f76b299d42489961543dc7713775c71d7ee4f880c853787c3c4"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "ccm",
+ "cmac",
+ "digest 0.11.3",
+ "futures-util",
+ "getrandom 0.4.2",
+ "hmac",
+ "log",
+ "lz4_flex",
+ "md-5",
+ "md4",
+ "num_enum",
+ "pbkdf2",
+ "sha1 0.11.0",
+ "sha2",
+ "thiserror",
+ "tokio",
+]
 
 [[package]]
 name = "socket2"
@@ -1863,6 +2170,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-core"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "bytes",
  "libc",
@@ -1900,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-fuse"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1926,8 +2244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "synology-filestation-smb"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "smb2",
+ "synology-filestation-core",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "synology_filestation"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
@@ -1945,7 +2274,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1977,7 +2306,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2039,7 +2368,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2159,7 +2488,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2208,10 +2537,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "twox-hash"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -2236,6 +2571,16 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "untrusted"
@@ -2369,7 +2714,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2540,7 +2885,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2551,7 +2896,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2799,7 +3144,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2815,7 +3160,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2906,7 +3251,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2927,7 +3272,7 @@ checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2947,7 +3292,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2987,7 +3332,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "rust/synology-filestation-core",
     "rust/synology-filestation-fuse",
     "rust/synology-filestation-ffi",
+    "rust/synology-filestation-smb",
     "python/synology_filestation",
 ]

--- a/rust/synology-filestation-smb/Cargo.toml
+++ b/rust/synology-filestation-smb/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "synology-filestation-smb"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "In-process SMB read transport for the Synology FileStation client — bypasses the HTTP Download API to protect the NAS's shared synoscgi backend."
+repository = "https://github.com/UCSD-E4E/synology-filestation"
+# Not published to crates.io yet; consumed in-tree once wired into core/python.
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# Pure-Rust SMB2/3 client (no C deps): SMB3 + signing + AES encryption + NTLMv2,
+# validated against the AD-joined, SMB3-only e4e-nas.
+smb2 = "0.13"
+bytes = "1"
+tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+tracing = "0.1"
+# Shared error model so SMB failures classify the same way HTTP ones do.
+synology-filestation-core = { path = "../synology-filestation-core" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/rust/synology-filestation-smb/src/error.rs
+++ b/rust/synology-filestation-smb/src/error.rs
@@ -1,0 +1,132 @@
+//! Map `smb2` errors onto the workspace-wide [`SynoFsError`] so SMB failures
+//! classify the same way HTTP ones do.
+//!
+//! The important property preserved here is the **transient-vs-definitive**
+//! split, readable via [`SynoFsError::category`]:
+//!
+//! * connection loss / timeout / session-expiry / sharing-violation →
+//!   [`SynoFsError::Io`] (category `Transport`) — a future transport-selection
+//!   layer treats this as "SMB unhealthy, fall back to the HTTP path";
+//! * not-found / permission → definitive; they must propagate unchanged so we
+//!   never mask a real "file isn't there" behind a retry or a fallback.
+
+use smb2::ErrorKind;
+use synology_filestation_core::SynoFsError;
+
+/// Map an [`smb2::Error`] to a [`SynoFsError`].
+pub fn to_syno_error(err: &smb2::Error) -> SynoFsError {
+    kind_to_syno(err.kind(), &err.to_string())
+}
+
+/// Map `smb2`'s high-level [`ErrorKind`] to a [`SynoFsError`]. `context` is the
+/// human-readable detail carried into the `Io` variants.
+pub(crate) fn kind_to_syno(kind: ErrorKind, context: &str) -> SynoFsError {
+    match kind {
+        ErrorKind::NotFound => SynoFsError::NotFound,
+        // Bad/rejected credentials, no access, or a signing requirement all mean
+        // "this principal can't read it" to a caller.
+        ErrorKind::AccessDenied | ErrorKind::AuthRequired | ErrorKind::SigningRequired => {
+            SynoFsError::PermissionDenied
+        }
+        ErrorKind::AlreadyExists => SynoFsError::AlreadyExists,
+        ErrorKind::DiskFull => SynoFsError::NoSpace,
+        ErrorKind::Unsupported => SynoFsError::NotSupported,
+        // Caller/programmer errors: wrong entry type, or a single-read method
+        // used on an oversized file (we always use the chunked reads, so this
+        // shouldn't occur — surface as InvalidArg rather than hide it).
+        ErrorKind::IsADirectory | ErrorKind::NotADirectory | ErrorKind::TooLarge => {
+            SynoFsError::InvalidArg
+        }
+        // Transient / transport — category `Transport`, i.e. "fall back".
+        ErrorKind::ConnectionLost
+        | ErrorKind::TimedOut
+        | ErrorKind::Io
+        | ErrorKind::SessionExpired
+        | ErrorKind::SharingViolation
+        | ErrorKind::DfsReferral
+        | ErrorKind::InvalidData
+        | ErrorKind::Cancelled => SynoFsError::Io(format!("smb: {context}")),
+        // `ErrorKind` is #[non_exhaustive]: unknown/future kinds are treated as
+        // transport failures (safe default — the caller can fall back).
+        _ => SynoFsError::Io(format!("smb: {context}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use synology_filestation_core::error::ErrorCategory;
+
+    fn cat(kind: ErrorKind) -> ErrorCategory {
+        kind_to_syno(kind, "detail").category()
+    }
+
+    #[test]
+    fn definitive_kinds_map_to_their_categories() {
+        assert_eq!(cat(ErrorKind::NotFound), ErrorCategory::NotFound);
+        assert_eq!(
+            cat(ErrorKind::AccessDenied),
+            ErrorCategory::PermissionDenied
+        );
+        assert_eq!(
+            cat(ErrorKind::AuthRequired),
+            ErrorCategory::PermissionDenied
+        );
+        assert_eq!(
+            cat(ErrorKind::SigningRequired),
+            ErrorCategory::PermissionDenied
+        );
+        assert_eq!(cat(ErrorKind::AlreadyExists), ErrorCategory::AlreadyExists);
+        assert_eq!(cat(ErrorKind::DiskFull), ErrorCategory::NoSpace);
+        assert_eq!(cat(ErrorKind::Unsupported), ErrorCategory::NotSupported);
+        assert_eq!(cat(ErrorKind::IsADirectory), ErrorCategory::InvalidArg);
+        assert_eq!(cat(ErrorKind::NotADirectory), ErrorCategory::InvalidArg);
+        assert_eq!(cat(ErrorKind::TooLarge), ErrorCategory::InvalidArg);
+    }
+
+    #[test]
+    fn transport_kinds_map_to_transport_so_selection_can_fall_back() {
+        for kind in [
+            ErrorKind::ConnectionLost,
+            ErrorKind::TimedOut,
+            ErrorKind::Io,
+            ErrorKind::SessionExpired,
+            ErrorKind::SharingViolation,
+            ErrorKind::DfsReferral,
+            ErrorKind::InvalidData,
+            ErrorKind::Cancelled,
+        ] {
+            assert_eq!(cat(kind), ErrorCategory::Transport, "{kind:?}");
+        }
+    }
+
+    #[test]
+    fn to_syno_error_wires_kind_through_for_constructible_errors() {
+        // A missing-file lookup stays definitive (NotFound category), never
+        // Transport — so it won't be silently retried/fallback-masked.
+        assert_eq!(
+            to_syno_error(&smb2::Error::Timeout).category(),
+            ErrorCategory::Transport
+        );
+        assert_eq!(
+            to_syno_error(&smb2::Error::Disconnected).category(),
+            ErrorCategory::Transport
+        );
+        assert_eq!(
+            to_syno_error(&smb2::Error::Auth {
+                message: "bad password".into(),
+            })
+            .category(),
+            ErrorCategory::PermissionDenied
+        );
+        // Using a single-read method on an oversized file is a programmer error.
+        assert_eq!(
+            to_syno_error(&smb2::Error::FileTooLargeForSingleRead {
+                size: 15_277_437,
+                max_read: 8_388_608,
+            })
+            .category(),
+            ErrorCategory::InvalidArg
+        );
+    }
+}

--- a/rust/synology-filestation-smb/src/lib.rs
+++ b/rust/synology-filestation-smb/src/lib.rs
@@ -1,0 +1,34 @@
+//! In-process SMB read transport for the Synology FileStation client.
+//!
+//! Reads NAS file bytes over SMB3 directly from the process — pure Rust, no OS
+//! mount, no privileges, cross-platform — so bulk staging bypasses the
+//! FileStation HTTP Download API and the shared `synoscgi` backend that a
+//! task-per-file download fan-out can saturate.
+//!
+//! Validated against the AD-joined, SMB3-only `e4e-nas` (see the design notes
+//! and the `spikes/smb-spike` feasibility spike). This crate is the **transport
+//! only**; preferring it over HTTP with a health-based fallback is a separate
+//! selection layer.
+//!
+//! ```no_run
+//! # async fn demo() -> Result<(), synology_filestation_core::SynoFsError> {
+//! use synology_filestation_smb::{SmbConfig, SmbTransport};
+//!
+//! let mut cfg = SmbConfig::new("e4e-nas.ucsd.edu", "c.crutchfield.642", "•••");
+//! cfg.domain = "KRG".into(); // AD account
+//! let smb = SmbTransport::connect(&cfg).await?;
+//!
+//! let meta = smb.stat("/fishsense_data/REEF/x.orf").await?;
+//! let bytes = smb.read("/fishsense_data/REEF/x.orf", 0, meta.size).await?;
+//! # let _ = bytes;
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod error;
+pub mod path;
+pub mod transport;
+
+pub use error::to_syno_error;
+pub use path::SmbPath;
+pub use transport::{FileMeta, SmbConfig, SmbTransport};

--- a/rust/synology-filestation-smb/src/path.rs
+++ b/rust/synology-filestation-smb/src/path.rs
@@ -1,0 +1,109 @@
+//! FileStation logical path → SMB (share, share-relative path) decomposition.
+//!
+//! FileStation speaks logical paths like `/fishsense_data/REEF/x.orf`; SMB
+//! addresses the same bytes as a **share** (`fishsense_data`) plus a
+//! share-relative path (`REEF/x.orf`). The share is always the first path
+//! component — so no mount-root mapping config is needed, unlike an OS mount.
+//!
+//! Paths stay forward-slash separated here; the `smb2` layer converts `/` → `\`
+//! on the wire.
+
+use synology_filestation_core::SynoFsError;
+
+/// An SMB location: a share name plus a share-relative path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmbPath {
+    /// SMB share name (the first component of the logical path).
+    pub share: String,
+    /// Share-relative path (forward-slash separated). Empty = the share root.
+    pub path: String,
+}
+
+impl SmbPath {
+    /// Decompose a FileStation logical path into `(share, relative path)`.
+    ///
+    /// A leading slash is optional and a trailing slash is trimmed. The
+    /// remainder may be empty (the share root). Returns
+    /// [`SynoFsError::InvalidArg`] when there is no share component
+    /// (`""`, `"/"`, all-slashes).
+    pub fn from_logical(logical: &str) -> Result<Self, SynoFsError> {
+        let trimmed = logical.trim_matches('/');
+        if trimmed.is_empty() {
+            return Err(SynoFsError::InvalidArg);
+        }
+        let (share, path) = match trimmed.split_once('/') {
+            Some((s, p)) => (s, p),
+            None => (trimmed, ""),
+        };
+        if share.is_empty() {
+            return Err(SynoFsError::InvalidArg);
+        }
+        Ok(SmbPath {
+            share: share.to_string(),
+            path: path.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ok(logical: &str) -> SmbPath {
+        SmbPath::from_logical(logical).expect("should decompose")
+    }
+
+    #[test]
+    fn nested_path_with_leading_slash() {
+        let p = ok("/fishsense_data/REEF/data/x.orf");
+        assert_eq!(p.share, "fishsense_data");
+        assert_eq!(p.path, "REEF/data/x.orf");
+    }
+
+    #[test]
+    fn leading_slash_is_optional_and_equivalent() {
+        assert_eq!(ok("/share/sub/f"), ok("share/sub/f"));
+    }
+
+    #[test]
+    fn share_root_has_empty_path() {
+        assert_eq!(
+            ok("/photos"),
+            SmbPath {
+                share: "photos".into(),
+                path: "".into()
+            }
+        );
+    }
+
+    #[test]
+    fn trailing_slash_is_trimmed() {
+        assert_eq!(ok("/photos/"), ok("/photos"));
+        assert_eq!(ok("/photos/2026/"), ok("/photos/2026"));
+    }
+
+    #[test]
+    fn spaces_in_path_are_preserved() {
+        // The real REEF path has a space — must survive verbatim (SMB paths
+        // allow spaces; the smb2 layer handles the `/`→`\` conversion).
+        let p = ok("/fishsense_data/REEF/08_2023/080123_FSL-01 Photos/P8010001.ORF");
+        assert_eq!(p.share, "fishsense_data");
+        assert_eq!(p.path, "REEF/08_2023/080123_FSL-01 Photos/P8010001.ORF");
+    }
+
+    #[test]
+    fn empty_and_root_are_invalid() {
+        assert!(matches!(
+            SmbPath::from_logical(""),
+            Err(SynoFsError::InvalidArg)
+        ));
+        assert!(matches!(
+            SmbPath::from_logical("/"),
+            Err(SynoFsError::InvalidArg)
+        ));
+        assert!(matches!(
+            SmbPath::from_logical("///"),
+            Err(SynoFsError::InvalidArg)
+        ));
+    }
+}

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -1,0 +1,196 @@
+//! [`SmbTransport`] — an in-process SMB read path for NAS files.
+//!
+//! Reads bytes over SMB3 (pure Rust, no OS mount, no privileges,
+//! cross-platform) so bulk staging bypasses the FileStation HTTP Download API
+//! and its shared `synoscgi` backend. This crate is the transport only; a
+//! future selection layer (in core / the Python bindings) will prefer it and
+//! fall back to the throttled HTTP path when SMB is unavailable.
+//!
+//! All ops on one transport share a single SMB connection and are serialized
+//! behind a mutex — correct and simple. Concurrency across files would use a
+//! connection pool (future work).
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use bytes::Bytes;
+use smb2::{ClientConfig, SmbClient, Tree};
+use synology_filestation_core::SynoFsError;
+use tokio::sync::Mutex;
+
+use crate::error::to_syno_error;
+use crate::path::SmbPath;
+
+/// Connection parameters for [`SmbTransport::connect`].
+#[derive(Debug, Clone)]
+pub struct SmbConfig {
+    /// NAS host, either `host` or `host:port`. If no port is present, [`port`]
+    /// is appended.
+    ///
+    /// [`port`]: Self::port
+    pub host: String,
+    /// Port used when `host` carries none. SMB is 445.
+    pub port: u16,
+    /// Account name (the sAMAccountName for AD users, e.g. `c.crutchfield.642`).
+    pub username: String,
+    /// Password (kept in memory by the SMB client for the session lifetime).
+    pub password: String,
+    /// NetBIOS domain for AD accounts (e.g. `KRG`); empty for local DSM users.
+    pub domain: String,
+    /// Connection/negotiate timeout.
+    pub timeout: Duration,
+}
+
+impl SmbConfig {
+    /// A config with the SMB defaults (port 445, 10 s timeout, no domain).
+    pub fn new(
+        host: impl Into<String>,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            host: host.into(),
+            port: 445,
+            username: username.into(),
+            password: password.into(),
+            domain: String::new(),
+            timeout: Duration::from_secs(10),
+        }
+    }
+
+    fn addr(&self) -> String {
+        if self.host.contains(':') {
+            self.host.clone()
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+}
+
+/// Minimal file metadata — enough for the verify-once integrity check that
+/// compares SMB against the FileStation API's `getinfo` before trusting SMB.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FileMeta {
+    pub size: u64,
+    pub is_directory: bool,
+}
+
+struct Inner {
+    client: SmbClient,
+    /// One attached `Tree` per share name, connected lazily on first use.
+    trees: HashMap<String, Tree>,
+}
+
+/// An authenticated SMB connection that reads NAS files.
+pub struct SmbTransport {
+    inner: Mutex<Inner>,
+}
+
+impl SmbTransport {
+    /// Connect + authenticate (SMB3 negotiate, NTLMv2, signing).
+    pub async fn connect(cfg: &SmbConfig) -> Result<Self, SynoFsError> {
+        let client = SmbClient::connect(ClientConfig {
+            addr: cfg.addr(),
+            timeout: cfg.timeout,
+            username: cfg.username.clone(),
+            password: cfg.password.clone(),
+            domain: cfg.domain.clone(),
+            auto_reconnect: false,
+            compression: true,
+            dfs_enabled: true,
+            dfs_target_overrides: HashMap::new(),
+        })
+        .await
+        .map_err(|e| to_syno_error(&e))?;
+        Ok(Self {
+            inner: Mutex::new(Inner {
+                client,
+                trees: HashMap::new(),
+            }),
+        })
+    }
+
+    /// Metadata for a logical path (`/share/sub/file`).
+    pub async fn stat(&self, logical: &str) -> Result<FileMeta, SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        ensure_tree(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        let info = client
+            .stat(tree, &loc.path)
+            .await
+            .map_err(|e| to_syno_error(&e))?;
+        Ok(FileMeta {
+            size: info.size,
+            is_directory: info.is_directory,
+        })
+    }
+
+    /// Read `length` bytes at `offset`. `length == 0` reads the whole file
+    /// (from `offset == 0`), mirroring the core HTTP client's `download`
+    /// contract. Ranged reads are chunked to the server's `MaxReadSize` by the
+    /// underlying SMB layer, so any `length` is valid.
+    pub async fn read(
+        &self,
+        logical: &str,
+        offset: u64,
+        length: u64,
+    ) -> Result<Bytes, SynoFsError> {
+        if length == 0 {
+            return self.read_full(logical).await;
+        }
+        let loc = SmbPath::from_logical(logical)?;
+        let guard = self.inner.lock().await;
+        // open_file_reader takes &SmbClient + &Tree (shared); ensure the tree
+        // under a short mutable reborrow, then read.
+        let mut guard = guard;
+        {
+            let Inner { client, trees } = &mut *guard;
+            ensure_tree(client, trees, &loc.share).await?;
+        }
+        let Inner { client, trees } = &*guard;
+        let tree = trees.get(&loc.share).expect("tree just ensured");
+        let reader = client
+            .open_file_reader(tree, &loc.path)
+            .await
+            .map_err(|e| to_syno_error(&e))?;
+        let data = reader
+            .read_at(offset, length)
+            .await
+            .map_err(|e| to_syno_error(&e))?;
+        Ok(Bytes::from(data))
+    }
+
+    /// Read an entire file. Uses the pipelined, chunked read so multi-MB `.ORF`
+    /// files (past the 8 MiB `MaxReadSize`) come back whole.
+    pub async fn read_full(&self, logical: &str) -> Result<Bytes, SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        ensure_tree(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        let data = client
+            .read_file_pipelined(tree, &loc.path)
+            .await
+            .map_err(|e| to_syno_error(&e))?;
+        Ok(Bytes::from(data))
+    }
+}
+
+/// Attach `share` if it isn't already, caching the `Tree`. Split borrows of the
+/// two `Inner` fields so callers can then use `client` and the tree together.
+async fn ensure_tree(
+    client: &mut SmbClient,
+    trees: &mut HashMap<String, Tree>,
+    share: &str,
+) -> Result<(), SynoFsError> {
+    if !trees.contains_key(share) {
+        let tree = client
+            .connect_share(share)
+            .await
+            .map_err(|e| to_syno_error(&e))?;
+        trees.insert(share.to_string(), tree);
+    }
+    Ok(())
+}

--- a/rust/synology-filestation-smb/tests/live_smb.rs
+++ b/rust/synology-filestation-smb/tests/live_smb.rs
@@ -1,0 +1,71 @@
+//! Live integration test against a real NAS — `#[ignore]`d by default because
+//! it needs credentials + reachability that CI doesn't have.
+//!
+//! Run it (mirrors `spikes/smb-spike`):
+//!
+//! ```text
+//! SMB2_HOST=e4e-nas.ucsd.edu SMB2_DOMAIN=KRG \
+//! SMB2_USER=c.crutchfield.642 SMB2_PASS='…' \
+//! SMB2_LOGICAL='/fishsense_data/REEF/.../P8010001.ORF' \
+//! nix develop ../.. -c cargo test -p synology-filestation-smb -- --ignored --nocapture
+//! ```
+//!
+//! It proves the transport end-to-end: connect + AD auth, stat, a ranged read,
+//! and a whole-file pipelined read, and checks the two read paths agree on the
+//! leading bytes.
+
+use synology_filestation_smb::{SmbConfig, SmbTransport};
+
+fn env(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+#[tokio::test]
+#[ignore = "needs a reachable NAS + credentials; run with --ignored"]
+async fn live_read_over_smb() {
+    let (host, user, pass, logical) = match (
+        env("SMB2_HOST"),
+        env("SMB2_USER"),
+        env("SMB2_PASS"),
+        env("SMB2_LOGICAL"),
+    ) {
+        (Some(h), Some(u), Some(p), Some(l)) => (h, u, p, l),
+        _ => panic!("set SMB2_HOST, SMB2_USER, SMB2_PASS, SMB2_LOGICAL"),
+    };
+
+    let mut cfg = SmbConfig::new(host, user, pass);
+    cfg.domain = env("SMB2_DOMAIN").unwrap_or_default();
+
+    let smb = SmbTransport::connect(&cfg)
+        .await
+        .expect("connect + auth should succeed");
+
+    let meta = smb.stat(&logical).await.expect("stat should succeed");
+    assert!(!meta.is_directory, "expected a file");
+    assert!(meta.size > 0, "expected a non-empty file");
+    println!("stat: {} bytes", meta.size);
+
+    // Ranged read (the transport's core operation).
+    let want = 262_144.min(meta.size);
+    let ranged = smb.read(&logical, 0, want).await.expect("ranged read");
+    assert_eq!(ranged.len() as u64, want, "ranged read length");
+
+    // Whole-file read (pipelined; handles files past MaxReadSize).
+    let full = smb.read_full(&logical).await.expect("whole-file read");
+    assert_eq!(
+        full.len() as u64,
+        meta.size,
+        "whole-file length matches stat"
+    );
+
+    // The two paths must agree on the overlapping prefix.
+    assert_eq!(
+        &full[..want as usize],
+        &ranged[..],
+        "ranged and whole-file reads disagree on the prefix"
+    );
+    println!(
+        "OK: ranged + whole-file reads agree; {} bytes total",
+        full.len()
+    );
+}


### PR DESCRIPTION
## Why

The NAS outage came from parallel FileStation HTTP **Download** calls saturating the appliance's shared `synoscgi` CGI backend. PR #124 added a throttle as the safety net; **this is the structural fix** the infra team recommended: read NAS bytes over **SMB** instead, bypassing `synoscgi` entirely.

Unlike an OS mount, this speaks SMB **in-process** (pure Rust, no `mount.cifs`, no privileges, cross-platform) — so it works in a plain Temporal-worker container.

## Validated against the real NAS

Feasibility spike confirmed end-to-end against the **AD-joined, SMB3-only** `e4e-nas`:
- SMB3 negotiate vs the hardened SMB3-only DSM ✔
- NTLMv2 + signing as an AD domain user (`KRG\…`) ✔
- share attach + `stat` ✔
- ranged read (`read_at`) and whole-file pipelined read (past the 8 MiB `MaxReadSize`) ✔

(Config facts from `KastnerRG/krg-infra`: `spec/e4e-nas/smb-globals.yml` min=max=SMB3, signing on, NTLMv1 off; `spec/e4e-nas/ad.yml` realm KRG.LOCAL. NFS was rejected — DSM winbind RID idmap vs the fleet's SSSD algorithmic mapping makes uid-based NFS unsafe here; SMB is SID-based.)

## What's in this PR

New workspace crate `rust/synology-filestation-smb` (built on the pure-Rust [`smb2`](https://crates.io/crates/smb2) crate):

| Module | Surface | Tests |
|---|---|---|
| `path` | `SmbPath::from_logical` — `/share/sub/file` → (share, relative) | 6 unit tests (slashes, share root, spaces, invalids) |
| `error` | `smb2::ErrorKind` → core `SynoFsError`, preserving transient-vs-definitive via `category()` | 3 unit tests over the full table |
| `transport` | `SmbTransport::{connect, stat, read (ranged), read_full (pipelined)}`; one connection, lazy per-share tree cache | `#[ignore]`d live integration test |

**Transport only — no consumer wiring.** Preferring SMB over HTTP with a health-based fallback (the network-mobility circuit breaker) is the follow-up PR, into core/Python.

## Tests

`cargo test -p synology-filestation-smb`: 9 unit tests + doc-test pass; live test is `ignored`. `cargo fmt` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

Run the live check against the NAS:
```bash
SMB2_HOST=e4e-nas.ucsd.edu SMB2_DOMAIN=KRG SMB2_USER=<user> SMB2_PASS='…' \
SMB2_LOGICAL='/fishsense_data/REEF/.../P8010001.ORF' \
nix develop . -c cargo test -p synology-filestation-smb -- --ignored --nocapture
```

## CI note

Adding the crate to the workspace means `nix flake check` will build it (pulls `smb2` + crypto deps). May need a small flake tweak if the nix job enumerates members explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)