### PR TITLE
build(deps): bring Rust crates to latest (reqwest 0.13, pyo3 0.29, fuser 0.18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,15 +1111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,29 +1565,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -1605,19 +1593,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1625,9 +1612,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.12.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45192e5e4a4d2505587e27806c7b710c231c40c56f3bfc19535d0bb25df52264"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -1636,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1648,13 +1635,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.119",
 ]
@@ -2306,9 +2292,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -2566,12 +2552,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,17 +265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,10 +361,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -743,10 +752,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -756,11 +763,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "rand_core",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -943,7 +948,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1152,6 +1156,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,12 +1257,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -1397,6 +1444,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "page_size"
@@ -1607,62 +1660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,30 +1675,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core",
-]
 
 [[package]]
 name = "redox_syscall"
@@ -1763,9 +1740,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1782,9 +1759,9 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1798,7 +1775,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1843,6 +1819,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,14 +1842,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1890,10 +1913,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2015,6 +2085,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2212,7 @@ dependencies = [
  "bytes",
  "libc",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -2261,21 +2348,6 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -2565,6 +2637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,20 +2727,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2684,6 +2756,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/python/synology_filestation/Cargo.toml
+++ b/python/synology_filestation/Cargo.toml
@@ -19,15 +19,14 @@ synology-filestation-smb = { path = "../../rust/synology-filestation-smb" }
 
 # abi3-py310 lets a single Linux wheel cover Python 3.10 through whatever's
 # current. Tied to pyproject.toml's `requires-python = ">=3.10"` and the CI
-# test matrix (3.10–3.13). Bumping pyo3 itself to 0.24+ later is a straight
-# find/replace; pyo3-async-runtimes versions track pyo3 versions.
-pyo3 = { version = "0.23", features = ["extension-module", "abi3-py310"] }
-pyo3-async-runtimes = { version = "0.23", features = ["tokio-runtime"] }
+# test matrix (3.10–3.13). pyo3-async-runtimes versions track pyo3 versions.
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"] }
+pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 
 # pyo3-log routes Rust `log` records into Python's `logging`. tracing-log
 # adapts our existing `tracing` events to the `log` crate so the bridge is
 # end-to-end.
-pyo3-log = "0.12"
+pyo3-log = "0.13"
 tracing-log = "0.2"
 
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/python/synology_filestation/src/lib.rs
+++ b/python/synology_filestation/src/lib.rs
@@ -272,7 +272,7 @@ impl Client {
         // We must release the GIL while blocking on async work — otherwise
         // every Python thread waiting on a network call would serialize and
         // deadlock-prone code in user-land would pay through the nose.
-        py.allow_threads(|| self.runtime.block_on(fut))
+        py.detach(|| self.runtime.block_on(fut))
             .map_err(|e| synofs_to_pyerr(py, e))
     }
 }
@@ -333,7 +333,7 @@ impl Client {
         // synofs_to_pyerr routes to the AuthError class.
         let rt = runtime.clone();
         let client = py
-            .allow_threads(move || {
+            .detach(move || {
                 rt.block_on(async move {
                     client
                         .login(username, password, otp)
@@ -361,7 +361,7 @@ impl Client {
     fn exists(&self, py: Python<'_>, path: &str) -> PyResult<bool> {
         let inner = self.inner.clone();
         let path = path.to_string();
-        let result = py.allow_threads(|| {
+        let result = py.detach(|| {
             self.runtime
                 .block_on(async { inner.with_relogin_retry(|| inner.get_info(&path)).await })
         });
@@ -379,7 +379,7 @@ impl Client {
         let inner = self.inner.clone();
         let path_owned = path.to_string();
         let info = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(async {
                     inner
                         .with_relogin_retry(|| inner.get_info(&path_owned))
@@ -409,7 +409,7 @@ impl Client {
         let inner = self.inner.clone();
         let path_owned = path.to_string();
         let bytes = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(async {
                     inner
                         .with_relogin_retry(|| inner.download(&path_owned, offset, length))
@@ -424,7 +424,7 @@ impl Client {
         let inner = self.inner.clone();
         let path_owned = path.to_string();
         let entries = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime.block_on(async {
                     inner
                         .with_relogin_retry(|| inner.list_dir(&path_owned))
@@ -438,7 +438,7 @@ impl Client {
     fn list_shares<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
         let inner = self.inner.clone();
         let shares = py
-            .allow_threads(|| {
+            .detach(|| {
                 self.runtime
                     .block_on(async { inner.with_relogin_retry(|| inner.list_shares()).await })
             })
@@ -460,7 +460,7 @@ impl Client {
         let (folder, filename) = split_remote_path(remote_path)?;
         let buf = data.to_vec();
         let inner = self.inner.clone();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime.block_on(async {
                 inner
                     .with_relogin_retry(|| inner.upload(&folder, &filename, buf.clone(), overwrite))
@@ -474,7 +474,7 @@ impl Client {
         let inner = self.inner.clone();
         let remote = remote_path.to_string();
         let local: PathBuf = local_path.into();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime
                 .block_on(async { inner.download_to_path(&remote, &local).await })
         })
@@ -502,7 +502,7 @@ impl Client {
         let remote_dir = remote_dir.to_string();
         // Streams the file straight to SMB when available (no in-memory copy);
         // falls back to reading it in + HTTP upload otherwise. API unchanged.
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime.block_on(async {
                 inner
                     .with_relogin_retry(|| {
@@ -525,7 +525,7 @@ impl Client {
         let inner = self.inner.clone();
         let parent = parent_dir.to_string();
         let name = name.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime.block_on(async {
                 inner
                     .with_relogin_retry(|| inner.create_folder(&parent, &name))
@@ -539,7 +539,7 @@ impl Client {
     fn delete(&self, py: Python<'_>, remote_path: &str) -> PyResult<()> {
         let inner = self.inner.clone();
         let path = remote_path.to_string();
-        py.allow_threads(|| {
+        py.detach(|| {
             self.runtime
                 .block_on(async { inner.with_relogin_retry(|| inner.delete(&path)).await })
         })
@@ -554,14 +554,14 @@ impl Client {
     fn __exit__(
         &self,
         py: Python<'_>,
-        exc_type: PyObject,
-        exc_value: PyObject,
-        traceback: PyObject,
+        exc_type: Py<PyAny>,
+        exc_value: Py<PyAny>,
+        traceback: Py<PyAny>,
     ) -> PyResult<bool> {
         // Best-effort logout: a failure during logout shouldn't shadow an
         // exception in the `with` body, so swallow logout errors entirely.
         let inner = self.inner.clone();
-        let _ = py.allow_threads(|| self.runtime.block_on(async move { inner.logout().await }));
+        let _ = py.detach(|| self.runtime.block_on(async move { inner.logout().await }));
         Ok(false) // do not suppress exceptions raised inside the `with` block
     }
 }
@@ -579,13 +579,13 @@ use pyo3_async_runtimes::tokio::future_into_py;
 /// blocks where we don't have a Python token in scope but need to construct
 /// a typed Python exception before returning.
 fn synofs_to_pyerr_gil(e: SynoFsError) -> PyErr {
-    Python::with_gil(|py| synofs_to_pyerr(py, e))
+    Python::attach(|py| synofs_to_pyerr(py, e))
 }
 
 /// Same as `synofs_to_pyerr_gil` but applies the getinfo-specific 408 →
 /// NoSuchFile remap. Centralized so sync and async getinfo agree.
 fn getinfo_err_gil(e: SynoFsError) -> PyErr {
-    Python::with_gil(|py| match e {
+    Python::attach(|py| match e {
         SynoFsError::ApiError(408) => synofs_to_pyerr(py, SynoFsError::NotFound),
         other => synofs_to_pyerr(py, other),
     })
@@ -672,7 +672,7 @@ impl AsyncClient {
                 .with_relogin_retry(|| inner.get_info(&path))
                 .await
                 .map_err(getinfo_err_gil)?;
-            Python::with_gil(|py| -> PyResult<Py<PyDict>> {
+            Python::attach(|py| -> PyResult<Py<PyDict>> {
                 fileinfo_to_pydict(py, &info).map(|d| d.unbind())
             })
         })
@@ -692,9 +692,7 @@ impl AsyncClient {
                 .with_relogin_retry(|| inner.download(&path, offset, length))
                 .await
                 .map_err(synofs_to_pyerr_gil)?;
-            Python::with_gil(|py| -> PyResult<Py<PyBytes>> {
-                Ok(PyBytes::new(py, &bytes).unbind())
-            })
+            Python::attach(|py| -> PyResult<Py<PyBytes>> { Ok(PyBytes::new(py, &bytes).unbind()) })
         })
     }
 
@@ -705,7 +703,7 @@ impl AsyncClient {
                 .with_relogin_retry(|| inner.list_dir(&path))
                 .await
                 .map_err(synofs_to_pyerr_gil)?;
-            Python::with_gil(|py| -> PyResult<Py<pyo3::types::PyList>> {
+            Python::attach(|py| -> PyResult<Py<pyo3::types::PyList>> {
                 let dicts: Vec<Bound<'_, PyDict>> = entries
                     .iter()
                     .map(|f| fileinfo_to_pydict(py, f))
@@ -722,7 +720,7 @@ impl AsyncClient {
                 .with_relogin_retry(|| inner.list_shares())
                 .await
                 .map_err(synofs_to_pyerr_gil)?;
-            Python::with_gil(|py| -> PyResult<Py<pyo3::types::PyList>> {
+            Python::attach(|py| -> PyResult<Py<pyo3::types::PyList>> {
                 let dicts: Vec<Bound<'_, PyDict>> = shares
                     .iter()
                     .map(|s| fileinfo_to_pydict(py, s))
@@ -781,9 +779,7 @@ impl AsyncClient {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .ok_or_else(|| {
-                    Python::with_gil(|_py| {
-                        PyErr::new::<InvalidArg, _>("local_path has no filename")
-                    })
+                    Python::attach(|_py| PyErr::new::<InvalidArg, _>("local_path has no filename"))
                 })?
                 .to_string();
             let local = std::path::PathBuf::from(&local_path);

--- a/rust/synology-filestation-core/Cargo.toml
+++ b/rust/synology-filestation-core/Cargo.toml
@@ -11,7 +11,12 @@ path = "src/lib.rs"
 
 [dependencies]
 tokio       = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros", "sync", "io-util", "fs"] }
-reqwest     = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }
+reqwest     = { version = "0.13", features = ["json", "multipart", "query", "rustls-no-provider"], default-features = false }
+# reqwest 0.13 drops ring as the rustls crypto provider in favour of aws-lc-rs
+# (which needs cmake + a C toolchain, and NASM on Windows). We keep the pre-0.13
+# ring provider — matching the old `rustls-tls` build footprint so CI needs no
+# new build tools — and install it as the process default in `SynologyClient::new`.
+rustls      = { version = "0.23", default-features = false, features = ["ring"] }
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 bytes       = "1"

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -216,8 +216,23 @@ impl std::fmt::Debug for SynologyClient {
     }
 }
 
+/// Install the ring `CryptoProvider` as the process default exactly once.
+///
+/// reqwest 0.13 is built with `rustls-no-provider`, so rustls has no compiled-in
+/// provider and needs one installed before the first TLS `ClientConfig` is built.
+/// We use ring (not aws-lc-rs) to keep the build free of cmake/NASM. `install_default`
+/// errors if a provider is already set — by another crate or a second client — which
+/// is exactly the idempotent outcome we want, so the result is intentionally ignored.
+fn install_crypto_provider() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 impl SynologyClient {
     pub fn new(host: &str, port: u16, https: bool) -> Self {
+        install_crypto_provider();
         let scheme = if https { "https" } else { "http" };
         let base_url = format!("{}://{}:{}/webapi", scheme, host, port);
         let http = Client::builder()
@@ -1197,6 +1212,23 @@ mod tests {
         let (host, port_str) = without_scheme.rsplit_once(':').unwrap();
         let port: u16 = port_str.parse().unwrap();
         SynologyClient::with_auto_relogin(host, port, false)
+    }
+
+    // ── TLS crypto provider ────────────────────────────────────────────────────
+
+    /// reqwest 0.13 is built with `rustls-no-provider`, so rustls ships no
+    /// compiled-in crypto provider. `SynologyClient::new` must install one (ring)
+    /// as the process default, otherwise the first HTTPS handshake to the NAS
+    /// panics/fails. The wiremock tests only speak HTTP and would not catch this,
+    /// so pin it directly: after constructing an HTTPS client a default provider
+    /// must be present.
+    #[test]
+    fn https_client_installs_default_crypto_provider() {
+        let _client = SynologyClient::new("nas.example.invalid", 5001, true);
+        assert!(
+            rustls::crypto::CryptoProvider::get_default().is_some(),
+            "SynologyClient::new must install a default rustls CryptoProvider"
+        );
     }
 
     // ── login ────────────────────────────────────────────────────────────────

--- a/rust/synology-filestation-fuse/Cargo.toml
+++ b/rust/synology-filestation-fuse/Cargo.toml
@@ -19,7 +19,7 @@ synology-filestation-core = { path = "../synology-filestation-core", version = "
 synology-filestation-smb = { path = "../synology-filestation-smb" }
 
 tokio       = { version = "1", features = ["full"] }
-reqwest     = { version = "0.12", features = ["json", "multipart", "rustls-tls"], default-features = false }
+reqwest     = { version = "0.13", features = ["json", "multipart", "query", "rustls-no-provider"], default-features = false }
 serde       = { version = "1", features = ["derive"] }
 serde_json  = "1"
 clap        = { version = "4", features = ["derive", "env"] }


### PR DESCRIPTION
Brings the Rust dependency surface to latest. Four atomic, individually-revertable commits; single Cargo.lock evolution. All gated on local `nix develop` runs.

## Commits
1. **cargo update within ranges** — refreshes Cargo.lock for every caret-range crate (anyhow, bytes, clap, hyper, serde_json, quinn-proto, futures, libc, …). Supersedes Dependabot #130/#118/#117/#115/#102/#101.
2. **fuser 0.17 → 0.18** — `spawn_mount2` was renamed to `spawn_mount` (same `&Config` signature); one call site. Linux-only backend.
3. **reqwest 0.12 → 0.13** — feature `rustls-tls`→`rustls`, `.query()` now behind the new `query` feature. **Crypto provider:** reqwest 0.13 defaults rustls to **aws-lc-rs** (needs cmake + C toolchain, NASM on Windows). To keep the build footprint identical — this repo ships a manylinux wheel and a Windows MSI, and CI installs no such tools — we build with `rustls-no-provider` + the `rustls` crate's `ring` feature and install ring as the process-default provider in `SynologyClient::new()`. Lockfile confirms **no aws-lc / cmake** pulled in. New regression test `https_client_installs_default_crypto_provider` (the wiremock suite is HTTP-only and can't catch a missing TLS provider).
4. **pyo3 0.23 → 0.29** (+ pyo3-async-runtimes 0.29, pyo3-log 0.13) — the removed GIL API needed three mechanical renames: `Python::with_gil`→`Python::attach`, `allow_threads`→`detach`, `PyObject`→`Py<PyAny>`. Bound<> API + `create_exception!` were already current.

## Verification (local, nix dev shell)
- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo test --workspace`: **122 passed** (incl. reconnect/streaming/throttle suites)
- forced native-ext rebuild → `uv run pytest`: **69 passed** (pyo3 0.29.0 confirmed in Cargo.lock)

> Note: the aws-lc-rs vs ring choice is deliberate — happy to switch to aws-lc-rs and add nasm/cmake to CI instead if you'd prefer the blessed default. Say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)