### PR TITLE
feat: streaming writes (stage large files without buffering in memory)

### DIFF
--- a/python/synology_filestation/src/lib.rs
+++ b/python/synology_filestation/src/lib.rs
@@ -346,7 +346,8 @@ impl Client {
                     {
                         Some(smb) => client
                             .with_read_transport(smb.clone())
-                            .with_write_transport(smb),
+                            .with_write_transport(smb.clone())
+                            .with_stream_write_transport(smb),
                         None => client,
                     };
                     Ok::<_, SynoFsError>(client)
@@ -497,12 +498,6 @@ impl Client {
         overwrite: bool,
         _create_parents: bool,
     ) -> PyResult<()> {
-        // Read file bytes on the calling thread; this is the only sync I/O
-        // Python expects to be cheap (small files) or already fits in RAM
-        // for large ones — the existing core API takes a Vec<u8>.
-        let data = std::fs::read(local_path)
-            .map_err(|e| PyErr::new::<TransportError, _>(format!("read {local_path}: {e}")))?;
-
         // Filename is the last path component.
         let filename = std::path::Path::new(local_path)
             .file_name()
@@ -511,12 +506,15 @@ impl Client {
             .to_string();
 
         let inner = self.inner.clone();
+        let local = std::path::PathBuf::from(local_path);
         let remote_dir = remote_dir.to_string();
+        // Streams the file straight to SMB when available (no in-memory copy);
+        // falls back to reading it in + HTTP upload otherwise. API unchanged.
         py.allow_threads(|| {
             self.runtime.block_on(async {
                 inner
                     .with_relogin_retry(|| {
-                        inner.upload(&remote_dir, &filename, data.clone(), overwrite)
+                        inner.upload_from_path(&local, &remote_dir, &filename, overwrite)
                     })
                     .await
             })
@@ -651,7 +649,8 @@ impl AsyncClient {
                 match synology_filestation_smb::auto_connect(&host, &username, &password).await {
                     Some(smb) => client
                         .with_read_transport(smb.clone())
-                        .with_write_transport(smb),
+                        .with_write_transport(smb.clone())
+                        .with_stream_write_transport(smb),
                     None => client,
                 };
             Ok(AsyncClient {
@@ -792,11 +791,6 @@ impl AsyncClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         future_into_py(py, async move {
-            let data = std::fs::read(&local_path).map_err(|e| {
-                Python::with_gil(|py| {
-                    PyErr::new::<TransportError, _>(format!("read {local_path}: {e}")).clone_ref(py)
-                })
-            })?;
             let filename = std::path::Path::new(&local_path)
                 .file_name()
                 .and_then(|n| n.to_str())
@@ -806,9 +800,36 @@ impl AsyncClient {
                     })
                 })?
                 .to_string();
+            let local = std::path::PathBuf::from(&local_path);
+            // Streams to SMB when available (no in-memory copy); HTTP fallback
+            // otherwise. API unchanged.
             inner
                 .with_relogin_retry(|| {
-                    inner.upload(&remote_dir, &filename, data.clone(), overwrite)
+                    inner.upload_from_path(&local, &remote_dir, &filename, overwrite)
+                })
+                .await
+                .map_err(synofs_to_pyerr_gil)
+        })
+    }
+
+    /// Stream a local file to a full remote path (`/share/dir/name`). Like
+    /// `upload` but the remote filename may differ from the local one. Streams
+    /// to SMB when available, HTTP fallback otherwise.
+    #[pyo3(signature = (local_path, remote_path, *, overwrite=true))]
+    fn upload_file<'py>(
+        &self,
+        py: Python<'py>,
+        local_path: String,
+        remote_path: String,
+        overwrite: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        future_into_py(py, async move {
+            let (folder, filename) = split_remote_path(&remote_path)?;
+            let local = std::path::PathBuf::from(&local_path);
+            inner
+                .with_relogin_retry(|| {
+                    inner.upload_from_path(&local, &folder, &filename, overwrite)
                 })
                 .await
                 .map_err(synofs_to_pyerr_gil)

--- a/python/synology_filestation/synology_filestation/fsspec.py
+++ b/python/synology_filestation/synology_filestation/fsspec.py
@@ -204,12 +204,9 @@ class SynologyFileSystem(AsyncFileSystem):
     async def _put_file(self, lpath: str, rpath: str, **kwargs) -> None:
         rpath = self._strip_protocol(rpath)
         client = await self._get_client()
-        # Read locally and ship as bytes; matches fsspec's small-file
-        # contract. For multi-GB uploads, callers should use
-        # `client.upload(local_path, remote_dir)` directly.
-        with open(lpath, "rb") as f:
-            data = f.read()
-        await client.upload_bytes(rpath, data)
+        # Streams the local file to the NAS (straight to SMB when available, so
+        # multi-GB uploads aren't buffered in memory; HTTP fallback otherwise).
+        await client.upload_file(lpath, rpath)
 
     async def _pipe_file(self, path: str, value: bytes, **kwargs) -> None:
         path = self._strip_protocol(path)

--- a/rust/synology-filestation-core/Cargo.toml
+++ b/rust/synology-filestation-core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/UCSD-E4E/synology-filestation"
 path = "src/lib.rs"
 
 [dependencies]
-tokio       = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros", "sync", "io-util"] }
+tokio       = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros", "sync", "io-util", "fs"] }
 reqwest     = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -7,7 +7,9 @@ use tokio::sync::{Mutex, Semaphore, SemaphorePermit};
 use tracing::{debug, warn};
 
 use crate::error::{dsm_code_to_category, ErrorCategory, SynoFsError};
-use crate::transport::{BreakerConfig, CircuitBreaker, ReadTransport, WriteTransport};
+use crate::transport::{
+    BreakerConfig, CircuitBreaker, ReadTransport, StreamWriteTransport, WriteTransport,
+};
 use crate::types::{
     AuthData, CreateFolderData, GetInfoData, ListData, ListShareData, RenameData, SynoFileInfo,
     SynoResponse, UploadData, ADDITIONAL_FIELDS, SHARE_ADDITIONAL_FIELDS,
@@ -188,6 +190,9 @@ pub struct SynologyClient {
     read_transports: Vec<TransportEntry<dyn ReadTransport>>,
     /// Injected write backends, tried in order before the HTTP Upload API.
     write_transports: Vec<TransportEntry<dyn WriteTransport>>,
+    /// Injected streaming write backends, tried in order by `upload_from_path`
+    /// before falling back to reading the file into memory + HTTP upload.
+    stream_write_transports: Vec<TransportEntry<dyn StreamWriteTransport>>,
 }
 
 impl std::fmt::Debug for SynologyClient {
@@ -198,6 +203,10 @@ impl std::fmt::Debug for SynologyClient {
             .field("throttled", &self.throttle.is_some())
             .field("read_transports", &self.read_transports.len())
             .field("write_transports", &self.write_transports.len())
+            .field(
+                "stream_write_transports",
+                &self.stream_write_transports.len(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -236,6 +245,7 @@ impl SynologyClient {
             throttle: None,
             read_transports: Vec::new(),
             write_transports: Vec::new(),
+            stream_write_transports: Vec::new(),
         }
     }
 
@@ -257,6 +267,15 @@ impl SynologyClient {
     /// The backend's `write` must be atomic so fallback is safe.
     pub fn with_write_transport(mut self, transport: Arc<dyn WriteTransport>) -> Self {
         self.write_transports.push(TransportEntry::new(transport));
+        self
+    }
+
+    /// Inject a [`StreamWriteTransport`] backend. `upload_from_path` will stream
+    /// the local file straight to it when healthy, falling back to reading the
+    /// file into memory + HTTP upload on transport failures.
+    pub fn with_stream_write_transport(mut self, transport: Arc<dyn StreamWriteTransport>) -> Self {
+        self.stream_write_transports
+            .push(TransportEntry::new(transport));
         self
     }
 
@@ -837,6 +856,55 @@ impl SynologyClient {
                 }
             }
         }
+        self.http_upload(folder_path, filename, data, overwrite)
+            .await
+    }
+
+    /// Stream a local file to the NAS, preferring a [`StreamWriteTransport`]
+    /// backend (SMB) so a large file is never buffered in memory.
+    ///
+    /// Same selection + circuit-breaker + `overwrite` semantics as
+    /// [`upload`](Self::upload). On fallback (no stream backend, or a transient
+    /// failure) the file is read into memory and sent over HTTP — so the memory
+    /// win applies to the streaming path, and correctness holds either way.
+    pub async fn upload_from_path(
+        &self,
+        local: &Path,
+        folder_path: &str,
+        filename: &str,
+        overwrite: bool,
+    ) -> Result<(), SynoFsError> {
+        if overwrite && !self.stream_write_transports.is_empty() {
+            let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
+            for entry in &self.stream_write_transports {
+                let allowed = entry.breaker.lock().unwrap().allows(Instant::now());
+                if !allowed {
+                    continue;
+                }
+                match entry.transport.write_from_path(&full_path, local).await {
+                    Ok(()) => {
+                        entry.breaker.lock().unwrap().on_success();
+                        return Ok(());
+                    }
+                    Err(e) if e.category() == ErrorCategory::Transport => {
+                        warn!("stream write backend failed (transient), falling back: {e}");
+                        entry.breaker.lock().unwrap().on_failure(Instant::now());
+                        continue;
+                    }
+                    Err(e) => {
+                        entry.breaker.lock().unwrap().on_success();
+                        return Err(e);
+                    }
+                }
+            }
+        }
+        // Fallback: read the file into memory and take the HTTP upload path.
+        let data = tokio::fs::read(local).await.map_err(|e| {
+            SynoFsError::Io(format!(
+                "upload_from_path: read {} failed: {e}",
+                local.display()
+            ))
+        })?;
         self.http_upload(folder_path, filename, data, overwrite)
             .await
     }
@@ -2450,6 +2518,13 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
+    impl StreamWriteTransport for FakeBackend {
+        async fn write_from_path(&self, _p: &str, _local: &Path) -> Result<(), SynoFsError> {
+            self.outcome_unit()
+        }
+    }
+
     /// A client pointed at a dead address (no HTTP server) — proves a call is
     /// served by the backend without ever touching HTTP.
     fn offline_client() -> SynologyClient {
@@ -2575,5 +2650,72 @@ mod tests {
             0,
             "overwrite=false must skip the replacing write backend"
         );
+    }
+
+    // ── streaming upload (upload_from_path) selection ────────────────────────
+
+    fn write_scratch_file(bytes: &[u8]) -> std::path::PathBuf {
+        let p = unique_tmp_path("stream-upload-src.bin");
+        std::fs::write(&p, bytes).unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn upload_from_path_prefers_stream_backend_and_skips_http() {
+        let src = write_scratch_file(b"streamed payload");
+        let backend = FakeBackend::new(Behave::Ok(b""));
+        let client = offline_client().with_stream_write_transport(backend.clone());
+        client
+            .upload_from_path(&src, "/share", "f.bin", true)
+            .await
+            .unwrap();
+        assert_eq!(backend.call_count(), 1);
+        std::fs::remove_file(&src).ok();
+    }
+
+    #[tokio::test]
+    async fn upload_from_path_falls_back_to_http_on_transient() {
+        let src = write_scratch_file(b"streamed payload");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true, "data": {"blks": null}
+            })))
+            .mount(&server)
+            .await;
+        let backend = FakeBackend::new(Behave::Transient);
+        let client = client_for(&server).with_stream_write_transport(backend.clone());
+        client
+            .upload_from_path(&src, "/share", "f.bin", true)
+            .await
+            .unwrap();
+        assert_eq!(backend.call_count(), 1, "attempted before HTTP fallback");
+        std::fs::remove_file(&src).ok();
+    }
+
+    #[tokio::test]
+    async fn upload_from_path_overwrite_false_bypasses_stream_backend() {
+        let src = write_scratch_file(b"streamed payload");
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true, "data": {"blks": null}
+            })))
+            .mount(&server)
+            .await;
+        let backend = FakeBackend::new(Behave::Ok(b""));
+        let client = client_for(&server).with_stream_write_transport(backend.clone());
+        client
+            .upload_from_path(&src, "/share", "f.bin", false)
+            .await
+            .unwrap();
+        assert_eq!(
+            backend.call_count(),
+            0,
+            "overwrite=false must skip the streaming backend"
+        );
+        std::fs::remove_file(&src).ok();
     }
 }

--- a/rust/synology-filestation-core/src/lib.rs
+++ b/rust/synology-filestation-core/src/lib.rs
@@ -12,5 +12,7 @@ pub mod types;
 
 pub use client::{SynologyClient, ThrottleConfig};
 pub use error::SynoFsError;
-pub use transport::{BreakerConfig, CircuitBreaker, ReadTransport, WriteTransport};
+pub use transport::{
+    BreakerConfig, CircuitBreaker, ReadTransport, StreamWriteTransport, WriteTransport,
+};
 pub use types::{SynoAdditional, SynoFileInfo, SynoOwner, SynoPerm, SynoTime};

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -31,6 +31,7 @@
 //! *safe* — a failed primary write can't leave a half-file for the HTTP path (or
 //! another backend) to collide with. It need not be a single atomic operation.
 
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -54,6 +55,20 @@ pub trait WriteTransport: Send + Sync {
     /// Replace the whole file at `path` with `data`. On failure the previous
     /// file must be preserved (old-or-new, never a partial target).
     async fn write(&self, path: &str, data: &[u8]) -> Result<(), SynoFsError>;
+}
+
+/// A write backend that **streams** a local file to `remote_path` without
+/// buffering it in memory — for staging large files (e.g. `.ORF`).
+///
+/// The source is a **local path**, not a reader, deliberately: a failed attempt
+/// must be retryable by the selection layer's HTTP fallback, and a consumed
+/// reader can't be rewound while a re-openable file can. Same old-or-new /
+/// error contract as [`WriteTransport`].
+#[async_trait]
+pub trait StreamWriteTransport: Send + Sync {
+    /// Stream the contents of local file `local` into `remote_path`, replacing
+    /// it (old-or-new).
+    async fn write_from_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError>;
 }
 
 /// Tuning for a backend's [`CircuitBreaker`].

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -333,7 +333,8 @@ pub unsafe extern "C" fn syno_connect(
                 )) {
                     Some(smb) => client
                         .with_read_transport(smb.clone())
-                        .with_write_transport(smb),
+                        .with_write_transport(smb.clone())
+                        .with_stream_write_transport(smb),
                     None => client,
                 };
                 let handle = Box::new(SynoClient {

--- a/rust/synology-filestation-fuse/src/main.rs
+++ b/rust/synology-filestation-fuse/src/main.rs
@@ -113,7 +113,8 @@ fn main() -> anyhow::Result<()> {
         info!("SMB reachable — mount will prefer it over the HTTP API");
         client = client
             .with_read_transport(smb.clone())
-            .with_write_transport(smb);
+            .with_write_transport(smb.clone())
+            .with_stream_write_transport(smb);
     }
 
     let client = Arc::new(client);

--- a/rust/synology-filestation-smb/Cargo.toml
+++ b/rust/synology-filestation-smb/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 # validated against the AD-joined, SMB3-only e4e-nas.
 smb2 = "0.13"
 bytes = "1"
-tokio = { version = "1", features = ["rt", "sync", "macros", "time"] }
+tokio = { version = "1", features = ["rt", "sync", "macros", "time", "io-util", "fs"] }
 tracing = "0.1"
 async-trait = "0.1"
 # Shared error model so SMB failures classify the same way HTTP ones do.

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -240,6 +240,19 @@ impl SmbTransport {
         Ok(Bytes::from(data))
     }
 
+    /// Delete a file at `logical`.
+    pub async fn delete(&self, logical: &str) -> Result<(), SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        ensure_tree(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        client
+            .delete_file(tree, &loc.path)
+            .await
+            .map_err(|e| to_syno_error(&e))
+    }
+
     /// Read an entire file. Uses the pipelined, chunked read so multi-MB `.ORF`
     /// files (past the 8 MiB `MaxReadSize`) come back whole.
     pub async fn read_full(&self, logical: &str) -> Result<Bytes, SynoFsError> {

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -11,6 +11,7 @@
 //! connection pool (future work).
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,7 +19,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use bytes::Bytes;
 use smb2::{ClientConfig, SmbClient, Tree};
-use synology_filestation_core::{ReadTransport, SynoFsError, WriteTransport};
+use synology_filestation_core::{ReadTransport, StreamWriteTransport, SynoFsError, WriteTransport};
+use tokio::io::AsyncReadExt;
 use tokio::sync::Mutex;
 
 use crate::error::to_syno_error;
@@ -302,36 +304,69 @@ impl SmbTransport {
             return Err(to_syno_error(&e));
         }
 
-        // Fast path: the target name is free → a single rename commits.
-        match client.rename(tree, &tmp, &loc.path).await {
-            Ok(()) => return Ok(()),
-            Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {} // replace below
-            Err(e) => {
-                let _ = client.delete_file(tree, &tmp).await;
-                return Err(to_syno_error(&e));
+        commit_temp(client, tree, &tmp, &loc.path, seq).await
+    }
+
+    /// Stream a local file to `logical` (old-or-new) **without buffering it in
+    /// memory** — for staging large files. Chunks are read from disk and written
+    /// straight to an SMB temp file via a streaming writer, then committed onto
+    /// the target with the same move-aside guarantee as [`write_atomic`].
+    ///
+    /// [`write_atomic`]: Self::write_atomic
+    pub async fn write_from_path(&self, logical: &str, local: &Path) -> Result<(), SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+        let seq = PART_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp = part_name(&loc.path, seq);
+
+        let mut file = tokio::fs::File::open(local)
+            .await
+            .map_err(|e| SynoFsError::Io(format!("open {}: {e}", local.display())))?;
+
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        ensure_tree(client, trees, &loc.share).await?;
+
+        // Streaming writer to the temp file (owned; retains no borrow of client).
+        let mut writer = {
+            let tree = trees.get(&loc.share).expect("tree just ensured");
+            match client.create_file_writer(tree, &tmp).await {
+                Ok(w) => w,
+                Err(e) => return Err(to_syno_error(&e)),
             }
+        };
+
+        // Pump disk → SMB in bounded chunks (constant memory, ~1 MiB).
+        let mut buf = vec![0u8; 1 << 20];
+        let mut stream_err: Option<SynoFsError> = None;
+        loop {
+            match file.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Err(e) = writer.write_chunk(&buf[..n]).await {
+                        stream_err = Some(to_syno_error(&e));
+                        break;
+                    }
+                }
+                Err(e) => {
+                    stream_err = Some(SynoFsError::Io(format!("read {}: {e}", local.display())));
+                    break;
+                }
+            }
+        }
+        // Always finalize to close the SMB handle; surface a finish error only if
+        // the pump itself hadn't already failed.
+        if let Err(e) = writer.finish().await {
+            stream_err.get_or_insert_with(|| to_syno_error(&e));
         }
 
-        // Replace path: move the old file aside, move the new one in, drop the
-        // backup. We never delete the only copy of the data, so a failure at any
-        // step leaves the old file recoverable (from the backup) and the new
-        // bytes recoverable (from the temp).
-        let backup = part_name(&format!("{}.bak", loc.path), seq);
-        if let Err(e) = client.rename(tree, &loc.path, &backup).await {
-            let _ = client.delete_file(tree, &tmp).await;
-            return Err(to_syno_error(&e));
+        if let Some(e) = stream_err {
+            let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+            let _ = client.delete_file(tree, &tmp).await; // best-effort cleanup
+            return Err(e);
         }
-        match client.rename(tree, &tmp, &loc.path).await {
-            Ok(()) => {
-                let _ = client.delete_file(tree, &backup).await; // best-effort
-                Ok(())
-            }
-            Err(e) => {
-                // Put the old file back; leave the new bytes in `tmp`.
-                let _ = client.rename(tree, &backup, &loc.path).await;
-                Err(to_syno_error(&e))
-            }
-        }
+
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        commit_temp(client, tree, &tmp, &loc.path, seq).await
     }
 }
 
@@ -354,6 +389,54 @@ impl ReadTransport for SmbTransport {
 impl WriteTransport for SmbTransport {
     async fn write(&self, path: &str, data: &[u8]) -> Result<(), SynoFsError> {
         self.write_atomic(path, data).await
+    }
+}
+
+#[async_trait]
+impl StreamWriteTransport for SmbTransport {
+    async fn write_from_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError> {
+        SmbTransport::write_from_path(self, remote_path, local).await
+    }
+}
+
+/// Commit a fully-written temp file onto `target` with an **old-or-new**
+/// guarantee. Fast path: a single rename. On a name collision (DSM's rename is
+/// `ReplaceIfExists=false`) the old file is moved aside to a backup, the temp is
+/// renamed in, and the backup dropped — restoring the old file on failure and
+/// never deleting the only copy of the data. Shared by [`SmbTransport::write_atomic`]
+/// and [`SmbTransport::write_from_path`].
+async fn commit_temp(
+    client: &mut SmbClient,
+    tree: &mut Tree,
+    tmp: &str,
+    target: &str,
+    seq: u64,
+) -> Result<(), SynoFsError> {
+    // Fast path: the target name is free → a single rename commits.
+    match client.rename(tree, tmp, target).await {
+        Ok(()) => return Ok(()),
+        Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {} // replace below
+        Err(e) => {
+            let _ = client.delete_file(tree, tmp).await;
+            return Err(to_syno_error(&e));
+        }
+    }
+
+    // Replace path: move-aside so no step ever deletes the only copy.
+    let backup = part_name(&format!("{target}.bak"), seq);
+    if let Err(e) = client.rename(tree, target, &backup).await {
+        let _ = client.delete_file(tree, tmp).await;
+        return Err(to_syno_error(&e));
+    }
+    match client.rename(tree, tmp, target).await {
+        Ok(()) => {
+            let _ = client.delete_file(tree, &backup).await; // best-effort
+            Ok(())
+        }
+        Err(e) => {
+            let _ = client.rename(tree, &backup, target).await; // restore old
+            Err(to_syno_error(&e))
+        }
     }
 }
 

--- a/rust/synology-filestation-smb/tests/live_smb.rs
+++ b/rust/synology-filestation-smb/tests/live_smb.rs
@@ -69,3 +69,60 @@ async fn live_read_over_smb() {
         full.len()
     );
 }
+
+/// Write-path validation — separate and doubly-gated so it never writes to the
+/// NAS by accident. Provide `SMB2_WRITE_LOGICAL` pointing at a **scratch** file
+/// you don't mind being created/overwritten/deleted (e.g. a temp share):
+///
+/// ```text
+/// SMB2_HOST=e4e-nas.ucsd.edu SMB2_DOMAIN=KRG SMB2_USER=… SMB2_PASS='…' \
+/// SMB2_WRITE_LOGICAL='/scratch/smb-spike-write-test.bin' \
+/// nix develop ../.. -c cargo test -p synology-filestation-smb -- --ignored --nocapture write_
+/// ```
+///
+/// Exercises both `write_atomic` paths: the create case (single rename) and the
+/// overwrite case (move-aside), reading the bytes back each time, then cleans up.
+#[tokio::test]
+#[ignore = "writes to the NAS; set SMB2_WRITE_LOGICAL to a scratch path and run with --ignored"]
+async fn write_roundtrip_over_smb() {
+    let (host, user, pass, logical) = match (
+        env("SMB2_HOST"),
+        env("SMB2_USER"),
+        env("SMB2_PASS"),
+        env("SMB2_WRITE_LOGICAL"),
+    ) {
+        (Some(h), Some(u), Some(p), Some(l)) => (h, u, p, l),
+        _ => panic!("set SMB2_HOST, SMB2_USER, SMB2_PASS, SMB2_WRITE_LOGICAL (a scratch path)"),
+    };
+
+    let mut cfg = SmbConfig::new(host, user, pass);
+    cfg.domain = env("SMB2_DOMAIN").unwrap_or_default();
+    let smb = SmbTransport::connect(&cfg).await.expect("connect + auth");
+
+    // 1. Create case: target should not exist → single-rename fast path.
+    let first = b"smb write roundtrip: create".to_vec();
+    smb.write_atomic(&logical, &first)
+        .await
+        .expect("create write");
+    let back = smb.read_full(&logical).await.expect("read back create");
+    assert_eq!(back.as_ref(), first.as_slice(), "create bytes round-trip");
+
+    // 2. Overwrite case: target now exists → move-aside replace path.
+    let second = b"smb write roundtrip: overwrite (longer than the first payload)".to_vec();
+    smb.write_atomic(&logical, &second)
+        .await
+        .expect("overwrite write");
+    let back = smb.read_full(&logical).await.expect("read back overwrite");
+    assert_eq!(
+        back.as_ref(),
+        second.as_slice(),
+        "overwrite bytes round-trip"
+    );
+
+    // 3. stat agrees, then clean up the scratch file.
+    let meta = smb.stat(&logical).await.expect("stat after write");
+    assert_eq!(meta.size, second.len() as u64);
+    let _ = smb.delete(&logical).await; // best-effort cleanup
+
+    println!("OK: write create + overwrite round-trip; scratch cleaned up");
+}


### PR DESCRIPTION
## Why

Uploads still buffered the whole file in memory — `WriteTransport::write(&[u8])` / core `upload(Vec<u8>)` / Python `upload` all read the file in first. This adds a **streaming** write path so staging a large file (e.g. a multi-GB `.ORF`) flows disk → NAS in bounded chunks. It's transparent: the existing `upload` / fsspec `_put_file` now stream, no API change.

## Design note — why file-based, not a reader

Streaming + fallback needs a **re-openable** source. A `&mut Reader` gets consumed by a failed SMB attempt, so the HTTP fallback couldn't retry it. So the streaming API takes a **local path** (`write_from_path(remote, local)`) — which is also exactly the bulk-staging case and lets the fallback re-open the file.

## core

- **`StreamWriteTransport`** trait + **`SynologyClient::upload_from_path`** — same ordered-selection + circuit-breaker + `overwrite` semantics as `upload`. Fallback reads the file in and takes the HTTP path (memory win applies to the SMB path; correctness holds either way).

## smb

- **`write_from_path`** streams disk → an SMB temp file via `create_file_writer` (~1 MiB chunks, constant memory), then commits with the shared **`commit_temp`** move-aside (old-or-new). `write_atomic` refactored onto the same helper.

## Consumers (transparent)

- All inject the SMB stream backend alongside read/write.
- Python `Client.upload` / `AsyncClient.upload` **now stream** (dropped the eager `std::fs::read`); added `AsyncClient.upload_file(local, remote_path)` for a differing remote name; fsspec `_put_file` streams through it.

## Also in this branch

A doubly-gated **live write-path test** (`SMB2_WRITE_LOGICAL`, `--ignored`) exercising `write_atomic`'s create + overwrite paths against a real NAS, plus `SmbTransport::delete` for its cleanup. (The write path still hasn't been run against real DSM — reads were validated; this is the harness.)

## Tests

TDD core selection/fallback/overwrite-guard with a fake stream backend. `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and **69 pytest** all green.

## Follow-ups (tracked)

- Truly-atomic replace (`ReplaceIfExists=true` — needs an upstream `smb2` change) to drop the brief name-absent window on overwrite.
- SMB reconnect after a mid-session network flap (`smb2` 0.13 `auto_reconnect` is a no-op) — matters for long-lived FUSE mounts.
- Streaming **reads** (`download_to_path` currently buffers) — symmetric follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)