### PR TITLE
feat: streaming reads (fetch large files straight to disk)

### DIFF
--- a/python/synology_filestation/src/lib.rs
+++ b/python/synology_filestation/src/lib.rs
@@ -339,17 +339,9 @@ impl Client {
                         .login(username, password, otp)
                         .await
                         .map_err(|e| SynoFsError::LoginFailed(Box::new(e)))?;
-                    let client = match synology_filestation_smb::auto_connect(
-                        host, username, password,
-                    )
-                    .await
-                    {
-                        Some(smb) => client
-                            .with_read_transport(smb.clone())
-                            .with_write_transport(smb.clone())
-                            .with_stream_write_transport(smb),
-                        None => client,
-                    };
+                    let client =
+                        synology_filestation_smb::auto_attach(client, host, username, password)
+                            .await;
                     Ok::<_, SynoFsError>(client)
                 })
             })
@@ -646,13 +638,7 @@ impl AsyncClient {
                 .map_err(|e| synofs_to_pyerr_gil(SynoFsError::LoginFailed(Box::new(e))))?;
             // Transparently prefer SMB when reachable; None → HTTP only.
             let client =
-                match synology_filestation_smb::auto_connect(&host, &username, &password).await {
-                    Some(smb) => client
-                        .with_read_transport(smb.clone())
-                        .with_write_transport(smb.clone())
-                        .with_stream_write_transport(smb),
-                    None => client,
-                };
+                synology_filestation_smb::auto_attach(client, &host, &username, &password).await;
             Ok(AsyncClient {
                 inner: Arc::new(client),
             })

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -8,7 +8,8 @@ use tracing::{debug, warn};
 
 use crate::error::{dsm_code_to_category, ErrorCategory, SynoFsError};
 use crate::transport::{
-    BreakerConfig, CircuitBreaker, ReadTransport, StreamWriteTransport, WriteTransport,
+    BreakerConfig, CircuitBreaker, ReadTransport, StreamReadTransport, StreamWriteTransport,
+    WriteTransport,
 };
 use crate::types::{
     AuthData, CreateFolderData, GetInfoData, ListData, ListShareData, RenameData, SynoFileInfo,
@@ -193,6 +194,9 @@ pub struct SynologyClient {
     /// Injected streaming write backends, tried in order by `upload_from_path`
     /// before falling back to reading the file into memory + HTTP upload.
     stream_write_transports: Vec<TransportEntry<dyn StreamWriteTransport>>,
+    /// Injected streaming read backends, tried in order by `download_to_path`
+    /// before falling back to the buffering HTTP download.
+    stream_read_transports: Vec<TransportEntry<dyn StreamReadTransport>>,
 }
 
 impl std::fmt::Debug for SynologyClient {
@@ -207,6 +211,7 @@ impl std::fmt::Debug for SynologyClient {
                 "stream_write_transports",
                 &self.stream_write_transports.len(),
             )
+            .field("stream_read_transports", &self.stream_read_transports.len())
             .finish_non_exhaustive()
     }
 }
@@ -246,6 +251,7 @@ impl SynologyClient {
             read_transports: Vec::new(),
             write_transports: Vec::new(),
             stream_write_transports: Vec::new(),
+            stream_read_transports: Vec::new(),
         }
     }
 
@@ -275,6 +281,15 @@ impl SynologyClient {
     /// file into memory + HTTP upload on transport failures.
     pub fn with_stream_write_transport(mut self, transport: Arc<dyn StreamWriteTransport>) -> Self {
         self.stream_write_transports
+            .push(TransportEntry::new(transport));
+        self
+    }
+
+    /// Inject a [`StreamReadTransport`] backend. `download_to_path` will stream
+    /// straight to disk through it when healthy, falling back to the buffering
+    /// HTTP download on transport failures.
+    pub fn with_stream_read_transport(mut self, transport: Arc<dyn StreamReadTransport>) -> Self {
+        self.stream_read_transports
             .push(TransportEntry::new(transport));
         self
     }
@@ -628,20 +643,53 @@ impl SynologyClient {
         }
     }
 
-    /// Download a remote file atomically to `local_path`.
+    /// Download a remote file atomically to `local_path`, preferring a
+    /// [`StreamReadTransport`] backend (SMB) so a large file streams straight to
+    /// disk with no in-memory copy.
     ///
-    /// Bytes are first written to `<local_path>.part`, fsynced, then renamed
-    /// to `local_path`. The final file is therefore never observed in a
-    /// partial state — either it's complete and correct, or it doesn't exist.
-    /// If any step fails (network error, DSM JSON-error envelope, I/O error)
-    /// the temporary file is removed and `local_path` is left untouched.
-    ///
-    /// This guards against the common DSM footgun of `200 OK` responses whose
-    /// body is `{"success":false,"error":{"code":119}}` — the synology-api
-    /// PyPI package opens its destination in `'wb'` first and silently leaves
-    /// a 0-byte file in this scenario.
+    /// The destination is never observed partial — either complete or absent.
+    /// On a transport failure the backend's breaker trips and we fall back to
+    /// the buffering HTTP download; a definitive error (not-found / permission)
+    /// propagates. With no stream backend injected this is exactly the HTTP
+    /// download — today's behavior.
     #[allow(dead_code)] // unused by the FUSE binary today; consumed by python bindings.
     pub async fn download_to_path(
+        &self,
+        remote_path: &str,
+        local_path: &Path,
+    ) -> Result<(), SynoFsError> {
+        for entry in &self.stream_read_transports {
+            let allowed = entry.breaker.lock().unwrap().allows(Instant::now());
+            if !allowed {
+                continue;
+            }
+            match entry.transport.read_to_path(remote_path, local_path).await {
+                Ok(()) => {
+                    entry.breaker.lock().unwrap().on_success();
+                    return Ok(());
+                }
+                Err(e) if e.category() == ErrorCategory::Transport => {
+                    warn!("stream read backend failed (transient), falling back: {e}");
+                    entry.breaker.lock().unwrap().on_failure(Instant::now());
+                    continue;
+                }
+                Err(e) => {
+                    entry.breaker.lock().unwrap().on_success();
+                    return Err(e);
+                }
+            }
+        }
+        self.http_download_to_path(remote_path, local_path).await
+    }
+
+    /// HTTP download-to-file: buffer the bytes, then write atomically
+    /// (`<local_path>.part`, fsync, rename). Used when no stream backend is
+    /// injected, and as the fallback when one trips its breaker.
+    ///
+    /// Guards against the DSM footgun of `200 OK` responses whose body is
+    /// `{"success":false,"error":{"code":119}}` — the synology-api PyPI package
+    /// opens its destination in `'wb'` first and silently leaves a 0-byte file.
+    async fn http_download_to_path(
         &self,
         remote_path: &str,
         local_path: &Path,
@@ -2525,6 +2573,23 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
+    impl StreamReadTransport for FakeBackend {
+        async fn read_to_path(&self, _remote: &str, local: &Path) -> Result<(), SynoFsError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.behave {
+                // A real backend writes the destination; do the same so tests
+                // can assert on the file it produced.
+                Behave::Ok(b) => {
+                    std::fs::write(local, b).map_err(|e| SynoFsError::Io(e.to_string()))?;
+                    Ok(())
+                }
+                Behave::Transient => Err(SynoFsError::Io("backend down".into())),
+                Behave::NotFound => Err(SynoFsError::NotFound),
+            }
+        }
+    }
+
     /// A client pointed at a dead address (no HTTP server) — proves a call is
     /// served by the backend without ever touching HTTP.
     fn offline_client() -> SynologyClient {
@@ -2717,5 +2782,54 @@ mod tests {
             "overwrite=false must skip the streaming backend"
         );
         std::fs::remove_file(&src).ok();
+    }
+
+    // ── streaming download (download_to_path) selection ──────────────────────
+
+    #[tokio::test]
+    async fn download_to_path_prefers_stream_backend_and_skips_http() {
+        let backend = FakeBackend::new(Behave::Ok(b"streamed to disk"));
+        let client = offline_client().with_stream_read_transport(backend.clone());
+        let dest = unique_tmp_path("stream-dl.bin");
+        client.download_to_path("/share/f", &dest).await.unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"streamed to disk");
+        assert_eq!(backend.call_count(), 1);
+        std::fs::remove_file(&dest).ok();
+    }
+
+    #[tokio::test]
+    async fn download_to_path_falls_back_to_http_on_transient() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"from-http".to_vec()))
+            .mount(&server)
+            .await;
+        let backend = FakeBackend::new(Behave::Transient);
+        let client = client_for(&server).with_stream_read_transport(backend.clone());
+        let dest = unique_tmp_path("stream-dl-fallback.bin");
+        client.download_to_path("/share/f", &dest).await.unwrap();
+        assert_eq!(
+            std::fs::read(&dest).unwrap(),
+            b"from-http",
+            "fell back to HTTP"
+        );
+        assert_eq!(backend.call_count(), 1);
+        std::fs::remove_file(&dest).ok();
+    }
+
+    #[tokio::test]
+    async fn download_to_path_propagates_definitive_backend_error() {
+        let backend = FakeBackend::new(Behave::NotFound);
+        let client = offline_client().with_stream_read_transport(backend.clone());
+        let dest = unique_tmp_path("stream-dl-missing.bin");
+        let err = client
+            .download_to_path("/share/missing", &dest)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SynoFsError::NotFound));
+        assert_eq!(backend.call_count(), 1);
+        assert!(!dest.exists(), "definitive failure leaves no file");
     }
 }

--- a/rust/synology-filestation-core/src/lib.rs
+++ b/rust/synology-filestation-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod types;
 pub use client::{SynologyClient, ThrottleConfig};
 pub use error::SynoFsError;
 pub use transport::{
-    BreakerConfig, CircuitBreaker, ReadTransport, StreamWriteTransport, WriteTransport,
+    BreakerConfig, CircuitBreaker, ReadTransport, StreamReadTransport, StreamWriteTransport,
+    WriteTransport,
 };
 pub use types::{SynoAdditional, SynoFileInfo, SynoOwner, SynoPerm, SynoTime};

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -47,6 +47,20 @@ pub trait ReadTransport: Send + Sync {
     async fn read(&self, path: &str, offset: u64, length: u64) -> Result<Bytes, SynoFsError>;
 }
 
+/// A read backend that **streams** a remote file to a local path without
+/// buffering it in memory — the symmetric counterpart of [`StreamWriteTransport`],
+/// for fetching large files (e.g. `.ORF`).
+///
+/// The destination is a **local path**: the implementor writes it atomically
+/// (old-or-nothing — a failed fetch leaves no file, so the selection layer's
+/// HTTP fallback can write cleanly). Same transient-vs-definitive error contract
+/// as [`ReadTransport`].
+#[async_trait]
+pub trait StreamReadTransport: Send + Sync {
+    /// Stream `remote_path` into the local file `local`, atomically.
+    async fn read_to_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError>;
+}
+
 /// A write backend replacing a whole file, as an alternative to the HTTP Upload
 /// API. Implementations MUST NOT leave a partial target on failure — see the
 /// [module docs](self#write-contract).

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -328,15 +328,9 @@ pub unsafe extern "C" fn syno_connect(
                 // Transparently prefer SMB for transfers when reachable (the GUI
                 // browser's downloads, and a GUI-initiated mount, then bypass
                 // synoscgi); silently HTTP-only otherwise.
-                let client = match runtime.block_on(synology_filestation_smb::auto_connect(
-                    host, username, password,
-                )) {
-                    Some(smb) => client
-                        .with_read_transport(smb.clone())
-                        .with_write_transport(smb.clone())
-                        .with_stream_write_transport(smb),
-                    None => client,
-                };
+                let client = runtime.block_on(synology_filestation_smb::auto_attach(
+                    client, host, username, password,
+                ));
                 let handle = Box::new(SynoClient {
                     inner: Arc::new(client),
                     runtime,

--- a/rust/synology-filestation-fuse/src/main.rs
+++ b/rust/synology-filestation-fuse/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> anyhow::Result<()> {
         args.port
     );
 
-    let mut client = SynologyClient::new(&args.host, args.port, args.https);
+    let client = SynologyClient::new(&args.host, args.port, args.https);
 
     let password = match args.password {
         Some(p) => p,
@@ -105,19 +105,12 @@ fn main() -> anyhow::Result<()> {
     // Transparently prefer SMB for the mount's reads/writes when the NAS's SMB
     // service is reachable — this bypasses synoscgi entirely. Silently HTTP-only
     // otherwise. Injected before the client is shared, since it consumes it.
-    if let Some(smb) = rt.block_on(synology_filestation_smb::auto_connect(
+    let client = Arc::new(rt.block_on(synology_filestation_smb::auto_attach(
+        client,
         &args.host,
         &args.username,
         &password,
-    )) {
-        info!("SMB reachable — mount will prefer it over the HTTP API");
-        client = client
-            .with_read_transport(smb.clone())
-            .with_write_transport(smb.clone())
-            .with_stream_write_transport(smb);
-    }
-
-    let client = Arc::new(client);
+    )));
 
     let opts = MountOptions {
         cache_ttl: args.cache_ttl,

--- a/rust/synology-filestation-smb/src/lib.rs
+++ b/rust/synology-filestation-smb/src/lib.rs
@@ -31,4 +31,4 @@ pub mod transport;
 
 pub use error::to_syno_error;
 pub use path::SmbPath;
-pub use transport::{auto_connect, FileMeta, SmbConfig, SmbTransport};
+pub use transport::{auto_attach, auto_connect, FileMeta, SmbConfig, SmbTransport};

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -19,8 +19,11 @@ use std::time::Duration;
 use async_trait::async_trait;
 use bytes::Bytes;
 use smb2::{ClientConfig, SmbClient, Tree};
-use synology_filestation_core::{ReadTransport, StreamWriteTransport, SynoFsError, WriteTransport};
-use tokio::io::AsyncReadExt;
+use synology_filestation_core::{
+    ReadTransport, StreamReadTransport, StreamWriteTransport, SynoFsError, SynologyClient,
+    WriteTransport,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
 
 use crate::error::to_syno_error;
@@ -147,6 +150,28 @@ pub async fn auto_connect(host: &str, username: &str, password: &str) -> Option<
     }
 }
 
+/// [`auto_connect`] + attach: connect SMB from the login credentials and inject
+/// it into `client` as the preferred backend for **reads, writes, and streaming
+/// transfers**. Returns the client unchanged when SMB is unavailable.
+///
+/// This one call is the entire consumer integration — a consumer never lists the
+/// individual backends, so adding a future backend here never touches consumers.
+pub async fn auto_attach(
+    client: SynologyClient,
+    host: &str,
+    username: &str,
+    password: &str,
+) -> SynologyClient {
+    match auto_connect(host, username, password).await {
+        Some(smb) => client
+            .with_read_transport(smb.clone())
+            .with_write_transport(smb.clone())
+            .with_stream_write_transport(smb.clone())
+            .with_stream_read_transport(smb),
+        None => client,
+    }
+}
+
 /// Minimal file metadata — enough for the verify-once integrity check that
 /// compares SMB against the FileStation API's `getinfo` before trusting SMB.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -268,6 +293,58 @@ impl SmbTransport {
             .await
             .map_err(|e| to_syno_error(&e))?;
         Ok(Bytes::from(data))
+    }
+
+    /// Stream a remote file to the local path `local` **without buffering it in
+    /// memory** — for fetching large files. Chunks stream from SMB straight to a
+    /// local temp file, which is fsynced and renamed onto `local` (atomic
+    /// old-or-nothing; a failure leaves no destination).
+    pub async fn read_to_path(&self, logical: &str, local: &Path) -> Result<(), SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+        let tmp = {
+            let mut t = local.as_os_str().to_os_string();
+            t.push(".part");
+            std::path::PathBuf::from(t)
+        };
+
+        let result: Result<(), SynoFsError> = async {
+            let mut guard = self.inner.lock().await;
+            let Inner { client, trees } = &mut *guard;
+            ensure_tree(client, trees, &loc.share).await?;
+
+            // Streaming download handle (owned; retains no borrow of client).
+            let mut download = {
+                let tree = trees.get(&loc.share).expect("tree just ensured");
+                client
+                    .download(tree, &loc.path)
+                    .await
+                    .map_err(|e| to_syno_error(&e))?
+            };
+
+            // Pump SMB → local temp in bounded chunks (constant memory).
+            let mut file = tokio::fs::File::create(&tmp)
+                .await
+                .map_err(|e| SynoFsError::Io(format!("create {}: {e}", tmp.display())))?;
+            while let Some(chunk) = download.next_chunk().await {
+                let bytes = chunk.map_err(|e| to_syno_error(&e))?;
+                file.write_all(&bytes)
+                    .await
+                    .map_err(|e| SynoFsError::Io(format!("write {}: {e}", tmp.display())))?;
+            }
+            file.sync_all()
+                .await
+                .map_err(|e| SynoFsError::Io(format!("fsync {}: {e}", tmp.display())))?;
+            drop(file);
+            tokio::fs::rename(&tmp, local)
+                .await
+                .map_err(|e| SynoFsError::Io(format!("rename to {}: {e}", local.display())))
+        }
+        .await;
+
+        if result.is_err() {
+            let _ = tokio::fs::remove_file(&tmp).await; // best-effort cleanup
+        }
+        result
     }
 
     /// Replace the file at `logical` with `data`, guaranteeing **old-or-new**:
@@ -396,6 +473,13 @@ impl WriteTransport for SmbTransport {
 impl StreamWriteTransport for SmbTransport {
     async fn write_from_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError> {
         SmbTransport::write_from_path(self, remote_path, local).await
+    }
+}
+
+#[async_trait]
+impl StreamReadTransport for SmbTransport {
+    async fn read_to_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError> {
+        SmbTransport::read_to_path(self, remote_path, local).await
     }
 }
 

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -38,6 +38,28 @@ fn part_name(path: &str, seq: u64) -> String {
     format!("{path}.part-{}-{}", std::process::id(), seq)
 }
 
+/// Map a **local** filesystem error to a *definitive* [`SynoFsError`] (never
+/// `Transport`).
+///
+/// A local failure — disk full, unwritable destination, missing source — can't
+/// be fixed by falling back to another transport (HTTP would hit the same local
+/// I/O, after buffering the whole file in memory first), so the selection layer
+/// must not retry it elsewhere. The detail is logged since the definitive
+/// variants carry no message.
+fn local_fs_error(what: &str, e: &std::io::Error) -> SynoFsError {
+    use std::io::ErrorKind;
+    tracing::warn!(error = %e, "{what}");
+    match e.kind() {
+        ErrorKind::PermissionDenied => SynoFsError::PermissionDenied,
+        ErrorKind::NotFound => SynoFsError::NotFound,
+        ErrorKind::AlreadyExists => SynoFsError::AlreadyExists,
+        // ENOSPC has no stable ErrorKind; detect via the raw errno (28 on unix).
+        _ if e.raw_os_error() == Some(28) => SynoFsError::NoSpace,
+        // Any other local FS failure is still definitive — don't fall back.
+        _ => SynoFsError::InvalidArg,
+    }
+}
+
 /// Connection parameters for [`SmbTransport::connect`].
 #[derive(Debug, Clone)]
 pub struct SmbConfig {
@@ -324,20 +346,20 @@ impl SmbTransport {
             // Pump SMB → local temp in bounded chunks (constant memory).
             let mut file = tokio::fs::File::create(&tmp)
                 .await
-                .map_err(|e| SynoFsError::Io(format!("create {}: {e}", tmp.display())))?;
+                .map_err(|e| local_fs_error(&format!("create {}", tmp.display()), &e))?;
             while let Some(chunk) = download.next_chunk().await {
                 let bytes = chunk.map_err(|e| to_syno_error(&e))?;
                 file.write_all(&bytes)
                     .await
-                    .map_err(|e| SynoFsError::Io(format!("write {}: {e}", tmp.display())))?;
+                    .map_err(|e| local_fs_error(&format!("write {}", tmp.display()), &e))?;
             }
             file.sync_all()
                 .await
-                .map_err(|e| SynoFsError::Io(format!("fsync {}: {e}", tmp.display())))?;
+                .map_err(|e| local_fs_error(&format!("fsync {}", tmp.display()), &e))?;
             drop(file);
             tokio::fs::rename(&tmp, local)
                 .await
-                .map_err(|e| SynoFsError::Io(format!("rename to {}: {e}", local.display())))
+                .map_err(|e| local_fs_error(&format!("rename to {}", local.display()), &e))
         }
         .await;
 
@@ -397,7 +419,7 @@ impl SmbTransport {
 
         let mut file = tokio::fs::File::open(local)
             .await
-            .map_err(|e| SynoFsError::Io(format!("open {}: {e}", local.display())))?;
+            .map_err(|e| local_fs_error(&format!("open {}", local.display()), &e))?;
 
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;


### PR DESCRIPTION
## Why

The symmetric counterpart of streaming writes (#132): `download_to_path` buffered the whole file in memory (`download` → `Bytes` → disk). This streams a remote file **straight to disk** in bounded chunks. Transparent — Python `download_to` / fsspec `_get_file` stream with no API change.

## core

- **`StreamReadTransport`** trait: `read_to_path(remote, local)`. File-based (writes the destination atomically, old-or-nothing) so the HTTP fallback can write cleanly after a failed attempt — same reasoning as the write side.
- **`download_to_path`** now prefers a stream-read backend (SMB) with the same circuit-breaker + fallback semantics, ending at the existing buffering HTTP path (renamed `http_download_to_path`).

## smb

- **`read_to_path`** streams SMB → a local temp via the `download`/`next_chunk` handle (~1 MiB chunks), then fsync + rename onto the destination.

## Consumer cleanup: `auto_attach`

There were now **four** backends to inject (read / write / stream-write / stream-read) at four consumer sites. Replaced all of it with one helper:

```rust
client = smb::auto_attach(client, host, user, pass).await;
```

`auto_attach` connects SMB and injects all four. Python (both clients), FUSE, and FFI now call it instead of hand-listing backends — so **adding a future backend (NFS/S3/cache) never touches a consumer again**.

## Tests

TDD core stream-read selection/fallback/definitive with a fake backend that writes the destination. `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and **69 pytest** green.

## Follow-ups (tracked)

- SMB reconnect after a mid-session network flap (next up).
- Truly-atomic replace (`ReplaceIfExists=true`, upstream `smb2`).
- Live validation of the write/read-to-path paths against real DSM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)