### PR TITLE
feat(smb): reconnect after a network flap instead of degrading to HTTP

### DIFF
--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -50,6 +50,43 @@ fn is_connection_lost(kind: smb2::ErrorKind) -> bool {
     )
 }
 
+/// Tracks whether the SMB link needs re-establishing. Isolated from `SmbClient`
+/// so the reconnect decision is unit-testable without a live connection.
+#[derive(Debug, Default)]
+struct ReconnectState {
+    needs: AtomicBool,
+}
+
+impl ReconnectState {
+    /// Flag for reconnect if `kind` means the link is dead.
+    fn flag_if_lost(&self, kind: smb2::ErrorKind) {
+        if is_connection_lost(kind) {
+            self.needs.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// If flagged, run `reconnect` (clearing the flag first). Returns `Ok(true)`
+    /// when a reconnect ran and succeeded — the caller then drops its stale tree
+    /// cache. On failure the flag is re-set so the next operation retries, and
+    /// the error is returned. `Ok(false)` means no reconnect was needed.
+    async fn reconnect_if_needed<F, Fut>(&self, reconnect: F) -> Result<bool, smb2::Error>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = Result<(), smb2::Error>>,
+    {
+        if !self.needs.swap(false, Ordering::SeqCst) {
+            return Ok(false);
+        }
+        match reconnect().await {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                self.needs.store(true, Ordering::SeqCst);
+                Err(e)
+            }
+        }
+    }
+}
+
 /// Map a **local** filesystem error to a *definitive* [`SynoFsError`] (never
 /// `Transport`).
 ///
@@ -223,10 +260,10 @@ struct Inner {
 /// An authenticated SMB connection that reads NAS files.
 pub struct SmbTransport {
     inner: Mutex<Inner>,
-    /// Set when an operation sees the SMB link is dead; the next operation
-    /// reconnects before using it. `smb2` doesn't auto-reconnect, so without
-    /// this a mount would degrade to HTTP permanently after one network flap.
-    needs_reconnect: AtomicBool,
+    /// Tracks whether the SMB link needs re-establishing. `smb2` doesn't
+    /// auto-reconnect, so without this a mount would degrade to HTTP permanently
+    /// after one network flap.
+    reconnect: ReconnectState,
 }
 
 impl SmbTransport {
@@ -250,17 +287,23 @@ impl SmbTransport {
                 client,
                 trees: HashMap::new(),
             }),
-            needs_reconnect: AtomicBool::new(false),
+            reconnect: ReconnectState::default(),
         })
     }
 
     /// Map an `smb2::Error`, flagging the connection for reconnect when the
     /// error means the link is dead — so the next operation re-establishes it.
     fn mark_and_map(&self, e: &smb2::Error) -> SynoFsError {
-        if is_connection_lost(e.kind()) {
-            self.needs_reconnect.store(true, Ordering::SeqCst);
-        }
+        self.reconnect.flag_if_lost(e.kind());
         to_syno_error(e)
+    }
+
+    /// Run a best-effort cleanup op, ignoring its result **except** to flag the
+    /// link for reconnect if it revealed a dead connection.
+    fn note_cleanup(&self, r: Result<(), smb2::Error>) {
+        if let Err(e) = r {
+            self.reconnect.flag_if_lost(e.kind());
+        }
     }
 
     /// Reconnect if a prior operation flagged the SMB link dead, then attach the
@@ -274,11 +317,12 @@ impl SmbTransport {
         trees: &mut HashMap<String, Tree>,
         share: &str,
     ) -> Result<(), SynoFsError> {
-        if self.needs_reconnect.swap(false, Ordering::SeqCst) {
-            if let Err(e) = client.reconnect().await {
-                self.needs_reconnect.store(true, Ordering::SeqCst);
-                return Err(self.mark_and_map(&e));
-            }
+        let reconnected = self
+            .reconnect
+            .reconnect_if_needed(|| client.reconnect())
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+        if reconnected {
             trees.clear(); // the cached trees belonged to the dead session
         }
         if !trees.contains_key(share) {
@@ -306,23 +350,23 @@ impl SmbTransport {
             Ok(()) => return Ok(()),
             Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {} // replace below
             Err(e) => {
-                let _ = client.delete_file(tree, tmp).await;
+                self.note_cleanup(client.delete_file(tree, tmp).await);
                 return Err(self.mark_and_map(&e));
             }
         }
         // Move the old file aside so no step ever deletes the only copy.
         let backup = part_name(&format!("{target}.bak"), seq);
         if let Err(e) = client.rename(tree, target, &backup).await {
-            let _ = client.delete_file(tree, tmp).await;
+            self.note_cleanup(client.delete_file(tree, tmp).await);
             return Err(self.mark_and_map(&e));
         }
         match client.rename(tree, tmp, target).await {
             Ok(()) => {
-                let _ = client.delete_file(tree, &backup).await; // best-effort
+                self.note_cleanup(client.delete_file(tree, &backup).await); // best-effort
                 Ok(())
             }
             Err(e) => {
-                let _ = client.rename(tree, &backup, target).await; // restore old
+                self.note_cleanup(client.rename(tree, &backup, target).await); // restore old
                 Err(self.mark_and_map(&e))
             }
         }
@@ -490,7 +534,7 @@ impl SmbTransport {
         // New contents → temp file adjacent to the target (pipelined, so files
         // past the server's MaxWriteSize go in chunks).
         if let Err(e) = client.write_file_pipelined(tree, &tmp, data).await {
-            let _ = client.delete_file(tree, &tmp).await; // best-effort cleanup
+            self.note_cleanup(client.delete_file(tree, &tmp).await); // best-effort cleanup
             return Err(self.mark_and_map(&e));
         }
 
@@ -551,7 +595,7 @@ impl SmbTransport {
 
         if let Some(e) = stream_err {
             let tree = trees.get_mut(&loc.share).expect("tree just ensured");
-            let _ = client.delete_file(tree, &tmp).await; // best-effort cleanup
+            self.note_cleanup(client.delete_file(tree, &tmp).await); // best-effort cleanup
             return Err(e);
         }
 
@@ -610,6 +654,63 @@ mod tests {
         assert!(!is_connection_lost(smb2::ErrorKind::NotFound));
         assert!(!is_connection_lost(smb2::ErrorKind::AccessDenied));
         assert!(!is_connection_lost(smb2::ErrorKind::SharingViolation));
+    }
+
+    #[tokio::test]
+    async fn reconnect_runs_only_when_flagged_then_clears() {
+        let state = ReconnectState::default();
+        // Not flagged → no reconnect, and the closure is never run.
+        let ran = state
+            .reconnect_if_needed(|| async { panic!("should not reconnect") })
+            .await
+            .unwrap();
+        assert!(!ran);
+
+        // A connection-lost error flags it → reconnect runs once and succeeds.
+        state.flag_if_lost(smb2::ErrorKind::ConnectionLost);
+        let ran = state
+            .reconnect_if_needed(|| async { Ok(()) })
+            .await
+            .unwrap();
+        assert!(
+            ran,
+            "flagged → reconnect ran (caller clears its tree cache)"
+        );
+
+        // Flag cleared on success → the next op is a no-op again.
+        let ran = state
+            .reconnect_if_needed(|| async { panic!("should not reconnect") })
+            .await
+            .unwrap();
+        assert!(!ran);
+    }
+
+    #[tokio::test]
+    async fn failed_reconnect_keeps_the_flag_set_for_retry() {
+        let state = ReconnectState::default();
+        state.flag_if_lost(smb2::ErrorKind::TimedOut);
+        // Reconnect fails → error surfaces, flag stays set.
+        assert!(state
+            .reconnect_if_needed(|| async { Err(smb2::Error::Disconnected) })
+            .await
+            .is_err());
+        // Still flagged → the next operation retries the reconnect.
+        let ran = state
+            .reconnect_if_needed(|| async { Ok(()) })
+            .await
+            .unwrap();
+        assert!(ran, "flag persisted so reconnect is retried");
+    }
+
+    #[tokio::test]
+    async fn per_request_errors_do_not_flag_reconnect() {
+        let state = ReconnectState::default();
+        state.flag_if_lost(smb2::ErrorKind::NotFound); // not a link failure
+        let ran = state
+            .reconnect_if_needed(|| async { panic!("should not reconnect") })
+            .await
+            .unwrap();
+        assert!(!ran);
     }
 
     #[test]

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,6 +36,18 @@ static PART_SEQ: AtomicU64 = AtomicU64::new(0);
 /// Name of the adjacent temp file an atomic write goes to before the rename.
 fn part_name(path: &str, seq: u64) -> String {
     format!("{path}.part-{}-{}", std::process::id(), seq)
+}
+
+/// Whether an `smb2` error means the connection itself is dead (so the transport
+/// should reconnect before the next operation), vs. a per-request error the live
+/// connection can keep serving.
+fn is_connection_lost(kind: smb2::ErrorKind) -> bool {
+    matches!(
+        kind,
+        smb2::ErrorKind::ConnectionLost
+            | smb2::ErrorKind::TimedOut
+            | smb2::ErrorKind::SessionExpired
+    )
 }
 
 /// Map a **local** filesystem error to a *definitive* [`SynoFsError`] (never
@@ -211,6 +223,10 @@ struct Inner {
 /// An authenticated SMB connection that reads NAS files.
 pub struct SmbTransport {
     inner: Mutex<Inner>,
+    /// Set when an operation sees the SMB link is dead; the next operation
+    /// reconnects before using it. `smb2` doesn't auto-reconnect, so without
+    /// this a mount would degrade to HTTP permanently after one network flap.
+    needs_reconnect: AtomicBool,
 }
 
 impl SmbTransport {
@@ -234,7 +250,82 @@ impl SmbTransport {
                 client,
                 trees: HashMap::new(),
             }),
+            needs_reconnect: AtomicBool::new(false),
         })
+    }
+
+    /// Map an `smb2::Error`, flagging the connection for reconnect when the
+    /// error means the link is dead — so the next operation re-establishes it.
+    fn mark_and_map(&self, e: &smb2::Error) -> SynoFsError {
+        if is_connection_lost(e.kind()) {
+            self.needs_reconnect.store(true, Ordering::SeqCst);
+        }
+        to_syno_error(e)
+    }
+
+    /// Reconnect if a prior operation flagged the SMB link dead, then attach the
+    /// share. This is what lets a long-lived mount recover after a network flap:
+    /// once the network is back, the next operation (e.g. a circuit-breaker
+    /// half-open probe) rebuilds the session here and succeeds, closing the
+    /// breaker — instead of degrading to HTTP for the rest of the session.
+    async fn ensure_ready(
+        &self,
+        client: &mut SmbClient,
+        trees: &mut HashMap<String, Tree>,
+        share: &str,
+    ) -> Result<(), SynoFsError> {
+        if self.needs_reconnect.swap(false, Ordering::SeqCst) {
+            if let Err(e) = client.reconnect().await {
+                self.needs_reconnect.store(true, Ordering::SeqCst);
+                return Err(self.mark_and_map(&e));
+            }
+            trees.clear(); // the cached trees belonged to the dead session
+        }
+        if !trees.contains_key(share) {
+            let tree = client
+                .connect_share(share)
+                .await
+                .map_err(|e| self.mark_and_map(&e))?;
+            trees.insert(share.to_string(), tree);
+        }
+        Ok(())
+    }
+
+    /// Commit a fully-written temp file onto `target` with an **old-or-new**
+    /// guarantee (fast rename, or move-aside on a name collision). See the
+    /// module note; shared by `write_atomic` and `write_from_path`.
+    async fn commit_temp(
+        &self,
+        client: &mut SmbClient,
+        tree: &mut Tree,
+        tmp: &str,
+        target: &str,
+        seq: u64,
+    ) -> Result<(), SynoFsError> {
+        match client.rename(tree, tmp, target).await {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {} // replace below
+            Err(e) => {
+                let _ = client.delete_file(tree, tmp).await;
+                return Err(self.mark_and_map(&e));
+            }
+        }
+        // Move the old file aside so no step ever deletes the only copy.
+        let backup = part_name(&format!("{target}.bak"), seq);
+        if let Err(e) = client.rename(tree, target, &backup).await {
+            let _ = client.delete_file(tree, tmp).await;
+            return Err(self.mark_and_map(&e));
+        }
+        match client.rename(tree, tmp, target).await {
+            Ok(()) => {
+                let _ = client.delete_file(tree, &backup).await; // best-effort
+                Ok(())
+            }
+            Err(e) => {
+                let _ = client.rename(tree, &backup, target).await; // restore old
+                Err(self.mark_and_map(&e))
+            }
+        }
     }
 
     /// Metadata for a logical path (`/share/sub/file`).
@@ -242,12 +333,12 @@ impl SmbTransport {
         let loc = SmbPath::from_logical(logical)?;
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;
-        ensure_tree(client, trees, &loc.share).await?;
+        self.ensure_ready(client, trees, &loc.share).await?;
         let tree = trees.get_mut(&loc.share).expect("tree just ensured");
         let info = client
             .stat(tree, &loc.path)
             .await
-            .map_err(|e| to_syno_error(&e))?;
+            .map_err(|e| self.mark_and_map(&e))?;
         Ok(FileMeta {
             size: info.size,
             is_directory: info.is_directory,
@@ -274,18 +365,18 @@ impl SmbTransport {
         let mut guard = guard;
         {
             let Inner { client, trees } = &mut *guard;
-            ensure_tree(client, trees, &loc.share).await?;
+            self.ensure_ready(client, trees, &loc.share).await?;
         }
         let Inner { client, trees } = &*guard;
         let tree = trees.get(&loc.share).expect("tree just ensured");
         let reader = client
             .open_file_reader(tree, &loc.path)
             .await
-            .map_err(|e| to_syno_error(&e))?;
+            .map_err(|e| self.mark_and_map(&e))?;
         let data = reader
             .read_at(offset, length)
             .await
-            .map_err(|e| to_syno_error(&e))?;
+            .map_err(|e| self.mark_and_map(&e))?;
         Ok(Bytes::from(data))
     }
 
@@ -294,12 +385,12 @@ impl SmbTransport {
         let loc = SmbPath::from_logical(logical)?;
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;
-        ensure_tree(client, trees, &loc.share).await?;
+        self.ensure_ready(client, trees, &loc.share).await?;
         let tree = trees.get_mut(&loc.share).expect("tree just ensured");
         client
             .delete_file(tree, &loc.path)
             .await
-            .map_err(|e| to_syno_error(&e))
+            .map_err(|e| self.mark_and_map(&e))
     }
 
     /// Read an entire file. Uses the pipelined, chunked read so multi-MB `.ORF`
@@ -308,12 +399,12 @@ impl SmbTransport {
         let loc = SmbPath::from_logical(logical)?;
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;
-        ensure_tree(client, trees, &loc.share).await?;
+        self.ensure_ready(client, trees, &loc.share).await?;
         let tree = trees.get_mut(&loc.share).expect("tree just ensured");
         let data = client
             .read_file_pipelined(tree, &loc.path)
             .await
-            .map_err(|e| to_syno_error(&e))?;
+            .map_err(|e| self.mark_and_map(&e))?;
         Ok(Bytes::from(data))
     }
 
@@ -332,7 +423,7 @@ impl SmbTransport {
         let result: Result<(), SynoFsError> = async {
             let mut guard = self.inner.lock().await;
             let Inner { client, trees } = &mut *guard;
-            ensure_tree(client, trees, &loc.share).await?;
+            self.ensure_ready(client, trees, &loc.share).await?;
 
             // Streaming download handle (owned; retains no borrow of client).
             let mut download = {
@@ -340,7 +431,7 @@ impl SmbTransport {
                 client
                     .download(tree, &loc.path)
                     .await
-                    .map_err(|e| to_syno_error(&e))?
+                    .map_err(|e| self.mark_and_map(&e))?
             };
 
             // Pump SMB → local temp in bounded chunks (constant memory).
@@ -348,7 +439,7 @@ impl SmbTransport {
                 .await
                 .map_err(|e| local_fs_error(&format!("create {}", tmp.display()), &e))?;
             while let Some(chunk) = download.next_chunk().await {
-                let bytes = chunk.map_err(|e| to_syno_error(&e))?;
+                let bytes = chunk.map_err(|e| self.mark_and_map(&e))?;
                 file.write_all(&bytes)
                     .await
                     .map_err(|e| local_fs_error(&format!("write {}", tmp.display()), &e))?;
@@ -393,17 +484,17 @@ impl SmbTransport {
 
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;
-        ensure_tree(client, trees, &loc.share).await?;
+        self.ensure_ready(client, trees, &loc.share).await?;
         let tree = trees.get_mut(&loc.share).expect("tree just ensured");
 
         // New contents → temp file adjacent to the target (pipelined, so files
         // past the server's MaxWriteSize go in chunks).
         if let Err(e) = client.write_file_pipelined(tree, &tmp, data).await {
             let _ = client.delete_file(tree, &tmp).await; // best-effort cleanup
-            return Err(to_syno_error(&e));
+            return Err(self.mark_and_map(&e));
         }
 
-        commit_temp(client, tree, &tmp, &loc.path, seq).await
+        self.commit_temp(client, tree, &tmp, &loc.path, seq).await
     }
 
     /// Stream a local file to `logical` (old-or-new) **without buffering it in
@@ -423,14 +514,14 @@ impl SmbTransport {
 
         let mut guard = self.inner.lock().await;
         let Inner { client, trees } = &mut *guard;
-        ensure_tree(client, trees, &loc.share).await?;
+        self.ensure_ready(client, trees, &loc.share).await?;
 
         // Streaming writer to the temp file (owned; retains no borrow of client).
         let mut writer = {
             let tree = trees.get(&loc.share).expect("tree just ensured");
             match client.create_file_writer(tree, &tmp).await {
                 Ok(w) => w,
-                Err(e) => return Err(to_syno_error(&e)),
+                Err(e) => return Err(self.mark_and_map(&e)),
             }
         };
 
@@ -442,7 +533,7 @@ impl SmbTransport {
                 Ok(0) => break,
                 Ok(n) => {
                     if let Err(e) = writer.write_chunk(&buf[..n]).await {
-                        stream_err = Some(to_syno_error(&e));
+                        stream_err = Some(self.mark_and_map(&e));
                         break;
                     }
                 }
@@ -455,7 +546,7 @@ impl SmbTransport {
         // Always finalize to close the SMB handle; surface a finish error only if
         // the pump itself hadn't already failed.
         if let Err(e) = writer.finish().await {
-            stream_err.get_or_insert_with(|| to_syno_error(&e));
+            stream_err.get_or_insert_with(|| self.mark_and_map(&e));
         }
 
         if let Some(e) = stream_err {
@@ -465,7 +556,7 @@ impl SmbTransport {
         }
 
         let tree = trees.get_mut(&loc.share).expect("tree just ensured");
-        commit_temp(client, tree, &tmp, &loc.path, seq).await
+        self.commit_temp(client, tree, &tmp, &loc.path, seq).await
     }
 }
 
@@ -505,67 +596,21 @@ impl StreamReadTransport for SmbTransport {
     }
 }
 
-/// Commit a fully-written temp file onto `target` with an **old-or-new**
-/// guarantee. Fast path: a single rename. On a name collision (DSM's rename is
-/// `ReplaceIfExists=false`) the old file is moved aside to a backup, the temp is
-/// renamed in, and the backup dropped — restoring the old file on failure and
-/// never deleting the only copy of the data. Shared by [`SmbTransport::write_atomic`]
-/// and [`SmbTransport::write_from_path`].
-async fn commit_temp(
-    client: &mut SmbClient,
-    tree: &mut Tree,
-    tmp: &str,
-    target: &str,
-    seq: u64,
-) -> Result<(), SynoFsError> {
-    // Fast path: the target name is free → a single rename commits.
-    match client.rename(tree, tmp, target).await {
-        Ok(()) => return Ok(()),
-        Err(e) if e.kind() == smb2::ErrorKind::AlreadyExists => {} // replace below
-        Err(e) => {
-            let _ = client.delete_file(tree, tmp).await;
-            return Err(to_syno_error(&e));
-        }
-    }
-
-    // Replace path: move-aside so no step ever deletes the only copy.
-    let backup = part_name(&format!("{target}.bak"), seq);
-    if let Err(e) = client.rename(tree, target, &backup).await {
-        let _ = client.delete_file(tree, tmp).await;
-        return Err(to_syno_error(&e));
-    }
-    match client.rename(tree, tmp, target).await {
-        Ok(()) => {
-            let _ = client.delete_file(tree, &backup).await; // best-effort
-            Ok(())
-        }
-        Err(e) => {
-            let _ = client.rename(tree, &backup, target).await; // restore old
-            Err(to_syno_error(&e))
-        }
-    }
-}
-
-/// Attach `share` if it isn't already, caching the `Tree`. Split borrows of the
-/// two `Inner` fields so callers can then use `client` and the tree together.
-async fn ensure_tree(
-    client: &mut SmbClient,
-    trees: &mut HashMap<String, Tree>,
-    share: &str,
-) -> Result<(), SynoFsError> {
-    if !trees.contains_key(share) {
-        let tree = client
-            .connect_share(share)
-            .await
-            .map_err(|e| to_syno_error(&e))?;
-        trees.insert(share.to_string(), tree);
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connection_lost_kinds_trigger_reconnect() {
+        // These mean the link is dead → reconnect before the next op.
+        assert!(is_connection_lost(smb2::ErrorKind::ConnectionLost));
+        assert!(is_connection_lost(smb2::ErrorKind::TimedOut));
+        assert!(is_connection_lost(smb2::ErrorKind::SessionExpired));
+        // These are per-request; the connection is still good.
+        assert!(!is_connection_lost(smb2::ErrorKind::NotFound));
+        assert!(!is_connection_lost(smb2::ErrorKind::AccessDenied));
+        assert!(!is_connection_lost(smb2::ErrorKind::SharingViolation));
+    }
 
     #[test]
     fn part_name_is_adjacent_and_unique_per_seq() {


### PR DESCRIPTION
## Why

`smb2` 0.13 doesn't auto-reconnect. So once the SMB link died mid-session (a network flap, NAS reboot, VPN change), the injected `SmbTransport` stayed broken: the circuit breaker's half-open probes kept hitting the *dead* connection and re-opening, so a **long-lived mount degraded to HTTP permanently** even after the network came back. (Short-lived Temporal activities were fine — they reconnect per activity.)

## Fix

Track a `needs_reconnect` flag:
- **Set** it (in `mark_and_map`) whenever an operation sees a connection-lost error — `ConnectionLost` / `TimedOut` / `SessionExpired`. Per-request errors (`NotFound`, `AccessDenied`, `SharingViolation`) do **not** trip it.
- **Act** on it in `ensure_ready` (run before every op): call `SmbClient::reconnect()` (rebuilds the connection + session from the stored credentials), drop the now-stale tree cache, and proceed.

Net effect: after the network returns, the circuit breaker's next half-open probe re-establishes SMB here and **succeeds, closing the breaker on its own** — no restart needed.

Refactored the shared `ensure_tree`/`commit_temp` free functions into methods so all SMB error mapping flows through `mark_and_map` (complete flag coverage).

## Tests

Unit-tests the reconnect trigger (`is_connection_lost` — which `ErrorKind`s reconnect vs not). The reconnect behavior itself is live-only, covered by the `#[ignore]`d integration tests. `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and **69 pytest** green.

## Follow-ups (remaining)

- Truly-atomic replace (`ReplaceIfExists=true`, upstream `smb2`).
- Live validation of the write / stream paths against real DSM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)