### PR TITLE
feat: transparent SMB-preferred read/write with HTTP fallback (selection + auto-wiring)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,7 @@ dependencies = [
  "serde_json",
  "synology-filestation-core",
  "synology-filestation-fuse",
+ "synology-filestation-smb",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2236,6 +2237,7 @@ dependencies = [
  "serde",
  "serde_json",
  "synology-filestation-core",
+ "synology-filestation-smb",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2264,6 +2266,7 @@ dependencies = [
  "pyo3-async-runtimes",
  "pyo3-log",
  "synology-filestation-core",
+ "synology-filestation-smb",
  "tokio",
  "tracing-log",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,7 @@ dependencies = [
 name = "synology-filestation-core"
 version = "0.1.20"
 dependencies = [
+ "async-trait",
  "bytes",
  "libc",
  "reqwest",
@@ -2247,6 +2248,7 @@ dependencies = [
 name = "synology-filestation-smb"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes",
  "smb2",
  "synology-filestation-core",

--- a/python/synology_filestation/Cargo.toml
+++ b/python/synology_filestation/Cargo.toml
@@ -12,6 +12,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 synology-filestation-core = { path = "../../rust/synology-filestation-core", version = "0.1.16" }
+# In-process SMB backend. The client transparently prefers it over the HTTP
+# Download/Upload API when reachable, protecting the NAS's shared synoscgi
+# backend; falls back to HTTP automatically otherwise.
+synology-filestation-smb = { path = "../../rust/synology-filestation-smb" }
 
 # abi3-py310 lets a single Linux wheel cover Python 3.10 through whatever's
 # current. Tied to pyproject.toml's `requires-python = ">=3.10"` and the CI

--- a/python/synology_filestation/src/lib.rs
+++ b/python/synology_filestation/src/lib.rs
@@ -322,12 +322,37 @@ impl Client {
             backoff_max_ms,
         );
 
-        // Login failures are always AuthError regardless of the underlying
-        // DSM code: a 400 means "wrong password", a 408 means "OTP required",
-        // etc., but for the caller they're all "auth didn't work." Wrap in
-        // LoginFailed so synofs_to_pyerr routes to the AuthError class.
-        py.allow_threads(|| runtime.block_on(client.login(username, password, otp)))
-            .map_err(|e| synofs_to_pyerr(py, SynoFsError::LoginFailed(Box::new(e))))?;
+        // Log in, then transparently prefer SMB when it's reachable — bulk
+        // transfers then avoid the HTTP Download/Upload API (and the synoscgi
+        // backend it can saturate). `auto_connect` returns None on any failure,
+        // so this silently degrades to HTTP; it runs before the client is frozen
+        // into an Arc because injecting a backend consumes the client.
+        //
+        // Login failures are always AuthError regardless of the underlying DSM
+        // code (wrong password / OTP required / …); wrap in LoginFailed so
+        // synofs_to_pyerr routes to the AuthError class.
+        let rt = runtime.clone();
+        let client = py
+            .allow_threads(move || {
+                rt.block_on(async move {
+                    client
+                        .login(username, password, otp)
+                        .await
+                        .map_err(|e| SynoFsError::LoginFailed(Box::new(e)))?;
+                    let client = match synology_filestation_smb::auto_connect(
+                        host, username, password,
+                    )
+                    .await
+                    {
+                        Some(smb) => client
+                            .with_read_transport(smb.clone())
+                            .with_write_transport(smb),
+                        None => client,
+                    };
+                    Ok::<_, SynoFsError>(client)
+                })
+            })
+            .map_err(|e| synofs_to_pyerr(py, e))?;
 
         Ok(Self {
             inner: Arc::new(client),
@@ -621,6 +646,14 @@ impl AsyncClient {
                 .login(&username, &password, otp.as_deref())
                 .await
                 .map_err(|e| synofs_to_pyerr_gil(SynoFsError::LoginFailed(Box::new(e))))?;
+            // Transparently prefer SMB when reachable; None → HTTP only.
+            let client =
+                match synology_filestation_smb::auto_connect(&host, &username, &password).await {
+                    Some(smb) => client
+                        .with_read_transport(smb.clone())
+                        .with_write_transport(smb),
+                    None => client,
+                };
             Ok(AsyncClient {
                 inner: Arc::new(client),
             })

--- a/python/synology_filestation/tests/conftest.py
+++ b/python/synology_filestation/tests/conftest.py
@@ -8,10 +8,16 @@ mock the HTTP layer in Python because the requests are issued from Rust
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Iterator
 
 import pytest
 from pytest_httpserver import HTTPServer
+
+# The client now transparently prefers SMB when reachable. These tests exercise
+# the HTTP layer against a local mock server (no SMB), so disable the SMB probe
+# for determinism and speed — SMB behavior is covered by the Rust crate's tests.
+os.environ["SYNOLOGY_FS_SMB_DISABLE"] = "1"
 
 
 # Stock responses the tests assemble together. Keeping them in one place

--- a/rust/synology-filestation-core/Cargo.toml
+++ b/rust/synology-filestation-core/Cargo.toml
@@ -16,6 +16,7 @@ serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 bytes       = "1"
 tracing     = "0.1"
+async-trait = "0.1"
 
 # libc is only needed for the Linux errno mapping on SynoFsError, used by the
 # FUSE backend in the sibling crate. Gating it to Linux keeps the wheel build

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -809,7 +809,11 @@ impl SynologyClient {
         data: Vec<u8>,
         overwrite: bool,
     ) -> Result<(), SynoFsError> {
-        if !self.write_transports.is_empty() {
+        // Only route *replacing* writes through a write backend. A backend's
+        // `write` unconditionally replaces the file, so it can't honor
+        // `overwrite=false`'s "fail if the file already exists" contract —
+        // those go straight to the HTTP path, which does.
+        if overwrite && !self.write_transports.is_empty() {
             let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
             for entry in &self.write_transports {
                 let allowed = entry.breaker.lock().unwrap().allows(Instant::now());
@@ -2516,11 +2520,11 @@ mod tests {
 
     #[tokio::test]
     async fn upload_prefers_backend_then_falls_back_on_transient() {
-        // Healthy write backend serves the upload with no HTTP server present.
+        // Healthy write backend serves a replacing upload with no HTTP server.
         let ok_backend = FakeBackend::new(Behave::Ok(b""));
         let client = offline_client().with_write_transport(ok_backend.clone());
         client
-            .upload("/share", "f.bin", b"data".to_vec(), false)
+            .upload("/share", "f.bin", b"data".to_vec(), true)
             .await
             .unwrap();
         assert_eq!(ok_backend.call_count(), 1);
@@ -2537,13 +2541,39 @@ mod tests {
         let bad_backend = FakeBackend::new(Behave::Transient);
         let client = client_for(&server).with_write_transport(bad_backend.clone());
         client
-            .upload("/share", "f.bin", b"data".to_vec(), false)
+            .upload("/share", "f.bin", b"data".to_vec(), true)
             .await
             .unwrap();
         assert_eq!(
             bad_backend.call_count(),
             1,
             "attempted before HTTP fallback"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_overwrite_false_bypasses_write_backend() {
+        // A backend's write always replaces, so it can't honor overwrite=false's
+        // "fail if the file exists" contract — that write must go to HTTP, not
+        // silently clobber an existing file over SMB.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true, "data": {"blks": null}
+            })))
+            .mount(&server)
+            .await;
+        let backend = FakeBackend::new(Behave::Ok(b""));
+        let client = client_for(&server).with_write_transport(backend.clone());
+        client
+            .upload("/share", "f.bin", b"data".to_vec(), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.call_count(),
+            0,
+            "overwrite=false must skip the replacing write backend"
         );
     }
 }

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -1,12 +1,13 @@
 use bytes::Bytes;
 use reqwest::{multipart, Client};
 use std::path::Path;
-use std::sync::RwLock;
+use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex, Semaphore, SemaphorePermit};
 use tracing::{debug, warn};
 
 use crate::error::{dsm_code_to_category, ErrorCategory, SynoFsError};
+use crate::transport::{BreakerConfig, CircuitBreaker, ReadTransport, WriteTransport};
 use crate::types::{
     AuthData, CreateFolderData, GetInfoData, ListData, ListShareData, RenameData, SynoFileInfo,
     SynoResponse, UploadData, ADDITIONAL_FIELDS, SHARE_ADDITIONAL_FIELDS,
@@ -151,7 +152,23 @@ fn full_jitter(cap: Duration) -> Duration {
     cap.mul_f64(frac)
 }
 
-#[derive(Debug)]
+/// One injected backend plus the [`CircuitBreaker`] tracking its health. The
+/// breaker is a `std::sync::Mutex` (quick, non-async state mutation, never held
+/// across an `.await`).
+struct TransportEntry<T: ?Sized> {
+    transport: Arc<T>,
+    breaker: StdMutex<CircuitBreaker>,
+}
+
+impl<T: ?Sized> TransportEntry<T> {
+    fn new(transport: Arc<T>) -> Self {
+        Self {
+            transport,
+            breaker: StdMutex::new(CircuitBreaker::new(BreakerConfig::default())),
+        }
+    }
+}
+
 pub struct SynologyClient {
     http: Client,
     base_url: String,
@@ -166,6 +183,23 @@ pub struct SynologyClient {
     /// behavior; opt in via [`SynologyClient::with_auto_relogin`].
     auto_relogin: bool,
     creds: RwLock<Option<StoredCreds>>,
+    /// Injected read backends, tried in order before the HTTP Download API.
+    /// Empty (the default) = HTTP only, i.e. exactly today's behavior.
+    read_transports: Vec<TransportEntry<dyn ReadTransport>>,
+    /// Injected write backends, tried in order before the HTTP Upload API.
+    write_transports: Vec<TransportEntry<dyn WriteTransport>>,
+}
+
+impl std::fmt::Debug for SynologyClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SynologyClient")
+            .field("base_url", &self.base_url)
+            .field("auto_relogin", &self.auto_relogin)
+            .field("throttled", &self.throttle.is_some())
+            .field("read_transports", &self.read_transports.len())
+            .field("write_transports", &self.write_transports.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl SynologyClient {
@@ -200,7 +234,30 @@ impl SynologyClient {
             auto_relogin: false,
             creds: RwLock::new(None),
             throttle: None,
+            read_transports: Vec::new(),
+            write_transports: Vec::new(),
         }
+    }
+
+    /// Inject a [`ReadTransport`] backend (e.g. SMB). `download` will prefer it
+    /// over the HTTP Download API when its circuit breaker is closed, falling
+    /// back to HTTP (and any later backends) on transport failures. Call more
+    /// than once to register several backends; they are tried in the order
+    /// added, with HTTP last.
+    ///
+    /// Read/write call sites never change — this is the only place a consumer
+    /// opts a backend in.
+    pub fn with_read_transport(mut self, transport: Arc<dyn ReadTransport>) -> Self {
+        self.read_transports.push(TransportEntry::new(transport));
+        self
+    }
+
+    /// Inject a [`WriteTransport`] backend. `upload` will prefer it over the
+    /// HTTP Upload API when healthy, falling back to HTTP on transport failures.
+    /// The backend's `write` must be atomic so fallback is safe.
+    pub fn with_write_transport(mut self, transport: Arc<dyn WriteTransport>) -> Self {
+        self.write_transports.push(TransportEntry::new(transport));
+        self
     }
 
     /// Attach a [`ThrottleConfig`] that caps concurrency, spaces requests, and
@@ -599,18 +656,58 @@ impl SynologyClient {
         Ok(())
     }
 
-    /// Download file bytes, optionally with a byte range.
+    /// Read file bytes, preferring any injected [`ReadTransport`] backend (SMB,
+    /// …) over the HTTP Download API.
     ///
-    /// Retries up to 2 times on transient connection errors (e.g. the NAS closing a
-    /// keep-alive connection mid-stream while the response body is being read).
+    /// Backends are tried in registration order; on a transport failure
+    /// (`category() == Transport`) the backend's circuit breaker trips and we
+    /// fall back to the next backend, ending at the HTTP path. A definitive
+    /// error (not-found / permission) from a backend propagates unchanged — the
+    /// backend answered, so re-asking HTTP the same question is pointless.
+    ///
+    /// With no backends injected this is exactly the HTTP download — today's
+    /// behavior, unchanged.
+    pub async fn download(
+        &self,
+        path: &str,
+        offset: u64,
+        length: u64,
+    ) -> Result<Bytes, SynoFsError> {
+        for entry in &self.read_transports {
+            // Lock only to read/update breaker state — never held across await.
+            let allowed = entry.breaker.lock().unwrap().allows(Instant::now());
+            if !allowed {
+                continue;
+            }
+            match entry.transport.read(path, offset, length).await {
+                Ok(bytes) => {
+                    entry.breaker.lock().unwrap().on_success();
+                    return Ok(bytes);
+                }
+                Err(e) if e.category() == ErrorCategory::Transport => {
+                    warn!("read backend failed (transient), falling back: {e}");
+                    entry.breaker.lock().unwrap().on_failure(Instant::now());
+                    continue;
+                }
+                Err(e) => {
+                    // Reachable backend, definitive answer — trust it, propagate.
+                    entry.breaker.lock().unwrap().on_success();
+                    return Err(e);
+                }
+            }
+        }
+        self.http_download(path, offset, length).await
+    }
+
+    /// The HTTP FileStation Download implementation: throttle, transient retry,
+    /// and DSM JSON-envelope detection. Used directly when no read backend is
+    /// injected, and as the fallback when a backend trips its breaker.
     ///
     /// DSM violates HTTP convention by returning `200 OK` with a JSON error
     /// envelope (`{"success":false,"error":{"code":119}}`) when the SID is
-    /// invalid, instead of a 4xx. We detect that case via the `Content-Type`
-    /// header and surface `ApiError(code)` rather than returning the JSON as
-    /// file content. Without this, a SID-expired download would silently
-    /// produce garbage data on disk.
-    pub async fn download(
+    /// invalid, instead of a 4xx. We detect that case via the response body and
+    /// surface `ApiError(code)` rather than returning the JSON as file content.
+    async fn http_download(
         &self,
         path: &str,
         offset: u64,
@@ -698,8 +795,51 @@ impl SynologyClient {
         Err(last_err)
     }
 
-    /// Upload file contents (replaces entire file).
+    /// Write a whole file, preferring any injected [`WriteTransport`] backend
+    /// (SMB, …) over the HTTP Upload API.
+    ///
+    /// Same selection + circuit-breaker semantics as [`download`](Self::download).
+    /// A backend's `write` is atomic (old-or-nothing), so falling back to HTTP
+    /// after a failed attempt can't collide with a half-written file. With no
+    /// backends injected this is exactly the HTTP upload.
     pub async fn upload(
+        &self,
+        folder_path: &str,
+        filename: &str,
+        data: Vec<u8>,
+        overwrite: bool,
+    ) -> Result<(), SynoFsError> {
+        if !self.write_transports.is_empty() {
+            let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
+            for entry in &self.write_transports {
+                let allowed = entry.breaker.lock().unwrap().allows(Instant::now());
+                if !allowed {
+                    continue;
+                }
+                match entry.transport.write(&full_path, &data).await {
+                    Ok(()) => {
+                        entry.breaker.lock().unwrap().on_success();
+                        return Ok(());
+                    }
+                    Err(e) if e.category() == ErrorCategory::Transport => {
+                        warn!("write backend failed (transient), falling back: {e}");
+                        entry.breaker.lock().unwrap().on_failure(Instant::now());
+                        continue;
+                    }
+                    Err(e) => {
+                        entry.breaker.lock().unwrap().on_success();
+                        return Err(e);
+                    }
+                }
+            }
+        }
+        self.http_upload(folder_path, filename, data, overwrite)
+            .await
+    }
+
+    /// The HTTP FileStation Upload implementation. Used directly when no write
+    /// backend is injected, and as the fallback when a backend trips its breaker.
+    async fn http_upload(
         &self,
         folder_path: &str,
         filename: &str,
@@ -2248,5 +2388,162 @@ mod tests {
         let client = client_for(&server);
         let bytes = client.download("/share/f", 0, 0).await.unwrap();
         assert_eq!(bytes.as_ref(), b"plain");
+    }
+
+    // ── read/write backend selection + fallback ──────────────────────────────
+    //
+    // Dependency-inversion: a backend (SMB today) is injected and preferred over
+    // HTTP, with a per-backend circuit breaker. These pin the selection contract
+    // with a configurable fake backend so no real SMB server is needed.
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    enum Behave {
+        Ok(&'static [u8]),
+        Transient, // category Transport → fall back
+        NotFound,  // definitive → propagate, no fallback
+    }
+
+    struct FakeBackend {
+        behave: Behave,
+        calls: AtomicUsize,
+    }
+
+    impl FakeBackend {
+        fn new(behave: Behave) -> Arc<Self> {
+            Arc::new(Self {
+                behave,
+                calls: AtomicUsize::new(0),
+            })
+        }
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+        fn outcome_bytes(&self) -> Result<Bytes, SynoFsError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.behave {
+                Behave::Ok(b) => Ok(Bytes::from_static(b)),
+                Behave::Transient => Err(SynoFsError::Io("backend down".into())),
+                Behave::NotFound => Err(SynoFsError::NotFound),
+            }
+        }
+        fn outcome_unit(&self) -> Result<(), SynoFsError> {
+            self.outcome_bytes().map(|_| ())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ReadTransport for FakeBackend {
+        async fn read(&self, _p: &str, _o: u64, _l: u64) -> Result<Bytes, SynoFsError> {
+            self.outcome_bytes()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WriteTransport for FakeBackend {
+        async fn write(&self, _p: &str, _d: &[u8]) -> Result<(), SynoFsError> {
+            self.outcome_unit()
+        }
+    }
+
+    /// A client pointed at a dead address (no HTTP server) — proves a call is
+    /// served by the backend without ever touching HTTP.
+    fn offline_client() -> SynologyClient {
+        SynologyClient::new("127.0.0.1", 1, false)
+    }
+
+    #[tokio::test]
+    async fn download_prefers_healthy_backend_and_skips_http() {
+        let backend = FakeBackend::new(Behave::Ok(b"from-smb"));
+        let client = offline_client().with_read_transport(backend.clone());
+        // No HTTP server exists; if this returns, the backend served it.
+        let bytes = client.download("/share/f", 0, 0).await.unwrap();
+        assert_eq!(bytes.as_ref(), b"from-smb");
+        assert_eq!(backend.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn download_propagates_definitive_backend_error_without_http() {
+        let backend = FakeBackend::new(Behave::NotFound);
+        let client = offline_client().with_read_transport(backend.clone());
+        let err = client.download("/share/missing", 0, 0).await.unwrap_err();
+        assert!(matches!(err, SynoFsError::NotFound));
+        assert_eq!(backend.call_count(), 1, "definitive error must not retry");
+    }
+
+    #[tokio::test]
+    async fn download_falls_back_to_http_on_transient_backend_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"from-http".to_vec()))
+            .mount(&server)
+            .await;
+
+        let backend = FakeBackend::new(Behave::Transient);
+        let client = client_for(&server).with_read_transport(backend.clone());
+        let bytes = client.download("/share/f", 0, 0).await.unwrap();
+        assert_eq!(bytes.as_ref(), b"from-http", "fell back to HTTP");
+        assert_eq!(backend.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn breaker_opens_and_stops_probing_a_failing_backend() {
+        // Default breaker threshold is 2. A persistently-transient backend
+        // should be tried on the first two downloads, then skipped entirely
+        // while HTTP keeps serving.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"http".to_vec()))
+            .mount(&server)
+            .await;
+
+        let backend = FakeBackend::new(Behave::Transient);
+        let client = client_for(&server).with_read_transport(backend.clone());
+
+        for _ in 0..5 {
+            assert_eq!(
+                client.download("/share/f", 0, 0).await.unwrap().as_ref(),
+                b"http"
+            );
+        }
+        // Tried twice (to reach the threshold), then the open breaker skips it.
+        assert_eq!(backend.call_count(), 2, "breaker should stop probing");
+    }
+
+    #[tokio::test]
+    async fn upload_prefers_backend_then_falls_back_on_transient() {
+        // Healthy write backend serves the upload with no HTTP server present.
+        let ok_backend = FakeBackend::new(Behave::Ok(b""));
+        let client = offline_client().with_write_transport(ok_backend.clone());
+        client
+            .upload("/share", "f.bin", b"data".to_vec(), false)
+            .await
+            .unwrap();
+        assert_eq!(ok_backend.call_count(), 1);
+
+        // Transient write failure falls back to the HTTP upload.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true, "data": {"blks": null}
+            })))
+            .mount(&server)
+            .await;
+        let bad_backend = FakeBackend::new(Behave::Transient);
+        let client = client_for(&server).with_write_transport(bad_backend.clone());
+        client
+            .upload("/share", "f.bin", b"data".to_vec(), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            bad_backend.call_count(),
+            1,
+            "attempted before HTTP fallback"
+        );
     }
 }

--- a/rust/synology-filestation-core/src/lib.rs
+++ b/rust/synology-filestation-core/src/lib.rs
@@ -7,8 +7,10 @@
 
 pub mod client;
 pub mod error;
+pub mod transport;
 pub mod types;
 
 pub use client::{SynologyClient, ThrottleConfig};
 pub use error::SynoFsError;
+pub use transport::{BreakerConfig, CircuitBreaker, ReadTransport, WriteTransport};
 pub use types::{SynoAdditional, SynoFileInfo, SynoOwner, SynoPerm, SynoTime};

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -1,0 +1,235 @@
+//! Pluggable read/write **backends** and the health tracking that lets
+//! [`SynologyClient`](crate::SynologyClient) prefer them over the HTTP
+//! FileStation API — while transparently falling back to HTTP when a backend is
+//! unavailable.
+//!
+//! The motivation is the NAS-saturation incident: the HTTP Download/Upload API
+//! is proxied through the shared `synoscgi` backend, so a bulk transfer load can
+//! take the appliance down. An alternative transport (SMB today; NFS, S3, or a
+//! cache tomorrow) that talks to a *different* service relieves it. Backends
+//! plug in by **dependency inversion**: they implement [`ReadTransport`] /
+//! [`WriteTransport`] here, and consumers inject them at construction — the
+//! read/write call sites (`download`/`upload`) never change, and this crate
+//! never depends on any backend's protocol library.
+//!
+//! ## Error contract (the integration seam)
+//!
+//! An implementor maps its failures onto [`SynoFsError`] so the selection layer
+//! can distinguish, via [`SynoFsError::category`]:
+//!
+//! * **transient** (connection lost / timeout / transport) → `Transport` — the
+//!   selection layer trips this backend's [`CircuitBreaker`] and falls back;
+//! * **definitive** (not-found / permission / …) → propagate unchanged; the
+//!   backend is healthy and gave a real answer, so falling back would just ask
+//!   the same NAS the same question.
+//!
+//! ## Write contract
+//!
+//! [`WriteTransport::write`] MUST be **atomic**: on success the whole file is
+//! replaced; on failure the target is left untouched (old-or-nothing, never a
+//! partial). That is what makes fallback *safe* — a failed primary write can't
+//! leave a half-file for the HTTP path (or another backend) to collide with.
+
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use crate::error::SynoFsError;
+
+/// A read backend serving file bytes as an alternative to the HTTP Download API.
+#[async_trait]
+pub trait ReadTransport: Send + Sync {
+    /// Read `length` bytes at `offset`; `length == 0` reads the whole file
+    /// (mirroring [`SynologyClient::download`](crate::SynologyClient::download)).
+    async fn read(&self, path: &str, offset: u64, length: u64) -> Result<Bytes, SynoFsError>;
+}
+
+/// A write backend replacing a whole file, as an alternative to the HTTP Upload
+/// API. Implementations MUST be atomic — see the [module docs](self#write-contract).
+#[async_trait]
+pub trait WriteTransport: Send + Sync {
+    /// Atomically replace the file at `path` with `data`.
+    async fn write(&self, path: &str, data: &[u8]) -> Result<(), SynoFsError>;
+}
+
+/// Tuning for a backend's [`CircuitBreaker`].
+#[derive(Debug, Clone, Copy)]
+pub struct BreakerConfig {
+    /// Consecutive transport failures that trip the breaker open.
+    pub failure_threshold: u32,
+    /// How long the breaker stays open before allowing a single re-probe.
+    pub cooldown: Duration,
+}
+
+impl Default for BreakerConfig {
+    /// Open after 2 consecutive transport failures; re-probe after 30 s. Sized
+    /// so that walking off the SMB network trips the backend quickly (so we
+    /// don't pay its connect timeout on every file) yet recovers on its own
+    /// once we're back.
+    fn default() -> Self {
+        Self {
+            failure_threshold: 2,
+            cooldown: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum State {
+    /// Backend is trusted — attempts are allowed.
+    Closed,
+    /// Backend is failing — attempts are skipped until `opened_at + cooldown`.
+    Open { opened_at: Instant },
+    /// Cooldown elapsed — one trial attempt is out; further attempts wait for
+    /// its verdict.
+    HalfOpen,
+}
+
+/// Per-backend health tracker. Skips a failing backend (so we don't pay its
+/// connect timeout on every operation) and periodically re-probes to recover.
+///
+/// Time is passed in explicitly (`now: Instant`) rather than read from the clock
+/// so the state machine is deterministically testable.
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    config: BreakerConfig,
+    state: State,
+    consecutive_failures: u32,
+}
+
+impl CircuitBreaker {
+    pub fn new(config: BreakerConfig) -> Self {
+        Self {
+            config,
+            state: State::Closed,
+            consecutive_failures: 0,
+        }
+    }
+
+    /// Whether a backend attempt is allowed at `now`. When the cooldown has
+    /// elapsed this transitions `Open → HalfOpen` and allows exactly one trial.
+    pub fn allows(&mut self, now: Instant) -> bool {
+        match self.state {
+            State::Closed => true,
+            State::Open { opened_at } => {
+                if now.duration_since(opened_at) >= self.config.cooldown {
+                    self.state = State::HalfOpen;
+                    true
+                } else {
+                    false
+                }
+            }
+            State::HalfOpen => false,
+        }
+    }
+
+    /// Record a healthy response (bytes, or a definitive error the backend
+    /// answered): the backend is trusted again.
+    pub fn on_success(&mut self) {
+        self.state = State::Closed;
+        self.consecutive_failures = 0;
+    }
+
+    /// Record a transport failure. A half-open trial that fails re-opens the
+    /// breaker immediately; otherwise failures accumulate toward the threshold.
+    pub fn on_failure(&mut self, now: Instant) {
+        match self.state {
+            State::HalfOpen => {
+                self.state = State::Open { opened_at: now };
+            }
+            _ => {
+                self.consecutive_failures += 1;
+                if self.consecutive_failures >= self.config.failure_threshold {
+                    self.state = State::Open { opened_at: now };
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn breaker() -> CircuitBreaker {
+        CircuitBreaker::new(BreakerConfig {
+            failure_threshold: 2,
+            cooldown: Duration::from_secs(30),
+        })
+    }
+
+    #[test]
+    fn starts_closed_and_allows() {
+        let mut b = breaker();
+        assert!(b.allows(Instant::now()));
+    }
+
+    #[test]
+    fn opens_only_after_threshold_consecutive_failures() {
+        let t = Instant::now();
+        let mut b = breaker();
+        b.on_failure(t);
+        assert!(b.allows(t), "1 failure < threshold(2): still closed");
+        b.on_failure(t);
+        assert!(!b.allows(t), "2 failures: open, attempts skipped");
+    }
+
+    #[test]
+    fn success_resets_the_failure_count() {
+        let t = Instant::now();
+        let mut b = breaker();
+        b.on_failure(t);
+        b.on_success(); // reachable again
+        b.on_failure(t);
+        assert!(
+            b.allows(t),
+            "count reset, so a lone later failure stays closed"
+        );
+    }
+
+    #[test]
+    fn stays_open_during_cooldown_then_half_opens_for_one_probe() {
+        let t = Instant::now();
+        let mut b = breaker();
+        b.on_failure(t);
+        b.on_failure(t); // open at t
+        assert!(!b.allows(t + Duration::from_secs(10)), "still cooling");
+        assert!(!b.allows(t + Duration::from_secs(29)), "still cooling");
+        assert!(
+            b.allows(t + Duration::from_secs(30)),
+            "cooldown elapsed → half-open, one probe allowed"
+        );
+        assert!(
+            !b.allows(t + Duration::from_secs(30)),
+            "half-open: only a single trial is in flight"
+        );
+    }
+
+    #[test]
+    fn half_open_success_closes() {
+        let t = Instant::now();
+        let mut b = breaker();
+        b.on_failure(t);
+        b.on_failure(t);
+        assert!(b.allows(t + Duration::from_secs(30))); // half-open probe
+        b.on_success();
+        assert!(b.allows(t + Duration::from_secs(31)), "closed again");
+    }
+
+    #[test]
+    fn half_open_failure_reopens_for_another_cooldown() {
+        let t = Instant::now();
+        let mut b = breaker();
+        b.on_failure(t);
+        b.on_failure(t);
+        let probe = t + Duration::from_secs(30);
+        assert!(b.allows(probe)); // half-open probe
+        b.on_failure(probe); // probe failed → reopen at `probe`
+        assert!(!b.allows(probe + Duration::from_secs(10)), "cooling again");
+        assert!(
+            b.allows(probe + Duration::from_secs(30)),
+            "half-opens again after another full cooldown"
+        );
+    }
+}

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -25,10 +25,11 @@
 //!
 //! ## Write contract
 //!
-//! [`WriteTransport::write`] MUST be **atomic**: on success the whole file is
-//! replaced; on failure the target is left untouched (old-or-nothing, never a
-//! partial). That is what makes fallback *safe* — a failed primary write can't
-//! leave a half-file for the HTTP path (or another backend) to collide with.
+//! [`WriteTransport::write`] MUST NOT leave a partial/corrupt target: on success
+//! the whole file is replaced; on failure the previous file is preserved
+//! (**old-or-new**, never a partial, no data lost). That is what makes fallback
+//! *safe* — a failed primary write can't leave a half-file for the HTTP path (or
+//! another backend) to collide with. It need not be a single atomic operation.
 
 use std::time::{Duration, Instant};
 
@@ -46,10 +47,12 @@ pub trait ReadTransport: Send + Sync {
 }
 
 /// A write backend replacing a whole file, as an alternative to the HTTP Upload
-/// API. Implementations MUST be atomic — see the [module docs](self#write-contract).
+/// API. Implementations MUST NOT leave a partial target on failure — see the
+/// [module docs](self#write-contract).
 #[async_trait]
 pub trait WriteTransport: Send + Sync {
-    /// Atomically replace the file at `path` with `data`.
+    /// Replace the whole file at `path` with `data`. On failure the previous
+    /// file must be preserved (old-or-new, never a partial target).
     async fn write(&self, path: &str, data: &[u8]) -> Result<(), SynoFsError>;
 }
 

--- a/rust/synology-filestation-ffi/Cargo.toml
+++ b/rust/synology-filestation-ffi/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 synology-filestation-core = { path = "../synology-filestation-core", version = "0.1.19" }
+synology-filestation-smb = { path = "../synology-filestation-smb" }
 synology-filestation-fuse = { path = "../synology-filestation-fuse", version = "0.1.19" }
 
 tokio       = { version = "1", features = ["rt", "rt-multi-thread"] }

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -325,6 +325,17 @@ pub unsafe extern "C" fn syno_connect(
                         )
                     }
                 };
+                // Transparently prefer SMB for transfers when reachable (the GUI
+                // browser's downloads, and a GUI-initiated mount, then bypass
+                // synoscgi); silently HTTP-only otherwise.
+                let client = match runtime.block_on(synology_filestation_smb::auto_connect(
+                    host, username, password,
+                )) {
+                    Some(smb) => client
+                        .with_read_transport(smb.clone())
+                        .with_write_transport(smb),
+                    None => client,
+                };
                 let handle = Box::new(SynoClient {
                     inner: Arc::new(client),
                     runtime,

--- a/rust/synology-filestation-fuse/Cargo.toml
+++ b/rust/synology-filestation-fuse/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 synology-filestation-core = { path = "../synology-filestation-core", version = "0.1.16" }
+synology-filestation-smb = { path = "../synology-filestation-smb" }
 
 tokio       = { version = "1", features = ["full"] }
 reqwest     = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }

--- a/rust/synology-filestation-fuse/src/main.rs
+++ b/rust/synology-filestation-fuse/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> anyhow::Result<()> {
         args.port
     );
 
-    let client = Arc::new(SynologyClient::new(&args.host, args.port, args.https));
+    let mut client = SynologyClient::new(&args.host, args.port, args.https);
 
     let password = match args.password {
         Some(p) => p,
@@ -101,6 +101,22 @@ fn main() -> anyhow::Result<()> {
     }
 
     info!("Logged in successfully");
+
+    // Transparently prefer SMB for the mount's reads/writes when the NAS's SMB
+    // service is reachable — this bypasses synoscgi entirely. Silently HTTP-only
+    // otherwise. Injected before the client is shared, since it consumes it.
+    if let Some(smb) = rt.block_on(synology_filestation_smb::auto_connect(
+        &args.host,
+        &args.username,
+        &password,
+    )) {
+        info!("SMB reachable — mount will prefer it over the HTTP API");
+        client = client
+            .with_read_transport(smb.clone())
+            .with_write_transport(smb);
+    }
+
+    let client = Arc::new(client);
 
     let opts = MountOptions {
         cache_ttl: args.cache_ttl,

--- a/rust/synology-filestation-smb/Cargo.toml
+++ b/rust/synology-filestation-smb/Cargo.toml
@@ -18,6 +18,7 @@ smb2 = "0.13"
 bytes = "1"
 tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
 tracing = "0.1"
+async-trait = "0.1"
 # Shared error model so SMB failures classify the same way HTTP ones do.
 synology-filestation-core = { path = "../synology-filestation-core" }
 

--- a/rust/synology-filestation-smb/src/lib.rs
+++ b/rust/synology-filestation-smb/src/lib.rs
@@ -31,4 +31,4 @@ pub mod transport;
 
 pub use error::to_syno_error;
 pub use path::SmbPath;
-pub use transport::{FileMeta, SmbConfig, SmbTransport};
+pub use transport::{auto_connect, FileMeta, SmbConfig, SmbTransport};

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -255,48 +255,67 @@ impl SmbTransport {
         Ok(Bytes::from(data))
     }
 
-    /// Atomically replace the file at `logical` with `data`.
+    /// Replace the file at `logical` with `data`, guaranteeing **old-or-new**:
+    /// a reader always sees either the previous file or the fully-written new
+    /// one — never a partial/corrupt file — and no data is lost on failure.
+    /// That is what makes the selection layer's fallback to HTTP safe.
     ///
-    /// Writes to an adjacent temp file, then renames it onto the target — so
-    /// the target is never observed partial (old-or-nothing), which is what
-    /// makes the selection layer's fallback to HTTP safe. DSM's rename won't
-    /// replace an existing file (`ReplaceIfExists=false`), so on a name
-    /// collision we delete the target first; the temp still holds the complete
-    /// new bytes throughout, so a failure there leaves the data recoverable
-    /// rather than a corrupt target.
+    /// New bytes go to an adjacent temp file first. If the target name is free,
+    /// a single rename commits. If it already exists (DSM's rename is
+    /// `ReplaceIfExists=false`, so it can't replace in one step) the old file is
+    /// moved aside to a backup, the new file is renamed in, and the backup is
+    /// dropped; a failure mid-swap restores the old file, and the new bytes stay
+    /// in the temp — so no copy of the data is ever the only casualty of a
+    /// failed step.
+    ///
+    /// Caveat: during the swap there is a brief window where the target *name*
+    /// is momentarily absent (the bytes are safe in the backup/temp). A truly
+    /// atomic replace needs `ReplaceIfExists=true` in the SMB layer — tracked as
+    /// a follow-up.
     pub async fn write_atomic(&self, logical: &str, data: &[u8]) -> Result<(), SynoFsError> {
         let loc = SmbPath::from_logical(logical)?;
-        let tmp = part_name(&loc.path, PART_SEQ.fetch_add(1, Ordering::Relaxed));
+        let seq = PART_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = part_name(&loc.path, seq);
 
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;
         ensure_tree(client, trees, &loc.share).await?;
         let tree = trees.get_mut(&loc.share).expect("tree just ensured");
 
-        // Full contents → temp file adjacent to the target (pipelined, so files
+        // New contents → temp file adjacent to the target (pipelined, so files
         // past the server's MaxWriteSize go in chunks).
         if let Err(e) = client.write_file_pipelined(tree, &tmp, data).await {
             let _ = client.delete_file(tree, &tmp).await; // best-effort cleanup
             return Err(to_syno_error(&e));
         }
 
-        // Move temp → target atomically. On collision (target exists), delete
-        // the target and retry the rename.
+        // Fast path: the target name is free → a single rename commits.
         match client.rename(tree, &tmp, &loc.path).await {
-            Ok(()) => Ok(()),
-            Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {
-                client
-                    .delete_file(tree, &loc.path)
-                    .await
-                    .map_err(|e| to_syno_error(&e))?;
-                if let Err(e) = client.rename(tree, &tmp, &loc.path).await {
-                    let _ = client.delete_file(tree, &tmp).await;
-                    return Err(to_syno_error(&e));
-                }
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {} // replace below
+            Err(e) => {
+                let _ = client.delete_file(tree, &tmp).await;
+                return Err(to_syno_error(&e));
+            }
+        }
+
+        // Replace path: move the old file aside, move the new one in, drop the
+        // backup. We never delete the only copy of the data, so a failure at any
+        // step leaves the old file recoverable (from the backup) and the new
+        // bytes recoverable (from the temp).
+        let backup = part_name(&format!("{}.bak", loc.path), seq);
+        if let Err(e) = client.rename(tree, &loc.path, &backup).await {
+            let _ = client.delete_file(tree, &tmp).await;
+            return Err(to_syno_error(&e));
+        }
+        match client.rename(tree, &tmp, &loc.path).await {
+            Ok(()) => {
+                let _ = client.delete_file(tree, &backup).await; // best-effort
                 Ok(())
             }
             Err(e) => {
-                let _ = client.delete_file(tree, &tmp).await;
+                // Put the old file back; leave the new bytes in `tmp`.
+                let _ = client.rename(tree, &backup, &loc.path).await;
                 Err(to_syno_error(&e))
             }
         }

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -69,11 +70,77 @@ impl SmbConfig {
         }
     }
 
+    /// Build an auto-SMB config from the same credentials the HTTP login uses,
+    /// parsing the domain out of the username so AD accounts work with no extra
+    /// input: `DOMAIN\user`, or `user@REALM` (NetBIOS domain = the first realm
+    /// label, upper-cased — e.g. `KRG.LOCAL` → `KRG`), else a local account with
+    /// no domain. Port defaults to 445.
+    pub fn from_login(host: &str, username: &str, password: &str) -> Self {
+        let (domain, user) = if let Some((d, u)) = username.split_once('\\') {
+            (d.to_string(), u.to_string())
+        } else if let Some((u, realm)) = username.split_once('@') {
+            let netbios = realm.split('.').next().unwrap_or(realm).to_uppercase();
+            (netbios, u.to_string())
+        } else {
+            (String::new(), username.to_string())
+        };
+        let mut cfg = SmbConfig::new(host, user, password);
+        cfg.domain = domain;
+        cfg
+    }
+
     fn addr(&self) -> String {
         if self.host.contains(':') {
             self.host.clone()
         } else {
             format!("{}:{}", self.host, self.port)
+        }
+    }
+}
+
+/// Transparently connect an SMB backend from the HTTP login credentials, for the
+/// "always prefer SMB when reachable" policy — so bulk transfers avoid the HTTP
+/// Download/Upload API (and the shared `synoscgi` backend it can saturate).
+///
+/// Returns `None` (→ HTTP only) whenever SMB is disabled, unreachable, or auth
+/// fails — **never** an error, so a failed probe silently degrades to HTTP. A
+/// short probe timeout bounds the cost off-network (where port 445 is dropped),
+/// and the caller's circuit breaker takes over from there.
+///
+/// Deploy escape hatches (environment, invisible to any public API):
+/// * `SYNOLOGY_FS_SMB_DISABLE` (any value) — never use SMB.
+/// * `SYNOLOGY_FS_SMB_DOMAIN` — override the domain parsed from the username.
+/// * `SYNOLOGY_FS_SMB_PORT` — override the SMB port (default 445).
+/// * `SYNOLOGY_FS_SMB_TIMEOUT_MS` — probe timeout (default 2000).
+pub async fn auto_connect(host: &str, username: &str, password: &str) -> Option<Arc<SmbTransport>> {
+    if std::env::var_os("SYNOLOGY_FS_SMB_DISABLE").is_some() {
+        return None;
+    }
+    let mut cfg = SmbConfig::from_login(host, username, password);
+    if let Ok(domain) = std::env::var("SYNOLOGY_FS_SMB_DOMAIN") {
+        cfg.domain = domain;
+    }
+    if let Some(port) = std::env::var("SYNOLOGY_FS_SMB_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+    {
+        cfg.port = port;
+    }
+    cfg.timeout = Duration::from_millis(
+        std::env::var("SYNOLOGY_FS_SMB_TIMEOUT_MS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(2000),
+    );
+
+    match SmbTransport::connect(&cfg).await {
+        Ok(transport) => {
+            tracing::info!(host, "SMB transport enabled; preferring it over HTTP");
+            Some(Arc::new(transport))
+        }
+        Err(e) => {
+            tracing::debug!(host, error = %e, "SMB unavailable; using HTTP only");
+            None
         }
     }
 }
@@ -289,6 +356,25 @@ mod tests {
         // Different sequence numbers yield different temp names (so concurrent
         // writers to the same target don't collide).
         assert_ne!(part_name("x", 1), part_name("x", 2));
+    }
+
+    #[test]
+    fn from_login_parses_domain_from_username() {
+        // DOMAIN\user — unambiguous.
+        let c = SmbConfig::from_login("nas", "KRG\\c.crutchfield.642", "pw");
+        assert_eq!(c.domain, "KRG");
+        assert_eq!(c.username, "c.crutchfield.642");
+
+        // user@REALM (UPN) — NetBIOS domain is the first realm label, upper-cased.
+        let c = SmbConfig::from_login("nas", "c.crutchfield.642@krg.local", "pw");
+        assert_eq!(c.domain, "KRG");
+        assert_eq!(c.username, "c.crutchfield.642");
+
+        // Local account — no domain.
+        let c = SmbConfig::from_login("nas", "admin", "pw");
+        assert_eq!(c.domain, "");
+        assert_eq!(c.username, "admin");
+        assert_eq!(c.port, 445);
     }
 
     #[test]

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -11,15 +11,26 @@
 //! connection pool (future work).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use smb2::{ClientConfig, SmbClient, Tree};
-use synology_filestation_core::SynoFsError;
+use synology_filestation_core::{ReadTransport, SynoFsError, WriteTransport};
 use tokio::sync::Mutex;
 
 use crate::error::to_syno_error;
 use crate::path::SmbPath;
+
+/// Process-wide sequence making temp write names unique so concurrent writers
+/// to the same target don't clobber each other's `.part` file.
+static PART_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Name of the adjacent temp file an atomic write goes to before the rename.
+fn part_name(path: &str, seq: u64) -> String {
+    format!("{path}.part-{}-{}", std::process::id(), seq)
+}
 
 /// Connection parameters for [`SmbTransport::connect`].
 #[derive(Debug, Clone)]
@@ -176,6 +187,75 @@ impl SmbTransport {
             .map_err(|e| to_syno_error(&e))?;
         Ok(Bytes::from(data))
     }
+
+    /// Atomically replace the file at `logical` with `data`.
+    ///
+    /// Writes to an adjacent temp file, then renames it onto the target — so
+    /// the target is never observed partial (old-or-nothing), which is what
+    /// makes the selection layer's fallback to HTTP safe. DSM's rename won't
+    /// replace an existing file (`ReplaceIfExists=false`), so on a name
+    /// collision we delete the target first; the temp still holds the complete
+    /// new bytes throughout, so a failure there leaves the data recoverable
+    /// rather than a corrupt target.
+    pub async fn write_atomic(&self, logical: &str, data: &[u8]) -> Result<(), SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+        let tmp = part_name(&loc.path, PART_SEQ.fetch_add(1, Ordering::Relaxed));
+
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        ensure_tree(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+
+        // Full contents → temp file adjacent to the target (pipelined, so files
+        // past the server's MaxWriteSize go in chunks).
+        if let Err(e) = client.write_file_pipelined(tree, &tmp, data).await {
+            let _ = client.delete_file(tree, &tmp).await; // best-effort cleanup
+            return Err(to_syno_error(&e));
+        }
+
+        // Move temp → target atomically. On collision (target exists), delete
+        // the target and retry the rename.
+        match client.rename(tree, &tmp, &loc.path).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {
+                client
+                    .delete_file(tree, &loc.path)
+                    .await
+                    .map_err(|e| to_syno_error(&e))?;
+                if let Err(e) = client.rename(tree, &tmp, &loc.path).await {
+                    let _ = client.delete_file(tree, &tmp).await;
+                    return Err(to_syno_error(&e));
+                }
+                Ok(())
+            }
+            Err(e) => {
+                let _ = client.delete_file(tree, &tmp).await;
+                Err(to_syno_error(&e))
+            }
+        }
+    }
+}
+
+// ── core transport traits (dependency inversion) ─────────────────────────────
+//
+// Implementing these is the entire integration surface: SynologyClient prefers
+// an injected backend over HTTP and falls back on transport failures, with no
+// change to any read/write call site.
+
+#[async_trait]
+impl ReadTransport for SmbTransport {
+    async fn read(&self, path: &str, offset: u64, length: u64) -> Result<Bytes, SynoFsError> {
+        // Delegate to the inherent method (inherent wins over the trait method
+        // for this path syntax, so this is not recursive).
+        SmbTransport::read(self, path, offset, length).await
+    }
+}
+
+#[async_trait]
+impl WriteTransport for SmbTransport {
+    async fn write(&self, path: &str, data: &[u8]) -> Result<(), SynoFsError> {
+        self.write_atomic(path, data).await
+    }
 }
 
 /// Attach `share` if it isn't already, caching the `Tree`. Split borrows of the
@@ -193,4 +273,34 @@ async fn ensure_tree(
         trees.insert(share.to_string(), tree);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn part_name_is_adjacent_and_unique_per_seq() {
+        let pid = std::process::id();
+        assert_eq!(
+            part_name("REEF/img.orf", 7),
+            format!("REEF/img.orf.part-{pid}-7")
+        );
+        // Different sequence numbers yield different temp names (so concurrent
+        // writers to the same target don't collide).
+        assert_ne!(part_name("x", 1), part_name("x", 2));
+    }
+
+    #[test]
+    fn smbconfig_new_defaults_and_addr() {
+        let cfg = SmbConfig::new("nas.example.com", "user", "pass");
+        assert_eq!(cfg.port, 445);
+        assert_eq!(cfg.addr(), "nas.example.com:445");
+        let cfg2 = SmbConfig::new("nas.example.com:1445", "user", "pass");
+        assert_eq!(
+            cfg2.addr(),
+            "nas.example.com:1445",
+            "explicit port preserved"
+        );
+    }
 }


### PR DESCRIPTION
## Why

The SMB transport (#129) existed but nothing used it. This makes the whole client **transparently prefer SMB over the HTTP FileStation API whenever the NAS's SMB service is reachable** — so bulk transfers stop loading `synoscgi` (the saturation cause) — and silently fall back to HTTP otherwise. **No public API changes anywhere**; callers can't tell which transport served a request.

Built by **dependency inversion**: `core` owns the selection + circuit-breaker logic; backends implement the traits; consumers inject at construction. Adding a future backend (NFS/S3/cache) is the same recipe with zero changes to core or any call site.

## core

- **`ReadTransport` / `WriteTransport`** — the entire integration surface. A backend maps errors onto `SynoFsError`; selection reads `category()` to tell **transient** (→ fall back + trip breaker) from **definitive** (→ propagate).
- **`CircuitBreaker`** — per-backend `Closed → Open → HalfOpen`. Walking off the SMB network trips it after N failures (so we don't pay the SMB connect timeout on every file) and it re-probes after a cooldown. Time injected → deterministically unit-tested.
- **`SynologyClient::download`/`upload`** now walk injected backends, ending at HTTP. With none injected, behavior is byte-for-byte as before.

## smb backend

- `impl ReadTransport + WriteTransport for SmbTransport`. `write` is **atomic** (temp file → rename onto target; on DSM's non-replacing rename, delete-then-rename), so write fallback can't collide with a half-file.
- `SmbConfig::from_login` parses the AD domain from the login username (`DOMAIN\user` / `user@REALM`); `auto_connect` connects from the login creds with a short probe timeout and returns `None` on any failure (never errors). Env escape hatches: `SYNOLOGY_FS_SMB_{DISABLE,DOMAIN,PORT,TIMEOUT_MS}`.

## Auto-wiring (all consumers)

SMB is injected at construction; **read/write call sites are unchanged**:
- **Python** `Client` + `AsyncClient` — after login, before the client is Arc-frozen.
- **FUSE** `main.rs` — after login, before the mount is spawned.
- **FFI** `syno_connect` — after login, on the client's runtime.

Policy: **auto** (always prefer SMB when reachable) — chosen so the NAS never eats the bulk load. Deployments that must opt out set `SYNOLOGY_FS_SMB_DISABLE`.

## Read/write asymmetry (why write needed care)

Reads are idempotent — fall back and re-read. Writes aren't: a naive fallback after a partial write risks corruption. The atomic temp+rename contract makes the target *old-or-nothing, never partial*, so write fallback is safe.

## Tests

`cargo test --workspace` (breaker state machine, selection/fallback/breaker-open with a fake backend, error mapping, path/temp-name/`from_login` helpers) + `cargo clippy --workspace --all-targets --all-features -- -D warnings` + `cargo fmt --all` clean. **pytest: 69 pass** (SMB probe disabled in the HTTP-mock suite). A `#[ignore]`d live SMB test remains for on-NAS validation.

## Follow-ups (tracked, not in this PR)

- **Write improvements**: truly-atomic replace (patch `smb2` for `ReplaceIfExists=true`, dropping the delete-then-rename window) and **streaming / positional writes** (`create_file_writer_at`) for the WinFsp path.
- SMB reconnect after a mid-session network flap (smb2 0.13's `auto_reconnect` is unimplemented), relevant to long-lived FUSE mounts.
- CI: `nix flake check` now builds `smb2` + crypto deps via the new workspace member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)