### PR TITLE
fix: make internal core dependency path-only so 0.x bumps resolve

### DIFF
--- a/python/synology_filestation/Cargo.toml
+++ b/python/synology_filestation/Cargo.toml
@@ -11,7 +11,7 @@ name = "synology_filestation"
 crate-type = ["cdylib"]
 
 [dependencies]
-synology-filestation-core = { path = "../../rust/synology-filestation-core", version = "0.1.16" }
+synology-filestation-core = { path = "../../rust/synology-filestation-core" }
 # In-process SMB backend. The client transparently prefers it over the HTTP
 # Download/Upload API when reachable, protecting the NAS's shared synoscgi
 # backend; falls back to HTTP automatically otherwise.

--- a/rust/synology-filestation-ffi/Cargo.toml
+++ b/rust/synology-filestation-ffi/Cargo.toml
@@ -11,9 +11,9 @@ name = "synology_filestation_ffi"
 crate-type = ["cdylib"]
 
 [dependencies]
-synology-filestation-core = { path = "../synology-filestation-core", version = "0.1.19" }
+synology-filestation-core = { path = "../synology-filestation-core" }
 synology-filestation-smb = { path = "../synology-filestation-smb" }
-synology-filestation-fuse = { path = "../synology-filestation-fuse", version = "0.1.19" }
+synology-filestation-fuse = { path = "../synology-filestation-fuse" }
 
 tokio       = { version = "1", features = ["rt", "rt-multi-thread"] }
 serde_json  = "1"

--- a/rust/synology-filestation-fuse/Cargo.toml
+++ b/rust/synology-filestation-fuse/Cargo.toml
@@ -15,7 +15,7 @@ name = "synology-filestation-fuse"
 path = "src/main.rs"
 
 [dependencies]
-synology-filestation-core = { path = "../synology-filestation-core", version = "0.1.16" }
+synology-filestation-core = { path = "../synology-filestation-core" }
 synology-filestation-smb = { path = "../synology-filestation-smb" }
 
 tokio       = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Problem

The 0.2.0 release PR (#125) fails `build-linux`/`build-macos`/`build-windows`/`flake-check` with:
```
error: failed to select a version for the requirement `synology-filestation-core = "^0.1.16"`
```

`fuse`/`ffi`/`python` pin the internal `synology-filestation-core` dependency at `version = "0.1.16"` / `"0.1.19"` — a `^0.1.x` requirement that means `>=0.1.16, <0.2.0`. On `main` core is `0.1.20` (satisfies it, so `main` builds), but the release bumps core to **0.2.0**, which the `<0.2.0` bound rejects → cargo can't resolve.

It's a pre-existing inconsistency (the pins were already stale vs core's actual version); crossing the `0.2.0` boundary is what exposes it.

## Fix

Drop the version requirement → **path-only**, matching how the `smb` crate already declares its core dep (which is why `smb` never hit this). A path-only dependency has no version constraint, so it resolves to the workspace crate regardless of version bump. These crates ship as installers/wheel (no `cargo publish`), so the version field bought nothing — and `ffi` isn't release-please-managed, so its pin would never be auto-bumped anyway; path-only is the only durable fix for it.

## Verified

In a scratch worktree with core temporarily set to `0.2.0` (reproducing the release condition), `cargo metadata` resolves cleanly with the path-only deps. No `Cargo.lock` change (the resolved core version is unchanged on `main`).

Once merged, release-please regenerates #125 with these path-only deps and the builds go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)