### PR TITLE
chore(release-please): give root-level GUI/installer commits a package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  ".": "0.2.0",
   "rust/synology-filestation-core": "0.2.0",
   "rust/synology-filestation-fuse": "0.2.0",
   "python/synology_filestation": "0.2.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,13 +230,16 @@ MVVM pattern (Avalonia). The GUI calls the Rust core **directly via the FFI cdyl
 
 Uses [release-please](https://github.com/googleapis/release-please-action) on the `main` branch. Commit messages follow **Conventional Commits** (`fix:` → patch, `feat:` → minor, `feat!:` → major).
 
-The repo has **three release-please packages** linked together via the `linked-versions` plugin (so they always bump to the same version, but each ships its own changelog and tag):
+The repo has **four release-please packages** linked together via the `linked-versions` plugin (so they always bump to the same version, but each ships its own changelog and tag):
 
 | Package | Tag prefix | Artifacts on release |
 |---|---|---|
+| `.` (GUI + installers)            | `synology-filestation-gui-v...`   | (changelog + `SynologyFuse.Gui.csproj` `<Version>` bump) |
 | `rust/synology-filestation-core`  | `synology-filestation-core-v...`  | (Cargo.toml bump only) |
 | `rust/synology-filestation-fuse`  | `synology-filestation-fuse-v...`  | `.deb`, `.pkg`, `.msi`, `*-Setup.exe` |
 | `python/synology_filestation`     | `synology_filestation-v...`       | `*.whl` (manylinux 2_34, x86_64) |
+
+**Why a root package exists.** release-please attributes a commit to a package by *path*, and the .NET projects (`SynologyFuse.Gui/`, `SynologyFuse.Tests/`, `SynologyFuse.*Installer/`) live at the repo root — outside every `rust/` and `python/` package. Without a package keyed `"."` those commits are "homeless": no package sees them, so no release PR is opened at all. (`include-paths` is *not* a release-please option — only `exclude-paths` is — so an earlier attempt to attribute them to the fuse package was a silent no-op.) The root package is given all commits and then filtered by `exclude-paths`, which drops any commit whose files live entirely under `rust/`, `python/`, `.github/`, or `nix/`. Since it is in the linked-versions group, a GUI-only change still bumps the fuse package and ships the installers. Note `exclude-paths` matches directories only, so a commit touching just a root-level *file* (`flake.nix`, `README.md`) lands in the GUI package; only `feat`/`fix` types actually trigger a bump. `extra-files` paths are resolved **relative to the package path**, which is why the `SynologyFuse.Gui.csproj` version bump belongs to the root package, not the fuse package.
 
 CI workflows:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "381d1b8eaa5a87f621350a19b1ecda07b5db5320",
   "plugins": [
     {
       "type": "linked-versions",
@@ -7,12 +8,32 @@
       "components": [
         "synology-filestation-core",
         "synology-filestation-fuse",
+        "synology-filestation-gui",
         "synology_filestation"
       ],
       "merge": false
     }
   ],
   "packages": {
+    ".": {
+      "release-type": "simple",
+      "package-name": "synology-filestation-gui",
+      "changelog-path": "SynologyFuse.Gui/CHANGELOG.md",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "exclude-paths": [
+        "rust",
+        "python",
+        ".github",
+        "nix"
+      ],
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "SynologyFuse.Gui/SynologyFuse.Gui.csproj"
+        }
+      ]
+    },
     "rust/synology-filestation-core": {
       "release-type": "rust",
       "package-name": "synology-filestation-core",
@@ -23,22 +44,7 @@
       "release-type": "rust",
       "package-name": "synology-filestation-fuse",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "include-paths": [
-        "rust/synology-filestation-fuse",
-        "SynologyFuse.Gui",
-        "SynologyFuse.Tests",
-        "SynologyFuse.MacInstaller",
-        "SynologyFuse.DebInstaller",
-        "SynologyFuse.Installer",
-        "SynologyFuse.sln"
-      ],
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "SynologyFuse.Gui/SynologyFuse.Gui.csproj"
-        }
-      ]
+      "bump-patch-for-minor-pre-major": true
     },
     "python/synology_filestation": {
       "release-type": "rust",


### PR DESCRIPTION
## Problem

A GUI-only change produces **no release at all**. On the merge of #146, release-please logged:

```
✔ Splitting 2 commits by path
✔ Considering: 0 commits
✔ No commits for path: rust/synology-filestation-core, skipping
✔ Considering: 0 commits
✔ No commits for path: rust/synology-filestation-fuse, skipping
✔ Considering: 0 commits
✔ No commits for path: python/synology_filestation, skipping
```

release-please attributes commits to packages by path, and all three packages live under `rust/` or `python/`. The .NET projects sit at the repo root, so commits touching only `SynologyFuse.Gui/`, `SynologyFuse.Tests/` or the installers are homeless.

The `include-paths` block added in 67a967b to fix exactly this **is not a release-please option** — the [config schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json) defines only `exclude-paths`, and `manifest.ts` reads only `config['exclude-paths']`. Unknown keys are ignored silently, so it has never done anything; the miss that commit cites (f540739, the GUI icon fix) is still absent from the fuse changelog.

## Fix

A catch-all package keyed `"."`:

- `manifest.ts:701` assigns **all** commits to the root path; `CommitExclude` then drops a commit only when *every* one of its files is under an `exclude-paths` entry. `["rust", "python", ".github", "nix"]` therefore leaves exactly the GUI/installer commits.
- It joins the `linked-versions` group, where the plugin appends a synthetic `chore(<component>): Synchronize …` commit for members with no candidate of their own — so a GUI-only change still bumps the fuse package and ships the `.deb`/`.pkg`/`.msi`.
- `release-type: simple`, so only a changelog is written (its `version.txt` updater is `createIfMissing: false`); `changelog-path` puts it at `SynologyFuse.Gui/CHANGELOG.md` rather than the repo root.
- `bootstrap-sha` pins the new package's history to the 0.2.0 release commit, so its first changelog covers commits after that instead of sweeping the whole repo.

**Second bug fixed along the way:** the `SynologyFuse.Gui.csproj` `extra-files` entry was on the fuse package, and `extra-files` paths resolve relative to the package path — so it was looking for `rust/synology-filestation-fuse/SynologyFuse.Gui/SynologyFuse.Gui.csproj`. The dry run reported `did not exist`, which is why the csproj still reads `<Version>0.1.16</Version>` while releases are at 0.2.0. Moved to the root package, where it resolves.

## Verification

Dry run of `release-please release-pr` against this branch (`--dry-run`, nothing created):

```
✔ Splitting 3 commits by path
✔ Found 4 group components for synology-filestation
✔ Considering: 5 commits                              # path "."
✔ Replacing strategy for path . with forced version: 0.2.1
❯ Appending fake commit for path: rust/synology-filestation-fuse
Would open 1 pull requests
```

Resulting `synology-filestation-gui: 0.2.1` section:

```
### Features
* **gui:** copy NAS paths from the browser path bar and context menu (dd63bd6)
* **gui:** copy NAS paths from the browser path bar and context menu (f718536)
```

All four components go to 0.2.1 (patch, per the repo's `bump-patch-for-minor-pre-major`), `SynologyFuse.Gui/SynologyFuse.Gui.csproj` is now in the update list, and the `did not exist` warning for it is gone. Once this merges, the pending GUI feature from #146 gets its release PR.

## Notes

- This commit is `chore`, not `fix`: `exclude-paths` can only name directories, so a root-level config change lands in the GUI package and a `fix` type would put CI plumbing in the product changelog.
- The duplicated changelog line above is pre-existing — merge-commit merges give both the merge commit and the branch commit the same conventional message (the fuse changelog has the same duplication). Squash-merging PRs would remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)