### PR TITLE
feat(core): stream large uploads in slices instead of buffering whole files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-core"
-version = "0.1.20"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-fuse"
-version = "0.1.20"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "synology_filestation"
-version = "0.1.20"
+version = "0.2.1"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -1104,6 +1104,7 @@ impl SynologyClient {
                 .map_err(|e| SynoFsError::Io(e.to_string()))?;
             let mut form = multipart::Form::new()
                 .text("overwrite", "false")
+                .text("create_parents", "true")
                 .text("path", folder_path.to_string());
             if let Some(ms) = &mtime_ms {
                 form = form.text("mtime", ms.clone());
@@ -3332,6 +3333,43 @@ mod tests {
             vec![(1024, 2500), (2048, 2500), (2500, 2500)],
             "cumulative bytes after each slice"
         );
+        std::fs::remove_file(&local).ok();
+    }
+
+    #[tokio::test]
+    async fn slice_upload_sends_create_parents_like_the_one_shot_path() {
+        // Both paths are reached through the same public API, so a large file
+        // must not lose directory auto-creation that a small one gets.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"blSkip": false, "tmpfile": "slice.1.0.9224"}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("parents.bin", 2500);
+        let client = client_for(&server).with_slice_size(1024);
+        client
+            .upload_from_path(&local, "/share/new/dir", "big.bin", false)
+            .await
+            .unwrap();
+
+        for req in server.received_requests().await.unwrap() {
+            let body = String::from_utf8_lossy(&req.body).to_string();
+            assert!(
+                body.contains("name=\"create_parents\""),
+                "every slice carries create_parents"
+            );
+            // Deliberately absent: DSM's own uploader sends `size` only on the
+            // one-shot path and puts the total in X-FILE-SIZE when slicing.
+            assert!(
+                !body.contains("name=\"size\""),
+                "the slice path uses the X-FILE-SIZE header, not a size field"
+            );
+        }
         std::fs::remove_file(&local).ok();
     }
 }

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -172,6 +172,18 @@ impl<T: ?Sized> TransportEntry<T> {
     }
 }
 
+/// Bytes per slice on the chunked upload path — the same 10 MiB DSM's own File
+/// Station uploader uses (`chunksize` in `FileUploader.js`).
+///
+/// DSM only slices above `MAX_POST_FILESIZE` (4 GiB − 4096), because its
+/// concern is the POST limit. Ours is memory: `http_upload` holds the whole
+/// file in a `Vec<u8>`, so we slice anything that exceeds one slice.
+pub const DEFAULT_SLICE_SIZE: usize = 10 * 1024 * 1024;
+
+/// Upload progress sink: `(bytes_done, bytes_total)`, called once per slice.
+/// Borrowed rather than boxed so callers can pass a plain closure reference.
+pub type ProgressSink<'a> = &'a (dyn Fn(u64, u64) + Send + Sync);
+
 pub struct SynologyClient {
     http: Client,
     base_url: String,
@@ -197,6 +209,10 @@ pub struct SynologyClient {
     /// Injected streaming read backends, tried in order by `download_to_path`
     /// before falling back to the buffering HTTP download.
     stream_read_transports: Vec<TransportEntry<dyn StreamReadTransport>>,
+    /// Bytes per slice for the chunked upload path. A file larger than this is
+    /// uploaded slice-by-slice so it is never held in memory whole; anything
+    /// smaller takes the one-shot path. Default [`DEFAULT_SLICE_SIZE`].
+    slice_size: usize,
 }
 
 impl std::fmt::Debug for SynologyClient {
@@ -267,6 +283,7 @@ impl SynologyClient {
             write_transports: Vec::new(),
             stream_write_transports: Vec::new(),
             stream_read_transports: Vec::new(),
+            slice_size: DEFAULT_SLICE_SIZE,
         }
     }
 
@@ -306,6 +323,15 @@ impl SynologyClient {
     pub fn with_stream_read_transport(mut self, transport: Arc<dyn StreamReadTransport>) -> Self {
         self.stream_read_transports
             .push(TransportEntry::new(transport));
+        self
+    }
+
+    /// Override the slice size used by the chunked upload path (default
+    /// [`DEFAULT_SLICE_SIZE`]). A file larger than this is uploaded slice by
+    /// slice; anything smaller takes the one-shot path. Mostly useful for tests
+    /// and for tuning against a slow link.
+    pub fn with_slice_size(mut self, bytes: usize) -> Self {
+        self.slice_size = bytes.max(1);
         self
     }
 
@@ -919,7 +945,7 @@ impl SynologyClient {
                 }
             }
         }
-        self.http_upload(folder_path, filename, data, overwrite)
+        self.http_upload(folder_path, filename, data, overwrite, None)
             .await
     }
 
@@ -936,6 +962,22 @@ impl SynologyClient {
         folder_path: &str,
         filename: &str,
         overwrite: bool,
+    ) -> Result<(), SynoFsError> {
+        self.upload_from_path_with_progress(local, folder_path, filename, overwrite, None)
+            .await
+    }
+
+    /// [`upload_from_path`](Self::upload_from_path) with a progress sink called
+    /// once per slice with cumulative bytes. Slice boundaries are internal to
+    /// this crate, so a caller that wants a moving progress bar (the GUI, via
+    /// the FFI) can only learn about them here.
+    pub async fn upload_from_path_with_progress(
+        &self,
+        local: &Path,
+        folder_path: &str,
+        filename: &str,
+        overwrite: bool,
+        progress: Option<ProgressSink<'_>>,
     ) -> Result<(), SynoFsError> {
         if overwrite && !self.stream_write_transports.is_empty() {
             let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
@@ -961,15 +1003,179 @@ impl SynologyClient {
                 }
             }
         }
-        // Fallback: read the file into memory and take the HTTP upload path.
+        // Fallback: HTTP. A file bigger than one slice goes down the chunked
+        // path so it is never resident in memory whole; smaller files keep the
+        // existing one-shot behavior.
+        let len = tokio::fs::metadata(local)
+            .await
+            .map_err(|e| {
+                SynoFsError::Io(format!(
+                    "upload_from_path: stat {} failed: {e}",
+                    local.display()
+                ))
+            })?
+            .len();
+        if len > self.slice_size as u64 {
+            return self
+                .http_slice_upload(local, folder_path, filename, len, overwrite, progress)
+                .await;
+        }
         let data = tokio::fs::read(local).await.map_err(|e| {
             SynoFsError::Io(format!(
                 "upload_from_path: read {} failed: {e}",
                 local.display()
             ))
         })?;
-        self.http_upload(folder_path, filename, data, overwrite)
-            .await
+        self.http_upload(
+            folder_path,
+            filename,
+            data,
+            overwrite,
+            local_mtime_ms(local).await,
+        )
+        .await?;
+        // One-shot: the only boundary we can report is the end of the file.
+        if let Some(p) = progress {
+            p(len, len);
+        }
+        Ok(())
+    }
+
+    /// Chunked ("slice") upload — the path DSM's own File Station uploader uses
+    /// for large files, reimplemented from a capture of it plus its JS source.
+    ///
+    /// Each slice is one POST carrying the same body fields; the chunking rides
+    /// in headers. The server hands back a `tmpfile` handle on the first slice,
+    /// which every later slice echoes as `X-TMP-FILE` to append to the same
+    /// partial file. The final slice sets `X-FILE-CHUNK-END: true` and its
+    /// response is the result — there is no separate finalize call.
+    ///
+    /// Memory is bounded by one slice, in contrast to [`Self::http_upload`],
+    /// which holds the whole file (and clones it per retry attempt).
+    ///
+    /// Deliberately **not** retried per slice: a resent slice would append
+    /// twice, and DSM exposes no way to ask how much of the partial file it
+    /// already holds. A failure surfaces and the caller restarts the file —
+    /// the outer-retry contract the throttle docs already specify.
+    async fn http_slice_upload(
+        &self,
+        local: &Path,
+        folder_path: &str,
+        filename: &str,
+        total: u64,
+        overwrite: bool,
+        progress: Option<ProgressSink<'_>>,
+    ) -> Result<(), SynoFsError> {
+        use tokio::io::AsyncReadExt;
+
+        let url = format!("{}/entry.cgi", self.base_url);
+        let slice_size = self.slice_size;
+        let slices = total.div_ceil(slice_size as u64).max(1);
+        debug!(
+            "slice upload: {}/{} ({} bytes, {} slices of {})",
+            folder_path, filename, total, slices, slice_size
+        );
+
+        if overwrite {
+            self.clear_for_overwrite(folder_path, filename).await;
+        }
+
+        let mtime_ms = local_mtime_ms(local).await;
+
+        let mut file = tokio::fs::File::open(local).await.map_err(|e| {
+            SynoFsError::Io(format!(
+                "slice upload: open {} failed: {e}",
+                local.display()
+            ))
+        })?;
+        let mut buf = vec![0u8; slice_size];
+        let mut tmpfile: Option<String> = None;
+
+        for index in 0..slices {
+            let want = std::cmp::min(slice_size as u64, total - index * slice_size as u64) as usize;
+            file.read_exact(&mut buf[..want]).await.map_err(|e| {
+                SynoFsError::Io(format!("slice upload: read slice {index} failed: {e}"))
+            })?;
+
+            let last = index + 1 == slices;
+            let file_part = multipart::Part::bytes(buf[..want].to_vec())
+                .file_name(filename.to_string())
+                .mime_str("application/octet-stream")
+                .map_err(|e| SynoFsError::Io(e.to_string()))?;
+            let mut form = multipart::Form::new()
+                .text("overwrite", "false")
+                .text("path", folder_path.to_string());
+            if let Some(ms) = &mtime_ms {
+                form = form.text("mtime", ms.clone());
+            }
+            let form = form.part("file", file_part);
+
+            let mut req = self
+                .http
+                .post(&url)
+                .query(&[
+                    ("api", "SYNO.FileStation.Upload"),
+                    ("method", "upload"),
+                    ("version", "2"),
+                ])
+                .query(&[("_sid", self.sid())])
+                .header("X-TYPE-NAME", "SLICEUPLOAD")
+                .header("X-FILE-SIZE", total.to_string())
+                .header("X-FILE-CHUNK-END", if last { "true" } else { "false" });
+            if let Some(t) = &tmpfile {
+                req = req.header("X-TMP-FILE", t.clone());
+            }
+
+            let text = {
+                let _slot = self.acquire_transfer_slot().await;
+                req.multipart(form).send().await?.text().await?
+            };
+            let parsed: SynoResponse<UploadData> = serde_json::from_str(&text)
+                .map_err(|e| SynoFsError::Io(format!("slice upload parse error: {e}")))?;
+            if !parsed.success {
+                let code = parsed.error.map(|e| e.code).unwrap_or(0);
+                return Err(SynoFsError::ApiError(code));
+            }
+
+            if let Some(p) = progress {
+                p(index * slice_size as u64 + want as u64, total);
+            }
+
+            if !last {
+                // Without a handle there is nothing for the next slice to append
+                // to; DSM's own client treats this as fatal rather than retrying.
+                tmpfile = match parsed
+                    .data
+                    .and_then(|d| d.tmpfile)
+                    .filter(|t| !t.is_empty())
+                {
+                    Some(t) => Some(t),
+                    None => {
+                        return Err(SynoFsError::Io(format!(
+                            "slice upload: server returned no tmpfile after slice {index}"
+                        )))
+                    }
+                };
+            }
+        }
+        Ok(())
+    }
+
+    /// Delete a file that is in the way of an upload, then wait for it to
+    /// actually disappear. Shared by the one-shot and slice upload paths:
+    /// `overwrite=true` on the multipart API times out on some DSM versions, so
+    /// both always upload with `overwrite=false` onto cleared ground. Delete is
+    /// async on modern DSM, hence the poll — otherwise the upload races it and
+    /// fails 418 AlreadyExists.
+    async fn clear_for_overwrite(&self, folder_path: &str, filename: &str) {
+        let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
+        let _ = self.delete(&full_path).await; // ignore error — file may not exist yet
+        for _ in 0..10u8 {
+            match self.get_info(&full_path).await {
+                Ok(_) => tokio::time::sleep(Duration::from_millis(50)).await,
+                Err(_) => break, // gone or inaccessible — safe to upload
+            }
+        }
     }
 
     /// The HTTP FileStation Upload implementation. Used directly when no write
@@ -980,6 +1186,9 @@ impl SynologyClient {
         filename: &str,
         data: Vec<u8>,
         overwrite: bool,
+        // Local modification time in ms, when the caller has a file to take it
+        // from. DSM stores it verbatim; without it the NAS stamps upload time.
+        mtime_ms: Option<String>,
     ) -> Result<(), SynoFsError> {
         let url = format!("{}/entry.cgi", self.base_url);
         debug!(
@@ -989,20 +1198,8 @@ impl SynologyClient {
             data.len()
         );
 
-        // overwrite=true via the multipart API times out on some DSM versions.
-        // Delete the existing file first so we can always upload with overwrite=false.
         if overwrite {
-            let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
-            let _ = self.delete(&full_path).await; // ignore error — file may not exist yet
-
-            // Synology Delete is async on modern DSM: poll get_info until the file is
-            // gone (or inaccessible) before uploading, to avoid 418 AlreadyExists.
-            for _ in 0..10u8 {
-                match self.get_info(&full_path).await {
-                    Ok(_) => tokio::time::sleep(Duration::from_millis(50)).await,
-                    Err(_) => break, // gone or inaccessible — safe to upload
-                }
-            }
+            self.clear_for_overwrite(folder_path, filename).await;
         }
 
         let max_attempts = self.max_transfer_attempts();
@@ -1023,8 +1220,13 @@ impl SynologyClient {
                 .text("method", "upload")
                 .text("path", folder_path.to_string())
                 .text("create_parents", "true")
+                .text("size", data.len().to_string())
                 .text("overwrite", "false")
                 .part("file", file_part);
+            let form = match &mtime_ms {
+                Some(ms) => form.text("mtime", ms.clone()),
+                None => form,
+            };
 
             // Hold a transfer slot only for the request+response read; drop it
             // before any backoff so a retrying upload doesn't hog a permit.
@@ -1188,6 +1390,18 @@ impl SynologyClient {
             Err(SynoFsError::ApiError(code))
         }
     }
+}
+
+/// A local file's modification time in milliseconds since the epoch, as DSM's
+/// upload API expects it. `None` when the filesystem can't report one — the
+/// upload still proceeds, it just lands with the NAS's own timestamp.
+async fn local_mtime_ms(path: &Path) -> Option<String> {
+    tokio::fs::metadata(path)
+        .await
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis().to_string())
 }
 
 #[cfg(test)]
@@ -2863,5 +3077,261 @@ mod tests {
         assert!(matches!(err, SynoFsError::NotFound));
         assert_eq!(backend.call_count(), 1);
         assert!(!dest.exists(), "definitive failure leaves no file");
+    }
+
+    // ── slice upload ─────────────────────────────────────────────────────────
+    //
+    // Mirrors what the DSM 7 File Station web UI does for large files (mined
+    // from a browser capture of a 4.9 GB upload): one POST per slice, with the
+    // chunking carried in request headers rather than the multipart body. Every
+    // slice repeats the same body fields; the server ties them together by tmpfile.
+    //
+    //   X-TYPE-NAME: SLICEUPLOAD
+    //   X-FILE-SIZE: <total bytes>
+    //   X-FILE-CHUNK-END: false   (true on the final slice)
+    //   X-TMP-FILE: <tmpfile>     (echoed from the previous response, slice 2+)
+    //
+    // Confirmed against DSM's own uploader (FileUploader_T9JY.js): the final
+    // data slice carries X-FILE-CHUNK-END: true and its response is the result --
+    // there is no separate finalize request. Slices are tied together by echoing
+    // the response's `tmpfile` back as X-TMP-FILE; a non-final response without
+    // one is fatal. DSM slices only above 4 GiB; we slice above one slice, because
+    // our motive is bounded memory rather than its POST limit.
+
+    /// Write `len` bytes to a scratch file and return its path.
+    fn scratch_file(name: &str, len: usize) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("syno-slice-{}-{name}", std::process::id()));
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        std::fs::write(&path, data).unwrap();
+        path
+    }
+
+    fn header_of(req: &wiremock::Request, name: &str) -> Option<String> {
+        req.headers
+            .get(name)
+            .map(|v| v.to_str().unwrap().to_string())
+    }
+
+    #[tokio::test]
+    async fn slice_upload_splits_file_and_marks_final_slice() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"blSkip": false, "progress": 1, "tmpfile": "slice.1.0.9224"}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("split.bin", 2500);
+        let client = client_for(&server).with_slice_size(1024);
+        client
+            .upload_from_path(&local, "/share", "big.bin", false)
+            .await
+            .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 3, "2500 bytes at 1024/slice is 3 slices");
+        for r in &reqs {
+            assert_eq!(header_of(r, "X-TYPE-NAME").as_deref(), Some("SLICEUPLOAD"));
+            assert_eq!(header_of(r, "X-FILE-SIZE").as_deref(), Some("2500"));
+        }
+        let ends: Vec<_> = reqs
+            .iter()
+            .map(|r| header_of(r, "X-FILE-CHUNK-END").unwrap())
+            .collect();
+        assert_eq!(ends, vec!["false", "false", "true"]);
+
+        // Slice 1 opens the upload; every later slice echoes the tmpfile the
+        // server handed back, which is what ties them to one partial file.
+        let tmps: Vec<_> = reqs.iter().map(|r| header_of(r, "X-TMP-FILE")).collect();
+        assert_eq!(
+            tmps,
+            vec![
+                None,
+                Some("slice.1.0.9224".to_string()),
+                Some("slice.1.0.9224".to_string())
+            ]
+        );
+        std::fs::remove_file(&local).ok();
+    }
+
+    #[tokio::test]
+    async fn slice_upload_skipped_for_file_that_fits_one_slice() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true, "data": {"blks": null}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("small.bin", 500);
+        let client = client_for(&server).with_slice_size(1024);
+        client
+            .upload_from_path(&local, "/share", "small.bin", false)
+            .await
+            .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "one-shot upload for a file under one slice");
+        assert!(
+            header_of(&reqs[0], "X-TYPE-NAME").is_none(),
+            "no slice headers on the one-shot path"
+        );
+        std::fs::remove_file(&local).ok();
+    }
+
+    #[tokio::test]
+    async fn slice_upload_stops_at_the_failing_slice() {
+        // No per-slice retry: a resumed slice could double-append, and the
+        // resume semantics are unverified. Surface the error and let the caller
+        // restart the whole file (the Temporal outer-retry contract).
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": false, "error": {"code": 1805}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("fail.bin", 2500);
+        let client = client_for(&server).with_slice_size(1024);
+        let err = client
+            .upload_from_path(&local, "/share", "big.bin", false)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SynoFsError::ApiError(1805)));
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "first slice fails, remaining slices are not sent"
+        );
+        std::fs::remove_file(&local).ok();
+    }
+
+    #[tokio::test]
+    async fn slice_upload_aborts_when_tmpfile_missing() {
+        // DSM's own client treats a non-final response with no tmpfile as fatal:
+        // without it the next slice has nothing to append to.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"blSkip": false, "progress": 1}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("notmp.bin", 2500);
+        let client = client_for(&server).with_slice_size(1024);
+        let err = client
+            .upload_from_path(&local, "/share", "big.bin", false)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SynoFsError::Io(_)));
+        assert_eq!(
+            server.received_requests().await.unwrap().len(),
+            1,
+            "no tmpfile to continue with, so no second slice"
+        );
+        std::fs::remove_file(&local).ok();
+    }
+
+    #[tokio::test]
+    async fn upload_preserves_mtime_and_sends_size() {
+        // Proven against the NAS in a browser capture: File Station sends the
+        // local mtime in ms and the server stores it (the listing came back with
+        // mtime = the value sent, crtime = upload time). Without it every
+        // uploaded file is stamped with the upload time instead.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true, "data": {"blks": null}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("mtime.bin", 300);
+        let client = client_for(&server);
+        client
+            .upload_from_path(&local, "/share", "mtime.bin", false)
+            .await
+            .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let body = String::from_utf8_lossy(&reqs[0].body).to_string();
+        assert!(body.contains("name=\"size\""), "one-shot upload sends size");
+        assert!(
+            body.contains("name=\"mtime\""),
+            "one-shot upload sends mtime"
+        );
+        let sent_ms: u128 = body
+            .split("name=\"mtime\"")
+            .nth(1)
+            .unwrap()
+            .trim_start_matches("\r\n\r\n")
+            .lines()
+            .next()
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let want_ms = std::fs::metadata(&local)
+            .unwrap()
+            .modified()
+            .unwrap()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+        assert_eq!(
+            sent_ms, want_ms,
+            "mtime is the local file's, in milliseconds"
+        );
+        std::fs::remove_file(&local).ok();
+    }
+
+    #[tokio::test]
+    async fn slice_upload_reports_progress_per_slice() {
+        // The FFI can't observe slice boundaries itself (they live inside the
+        // core loop), so the GUI's upload bar depends on this callback.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"blSkip": false, "tmpfile": "slice.1.0.9224"}
+            })))
+            .mount(&server)
+            .await;
+
+        let local = scratch_file("progress.bin", 2500);
+        let client = client_for(&server).with_slice_size(1024);
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        client
+            .upload_from_path_with_progress(
+                &local,
+                "/share",
+                "big.bin",
+                false,
+                Some(&move |done, total| sink.lock().unwrap().push((done, total))),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![(1024, 2500), (2048, 2500), (2500, 2500)],
+            "cumulative bytes after each slice"
+        );
+        std::fs::remove_file(&local).ok();
     }
 }

--- a/rust/synology-filestation-core/src/types.rs
+++ b/rust/synology-filestation-core/src/types.rs
@@ -108,6 +108,10 @@ pub struct RenameData {
 #[allow(dead_code)]
 pub struct UploadData {
     pub blks: Option<serde_json::Value>,
+    /// Slice-upload state: the server's partial-file handle, echoed back as
+    /// `X-TMP-FILE` on the next slice. Absent on one-shot uploads.
+    #[serde(default)]
+    pub tmpfile: Option<String>,
 }
 
 /// An entry in the inode cache

--- a/rust/synology-filestation-ffi/src/lib.rs
+++ b/rust/synology-filestation-ffi/src/lib.rs
@@ -606,8 +606,8 @@ pub unsafe extern "C" fn syno_download_to(
     })
 }
 
-/// Upload `local` into the remote directory `remote_dir`. Progress is coarse
-/// (0 → total) because the core upload is single-shot.
+/// Upload `local` into the remote directory `remote_dir`. Progress is reported
+/// per slice for files large enough to be sliced, else 0 → total.
 ///
 /// # Safety
 /// `client` must be live; `local`/`remote_dir` must be non-null.
@@ -635,15 +635,8 @@ pub unsafe extern "C" fn syno_upload(
             None => return set_err(err, SynoStatus::NullArg, 0, "client must not be null"),
         };
 
-        // The core Upload API is single-shot (takes a full `Vec<u8>`), so the
-        // whole file is buffered in memory — the same documented "write
-        // buffering" limitation the CLI and PyO3 binding share. There is no
-        // streaming path to prefer here; a streaming upload would have to land
-        // in the core crate first.
-        let data = match std::fs::read(&local) {
-            Ok(d) => d,
-            Err(e) => return set_err(err, SynoStatus::Io, 0, &format!("read {local}: {e}")),
-        };
+        // Streams from disk: large files go out in slices, so memory stays
+        // bounded and progress can move per slice instead of jumping 0 → 100%.
         let filename = match std::path::Path::new(&local)
             .file_name()
             .and_then(|n| n.to_str())
@@ -651,14 +644,28 @@ pub unsafe extern "C" fn syno_upload(
             Some(n) => n.to_string(),
             None => return set_err(err, SynoStatus::InvalidArg, 0, "local path has no filename"),
         };
-        let total = data.len() as u64;
+        let total = match std::fs::metadata(&local) {
+            Ok(m) => m.len(),
+            Err(e) => return set_err(err, SynoStatus::Io, 0, &format!("stat {local}: {e}")),
+        };
         report(progress, user_data, 0, total);
 
+        // `user_data` travels as a usize for the same reason the log sink does:
+        // it is an opaque token we never deref, and that keeps the closure Send.
+        let ud = user_data as usize;
+        let sink = move |done: u64, total: u64| report(progress, ud as *mut c_void, done, total);
+        let local_path = std::path::PathBuf::from(&local);
         let inner = c.inner.clone();
         let result = c.runtime.block_on(async {
             inner
                 .with_relogin_retry(|| {
-                    inner.upload(&remote_dir, &filename, data.clone(), overwrite)
+                    inner.upload_from_path_with_progress(
+                        &local_path,
+                        &remote_dir,
+                        &filename,
+                        overwrite,
+                        Some(&sink),
+                    )
                 })
                 .await
         });

--- a/rust/synology-filestation-fuse/src/fs.rs
+++ b/rust/synology-filestation-fuse/src/fs.rs
@@ -13,6 +13,7 @@ use fuser::{
 use tracing::{debug, error, info, warn};
 
 use crate::cache::{InodeCache, ReadCache};
+use crate::spill::{payload_for, upload_payload, SpillBuffer};
 use synology_filestation_core::client::SynologyClient;
 use synology_filestation_core::error::SynoFsError;
 use synology_filestation_core::types::{SynoFileInfo, VIRTUAL_ROOT_PATH};
@@ -29,7 +30,7 @@ fn errno(raw: i32) -> Errno {
 struct WriteBuffer {
     nas_path: String,
     ino: u64,
-    data: Vec<u8>,
+    data: SpillBuffer,
     dirty: bool,
     /// True when the file was just created and has not yet been uploaded.
     /// Allows flush to use overwrite=false, skipping the delete-before-upload round trips.
@@ -164,7 +165,13 @@ impl SynologyFS {
 
         let nas_path = buf.nas_path.clone();
         let ino = buf.ino;
-        let data = buf.data.clone();
+        let payload = match payload_for(&mut buf.data) {
+            Ok(p) => p,
+            Err(e) => {
+                error!("queue_upload: cannot read write buffer: {}", e);
+                return;
+            }
+        };
         let overwrite = !buf.new_file;
         buf.dirty = false;
 
@@ -179,7 +186,7 @@ impl SynologyFS {
             fh,
             parent,
             filename,
-            data.len()
+            payload.len()
         );
 
         let client = self.client.clone();
@@ -189,7 +196,7 @@ impl SynologyFS {
 
         // Spawn the upload; hold the mutex so the handle is stored before release() can run.
         let handle = self.rt.spawn(async move {
-            let result = client.upload(&parent, &filename, data, overwrite).await;
+            let result = upload_payload(&client, &parent, &filename, payload, overwrite).await;
             cache.invalidate_path(&path_for_task);
             read_cache.invalidate_ino(ino);
             result
@@ -202,7 +209,7 @@ impl SynologyFS {
     /// remaining dirty data.  Called from `release` and `destroy`.
     fn finish_upload(&self, fh: u64) -> Result<(), SynoFsError> {
         // Extract both the handle and dirty state without holding the lock while blocking.
-        let (handle, dirty, nas_path, ino, data, overwrite) = {
+        let (handle, dirty, nas_path, ino, payload, overwrite) = {
             let mut buffers = self.write_buffers.lock().unwrap();
             let buf = match buffers.get_mut(&fh) {
                 Some(b) => b,
@@ -221,10 +228,10 @@ impl SynologyFS {
             }
             let path = buf.nas_path.clone();
             let ino = buf.ino;
-            let data = buf.data.clone();
+            let payload = payload_for(&mut buf.data).map_err(|e| SynoFsError::Io(e.to_string()))?;
             let overwrite = !buf.new_file;
             buf.dirty = false;
-            (handle, true, path, ino, data, overwrite)
+            (handle, true, path, ino, payload, overwrite)
         };
         let _ = dirty; // used implicitly — we only reach here when dirty was true
 
@@ -245,9 +252,15 @@ impl SynologyFS {
             fh,
             parent,
             filename,
-            data.len()
+            payload.len()
         );
-        self.block(self.client.upload(parent, filename, data, overwrite))?;
+        self.block(upload_payload(
+            &self.client,
+            parent,
+            filename,
+            payload,
+            overwrite,
+        ))?;
         self.cache.invalidate_path(&nas_path);
         self.read_cache.invalidate_ino(ino);
         Ok(())
@@ -695,7 +708,7 @@ impl Filesystem for SynologyFS {
             WriteBuffer {
                 nas_path: path,
                 ino,
-                data: Vec::new(),
+                data: SpillBuffer::new(),
                 dirty: false,
                 new_file: false,
                 upload_handle: None,
@@ -761,12 +774,14 @@ impl Filesystem for SynologyFS {
         // If writing at an offset beyond current buffer, we need the existing file content first.
         // This is handled by seeding the buffer in create/open if needed.
         // For simplicity: if offset > current len, seed from API on first write.
-        let offset = offset as usize;
-        let end = offset + data.len();
-        if end > buf.data.len() {
-            buf.data.resize(end, 0);
+        // The buffer spills to a temp file once it outgrows SpillBuffer's
+        // threshold, so a large copy no longer pins the whole file in RAM (and
+        // no longer stalls every other FUSE callback behind that allocation).
+        if let Err(e) = buf.data.write_at(offset, data) {
+            error!("write: buffering failed: {}", e);
+            reply.error(Errno::EIO);
+            return;
         }
-        buf.data[offset..end].copy_from_slice(data);
         buf.dirty = true;
         reply.written(data.len() as u32);
     }
@@ -859,7 +874,7 @@ impl Filesystem for SynologyFS {
             WriteBuffer {
                 nas_path: new_path,
                 ino,
-                data: Vec::new(),
+                data: SpillBuffer::new(),
                 dirty: false,
                 new_file: true,
                 upload_handle: None,

--- a/rust/synology-filestation-fuse/src/lib.rs
+++ b/rust/synology-filestation-fuse/src/lib.rs
@@ -23,6 +23,7 @@ use synology_filestation_core::error::SynoFsError;
 mod cache;
 #[cfg(target_os = "linux")]
 mod fs;
+mod spill;
 
 #[cfg(target_os = "macos")]
 mod webdav;

--- a/rust/synology-filestation-fuse/src/spill.rs
+++ b/rust/synology-filestation-fuse/src/spill.rs
@@ -17,6 +17,23 @@ use std::path::{Path, PathBuf};
 use synology_filestation_core::client::SynologyClient;
 use synology_filestation_core::error::SynoFsError;
 
+/// How many candidate names a spill tries before giving up. Collisions should
+/// be impossible (the sequence number is process-unique), so this only matters
+/// if somebody is actively planting files at our candidate paths.
+const SPILL_NAME_ATTEMPTS: u32 = 8;
+
+/// Process-wide counter making each buffer's temp name unique without pulling
+/// in a random-number dependency. Uniqueness is what create_new needs; it is
+/// not a secret, which is why the open refuses to follow an existing path.
+static SPILL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn temp_path(seq: u64, attempt: u32) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "synofs-write-{}-{seq}-{attempt}.tmp",
+        std::process::id()
+    ))
+}
+
 /// Files larger than this are written to a temp file instead of RAM. Sized to
 /// cover the overwhelming majority of desktop file writes while capping what a
 /// single handle can pin in memory.
@@ -34,6 +51,8 @@ enum Store {
 
 pub struct SpillBuffer {
     store: Store,
+    /// Process-unique id feeding this buffer's temp-file name.
+    seq: u64,
     /// Logical length, tracked separately so a sparse write past the end
     /// extends the buffer the same way in both stores.
     len: u64,
@@ -48,6 +67,7 @@ impl SpillBuffer {
     pub fn with_spill_at(spill_at: usize) -> Self {
         SpillBuffer {
             store: Store::Memory(Vec::new()),
+            seq: SPILL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             len: 0,
             spill_at,
         }
@@ -107,8 +127,12 @@ impl SpillBuffer {
         Ok(())
     }
 
-    /// Read the whole buffer back. Only sound for unspilled buffers — a spilled
-    /// one is precisely the case we refuse to materialize in memory.
+    /// Read the whole buffer back, from disk if it has spilled.
+    ///
+    /// Allocates the full length, so callers on the upload path must go through
+    /// [`payload_for`], which only reaches for this when the buffer is still in
+    /// memory and therefore under the spill threshold. Calling it directly on a
+    /// spilled buffer defeats the point of this type.
     pub fn as_bytes(&mut self) -> std::io::Result<Vec<u8>> {
         match &mut self.store {
             Store::Memory(v) => Ok(v.clone()),
@@ -135,24 +159,35 @@ impl SpillBuffer {
 
     /// Move the accumulated bytes out of RAM and onto disk.
     fn spill(&mut self) -> std::io::Result<()> {
-        let existing = match &self.store {
-            Store::Memory(v) => v.clone(),
+        // Moved, not cloned: a clone would briefly double the very allocation
+        // this type exists to bound.
+        let existing = match &mut self.store {
+            Store::Memory(v) => std::mem::take(v),
             Store::Spilled { .. } => return Ok(()),
         };
-        let path = std::env::temp_dir().join(format!(
-            "synofs-write-{}-{:p}.tmp",
-            std::process::id(),
-            self as *const _
-        ));
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .read(true)
-            .write(true)
-            .open(&path)?;
-        file.write_all(&existing)?;
-        self.store = Store::Spilled { file, path };
-        Ok(())
+        // create_new, so an occupied name is stepped over rather than
+        // truncated. The temp dir is world-writable on Unix, and a predictable
+        // name plus create+truncate is how you end up destroying somebody
+        // else's file — or, through a symlink they planted, a file of their
+        // choosing.
+        let mut last_err = None;
+        for attempt in 0..SPILL_NAME_ATTEMPTS {
+            let path = temp_path(self.seq, attempt);
+            match std::fs::OpenOptions::new()
+                .create_new(true)
+                .read(true)
+                .write(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    file.write_all(&existing)?;
+                    self.store = Store::Spilled { file, path };
+                    return Ok(());
+                }
+                Err(e) => last_err = Some(e),
+            }
+        }
+        Err(last_err.unwrap_or_else(|| std::io::Error::other("no spill path available")))
     }
 }
 
@@ -352,5 +387,40 @@ mod tests {
             10,
             "the temp file shrinks with the buffer"
         );
+    }
+
+    #[test]
+    fn concurrent_buffers_get_distinct_temp_files() {
+        let mut a = SpillBuffer::with_spill_at(4);
+        let mut b = SpillBuffer::with_spill_at(4);
+        a.write_at(0, &[1u8; 16]).unwrap();
+        b.write_at(0, &[2u8; 16]).unwrap();
+        let pa = a.spilled_path().unwrap().unwrap().to_path_buf();
+        let pb = b.spilled_path().unwrap().unwrap().to_path_buf();
+        assert_ne!(pa, pb, "two live buffers must not share a temp file");
+        assert_eq!(std::fs::read(&pa).unwrap(), vec![1u8; 16]);
+        assert_eq!(std::fs::read(&pb).unwrap(), vec![2u8; 16]);
+    }
+
+    #[test]
+    fn spill_does_not_clobber_an_occupied_candidate_path() {
+        // The temp dir is world-writable on Unix, so a predictable name opened
+        // with create+truncate would let another user pre-place a file (or a
+        // symlink to one) and have us destroy it. Spilling must step over an
+        // occupied name, not truncate it.
+        let mut b = SpillBuffer::with_spill_at(4);
+        let occupied = temp_path(b.seq, 0);
+        std::fs::write(&occupied, b"precious").unwrap();
+
+        b.write_at(0, &[6u8; 16]).unwrap();
+        let used = b.spilled_path().unwrap().unwrap().to_path_buf();
+
+        assert_ne!(used, occupied, "spill must skip the occupied candidate");
+        assert_eq!(
+            std::fs::read(&occupied).unwrap(),
+            b"precious",
+            "the pre-existing file is left untouched"
+        );
+        std::fs::remove_file(&occupied).ok();
     }
 }

--- a/rust/synology-filestation-fuse/src/spill.rs
+++ b/rust/synology-filestation-fuse/src/spill.rs
@@ -1,0 +1,356 @@
+//! A write buffer that stops growing in memory.
+//!
+//! Every mount backend accumulates a file's writes until close and then hands
+//! the result to the upload API. Holding that in a `Vec<u8>` means a 6 GB copy
+//! needs 6 GB of RAM (12 GB once the upload clones it for a retry) — which is
+//! what wedged the mount: FUSE callbacks queue behind the allocation and every
+//! other filesystem operation stalls with it.
+//!
+//! [`SpillBuffer`] keeps small files exactly as they were — in memory, one
+//! allocation, no syscalls — and switches to a temp file once a file grows past
+//! `spill_at`. Past that point memory is bounded by the write size, and the
+//! upload streams from disk in slices.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+
+use synology_filestation_core::client::SynologyClient;
+use synology_filestation_core::error::SynoFsError;
+
+/// Files larger than this are written to a temp file instead of RAM. Sized to
+/// cover the overwhelming majority of desktop file writes while capping what a
+/// single handle can pin in memory.
+pub const DEFAULT_SPILL_AT: usize = 8 * 1024 * 1024;
+
+/// Where a buffer's bytes currently live.
+enum Store {
+    Memory(Vec<u8>),
+    /// An open temp file plus its path, deleted on drop.
+    Spilled {
+        file: std::fs::File,
+        path: PathBuf,
+    },
+}
+
+pub struct SpillBuffer {
+    store: Store,
+    /// Logical length, tracked separately so a sparse write past the end
+    /// extends the buffer the same way in both stores.
+    len: u64,
+    spill_at: usize,
+}
+
+impl SpillBuffer {
+    pub fn new() -> Self {
+        Self::with_spill_at(DEFAULT_SPILL_AT)
+    }
+
+    pub fn with_spill_at(spill_at: usize) -> Self {
+        SpillBuffer {
+            store: Store::Memory(Vec::new()),
+            len: 0,
+            spill_at,
+        }
+    }
+    /// Current logical length. Used by the WebDAV backend to append, and by the
+    /// tests; the FUSE backend writes at explicit offsets and never asks.
+    #[allow(dead_code)]
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// True once the bytes live on disk rather than in memory.
+    #[allow(dead_code)]
+    pub fn is_spilled(&self) -> bool {
+        matches!(self.store, Store::Spilled { .. })
+    }
+
+    /// Resize to `new_len`, truncating or zero-extending. Backs WinFsp's
+    /// `set_file_size`, which the shell uses to preallocate before a copy.
+    #[allow(dead_code)]
+    pub fn set_len(&mut self, new_len: u64) -> std::io::Result<()> {
+        if matches!(self.store, Store::Memory(_)) && new_len > self.spill_at as u64 {
+            self.spill()?;
+        }
+        match &mut self.store {
+            Store::Memory(v) => v.resize(new_len as usize, 0),
+            Store::Spilled { file, .. } => file.set_len(new_len)?,
+        }
+        self.len = new_len;
+        Ok(())
+    }
+
+    /// Write `data` at `offset`, extending (and zero-filling any gap) as needed.
+    pub fn write_at(&mut self, offset: u64, data: &[u8]) -> std::io::Result<()> {
+        let end = offset + data.len() as u64;
+        if matches!(self.store, Store::Memory(_)) && end > self.spill_at as u64 {
+            self.spill()?;
+        }
+        match &mut self.store {
+            Store::Memory(v) => {
+                if end > v.len() as u64 {
+                    v.resize(end as usize, 0);
+                }
+                v[offset as usize..end as usize].copy_from_slice(data);
+            }
+            Store::Spilled { file, .. } => {
+                file.seek(SeekFrom::Start(offset))?;
+                file.write_all(data)?;
+            }
+        }
+        self.len = self.len.max(end);
+        Ok(())
+    }
+
+    /// Read the whole buffer back. Only sound for unspilled buffers — a spilled
+    /// one is precisely the case we refuse to materialize in memory.
+    pub fn as_bytes(&mut self) -> std::io::Result<Vec<u8>> {
+        match &mut self.store {
+            Store::Memory(v) => Ok(v.clone()),
+            Store::Spilled { file, .. } => {
+                let mut out = Vec::with_capacity(self.len as usize);
+                file.seek(SeekFrom::Start(0))?;
+                file.read_to_end(&mut out)?;
+                Ok(out)
+            }
+        }
+    }
+
+    /// The temp file backing a spilled buffer, ready to hand to the streaming
+    /// upload. `None` while the buffer still lives in memory.
+    pub fn spilled_path(&mut self) -> std::io::Result<Option<&Path>> {
+        match &mut self.store {
+            Store::Memory(_) => Ok(None),
+            Store::Spilled { file, path } => {
+                file.flush()?;
+                Ok(Some(path.as_path()))
+            }
+        }
+    }
+
+    /// Move the accumulated bytes out of RAM and onto disk.
+    fn spill(&mut self) -> std::io::Result<()> {
+        let existing = match &self.store {
+            Store::Memory(v) => v.clone(),
+            Store::Spilled { .. } => return Ok(()),
+        };
+        let path = std::env::temp_dir().join(format!(
+            "synofs-write-{}-{:p}.tmp",
+            std::process::id(),
+            self as *const _
+        ));
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(&path)?;
+        file.write_all(&existing)?;
+        self.store = Store::Spilled { file, path };
+        Ok(())
+    }
+}
+
+/// Hand-written so a buffer never prints its contents — the WebDAV file
+/// context derives `Debug`, and dumping a multi-gigabyte body into a log line
+/// would be its own kind of memory incident.
+impl std::fmt::Debug for SpillBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpillBuffer")
+            .field("len", &self.len)
+            .field("spilled", &self.is_spilled())
+            .finish()
+    }
+}
+
+impl Drop for SpillBuffer {
+    fn drop(&mut self) {
+        if let Store::Spilled { path, .. } = &self.store {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+/// What a flush hands to the upload API: bytes for a buffer still in memory, or
+/// the temp file a spilled buffer wrote to. The file variant is what keeps a
+/// multi-gigabyte write off the heap — the core streams it to the NAS in slices.
+pub enum Payload {
+    Memory(Vec<u8>),
+    File(PathBuf),
+}
+
+impl Payload {
+    pub fn len(&self) -> u64 {
+        match self {
+            Payload::Memory(d) => d.len() as u64,
+            Payload::File(p) => std::fs::metadata(p).map(|m| m.len()).unwrap_or(0),
+        }
+    }
+}
+
+/// Snapshot a write buffer for upload without consuming it — the WinFsp backend
+/// depends on the buffer surviving a failed flush so `close` can retry.
+///
+/// A spilled buffer yields its temp path, so this stays O(1) no matter how large
+/// the file is; only an in-memory buffer is copied. The path stays valid as long
+/// as the buffer does, which every caller guarantees by holding the buffer until
+/// the upload returns.
+pub fn payload_for(buf: &mut SpillBuffer) -> std::io::Result<Payload> {
+    match buf.spilled_path()? {
+        Some(p) => Ok(Payload::File(p.to_path_buf())),
+        None => Ok(Payload::Memory(buf.as_bytes()?)),
+    }
+}
+
+/// Upload a payload, taking the streaming path when the bytes are already on
+/// disk. Shared by all three mount backends so they cannot drift apart.
+pub async fn upload_payload(
+    client: &SynologyClient,
+    parent: &str,
+    filename: &str,
+    payload: Payload,
+    overwrite: bool,
+) -> Result<(), SynoFsError> {
+    match payload {
+        Payload::Memory(data) => client.upload(parent, filename, data, overwrite).await,
+        Payload::File(path) => {
+            client
+                .upload_from_path(&path, parent, filename, overwrite)
+                .await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_writes_stay_in_memory() {
+        let mut b = SpillBuffer::with_spill_at(1024);
+        b.write_at(0, b"hello").unwrap();
+        assert!(!b.is_spilled());
+        assert_eq!(b.len(), 5);
+        assert_eq!(b.as_bytes().unwrap(), b"hello");
+        assert!(b.spilled_path().unwrap().is_none());
+    }
+
+    #[test]
+    fn crossing_the_threshold_spills_to_disk_preserving_content() {
+        let mut b = SpillBuffer::with_spill_at(16);
+        b.write_at(0, &[1u8; 10]).unwrap();
+        assert!(!b.is_spilled(), "still under the threshold");
+        b.write_at(10, &[2u8; 20]).unwrap();
+        assert!(b.is_spilled(), "crossing it moves the bytes to a file");
+
+        assert_eq!(b.len(), 30);
+        let bytes = b.as_bytes().unwrap();
+        assert_eq!(&bytes[..10], &[1u8; 10], "pre-spill bytes survive");
+        assert_eq!(&bytes[10..], &[2u8; 20]);
+    }
+
+    #[test]
+    fn spilled_path_points_at_the_written_file() {
+        let mut b = SpillBuffer::with_spill_at(4);
+        b.write_at(0, &[7u8; 32]).unwrap();
+        let path = b.spilled_path().unwrap().unwrap().to_path_buf();
+        assert_eq!(std::fs::read(&path).unwrap(), vec![7u8; 32]);
+    }
+
+    #[test]
+    fn sparse_write_past_the_end_zero_fills() {
+        let mut b = SpillBuffer::with_spill_at(1024);
+        b.write_at(4, b"xy").unwrap();
+        assert_eq!(b.len(), 6);
+        assert_eq!(b.as_bytes().unwrap(), vec![0, 0, 0, 0, b'x', b'y']);
+    }
+
+    #[test]
+    fn overwriting_in_place_works_after_spilling() {
+        let mut b = SpillBuffer::with_spill_at(8);
+        b.write_at(0, &[9u8; 40]).unwrap();
+        b.write_at(4, b"zz").unwrap();
+        let bytes = b.as_bytes().unwrap();
+        assert_eq!(&bytes[4..6], b"zz");
+        assert_eq!(b.len(), 40, "an in-place write does not shrink the file");
+    }
+
+    #[test]
+    fn temp_file_is_removed_on_drop() {
+        let mut b = SpillBuffer::with_spill_at(4);
+        b.write_at(0, &[1u8; 32]).unwrap();
+        let path = b.spilled_path().unwrap().unwrap().to_path_buf();
+        assert!(path.exists());
+        drop(b);
+        assert!(
+            !path.exists(),
+            "a dropped buffer leaves no temp file behind"
+        );
+    }
+
+    #[test]
+    fn payload_for_small_buffer_carries_the_bytes() {
+        let mut b = SpillBuffer::with_spill_at(1024);
+        b.write_at(0, b"inline").unwrap();
+        match payload_for(&mut b).unwrap() {
+            Payload::Memory(d) => assert_eq!(d, b"inline"),
+            Payload::File(_) => panic!("an in-memory buffer must not go out as a file"),
+        }
+    }
+
+    #[test]
+    fn payload_for_spilled_buffer_points_at_the_temp_file() {
+        let mut b = SpillBuffer::with_spill_at(4);
+        b.write_at(0, &[3u8; 64]).unwrap();
+        match payload_for(&mut b).unwrap() {
+            Payload::File(p) => {
+                assert_eq!(std::fs::read(&p).unwrap(), vec![3u8; 64]);
+                assert_eq!(payload_for(&mut b).unwrap().len(), 64);
+            }
+            Payload::Memory(_) => panic!("a spilled buffer must go out as a file"),
+        }
+    }
+
+    #[test]
+    fn payload_for_leaves_the_buffer_usable() {
+        // WinFsp's flush retries from close() on failure, so snapshotting must
+        // not consume the buffer.
+        let mut b = SpillBuffer::with_spill_at(4);
+        b.write_at(0, &[1u8; 32]).unwrap();
+        let _ = payload_for(&mut b).unwrap();
+        b.write_at(32, &[2u8; 8]).unwrap();
+        assert_eq!(b.len(), 40);
+        assert_eq!(payload_for(&mut b).unwrap().len(), 40);
+    }
+
+    #[test]
+    fn set_len_truncates_and_extends_in_memory() {
+        let mut b = SpillBuffer::with_spill_at(1024);
+        b.write_at(0, b"abcdef").unwrap();
+        b.set_len(3).unwrap();
+        assert_eq!(b.as_bytes().unwrap(), b"abc");
+        b.set_len(5).unwrap();
+        assert_eq!(b.as_bytes().unwrap(), b"abc\0\0", "extension zero-fills");
+        assert_eq!(b.len(), 5);
+    }
+
+    #[test]
+    fn set_len_truncates_a_spilled_buffer() {
+        let mut b = SpillBuffer::with_spill_at(4);
+        b.write_at(0, &[8u8; 64]).unwrap();
+        b.set_len(10).unwrap();
+        assert_eq!(b.len(), 10);
+        assert_eq!(b.as_bytes().unwrap(), vec![8u8; 10]);
+        let path = b.spilled_path().unwrap().unwrap().to_path_buf();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().len(),
+            10,
+            "the temp file shrinks with the buffer"
+        );
+    }
+}

--- a/rust/synology-filestation-fuse/src/webdav.rs
+++ b/rust/synology-filestation-fuse/src/webdav.rs
@@ -7,6 +7,7 @@ use dav_server::fs::*;
 use futures_util::stream;
 use tracing::debug;
 
+use crate::spill::SpillBuffer;
 use synology_filestation_core::client::SynologyClient;
 use synology_filestation_core::error::SynoFsError;
 use synology_filestation_core::types::SynoFileInfo;
@@ -171,7 +172,7 @@ struct SynoDavFile {
     info: SynoFileInfo,
     offset: u64,
     /// Buffered write data; `Some` when opened for writing.
-    write_buf: Option<Vec<u8>>,
+    write_buf: Option<SpillBuffer>,
     /// True when the file did not exist on the NAS at open time.
     /// Used to skip the delete-before-upload overwrite path.
     is_new: bool,
@@ -186,19 +187,19 @@ impl DavFile for SynoDavFile {
     fn write_buf(&mut self, buf: Box<dyn Buf + Send>) -> FsFuture<'_, ()> {
         let mut b = buf;
         let chunk = b.copy_to_bytes(b.remaining());
-        match &mut self.write_buf {
-            Some(v) => v.extend_from_slice(&chunk),
-            None => self.write_buf = Some(chunk.to_vec()),
-        }
-        Box::pin(async { Ok(()) })
+        Box::pin(async move {
+            let sink = self.write_buf.get_or_insert_with(SpillBuffer::new);
+            sink.write_at(sink.len(), &chunk)
+                .map_err(|_| FsError::GeneralFailure)
+        })
     }
 
     fn write_bytes(&mut self, buf: Bytes) -> FsFuture<'_, ()> {
-        match &mut self.write_buf {
-            Some(v) => v.extend_from_slice(&buf),
-            None => self.write_buf = Some(buf.to_vec()),
-        }
-        Box::pin(async { Ok(()) })
+        Box::pin(async move {
+            let sink = self.write_buf.get_or_insert_with(SpillBuffer::new);
+            sink.write_at(sink.len(), &buf)
+                .map_err(|_| FsError::GeneralFailure)
+        })
     }
 
     fn read_bytes(&mut self, count: usize) -> FsFuture<'_, Bytes> {
@@ -235,7 +236,7 @@ impl DavFile for SynoDavFile {
     }
 
     fn flush(&mut self) -> FsFuture<'_, ()> {
-        if let Some(data) = self.write_buf.take() {
+        if let Some(mut buf) = self.write_buf.take() {
             // AppleDouble companion files (._*) are discarded — not stored on the NAS.
             if is_apple_double(&self.nas_path) {
                 return Box::pin(async { Ok(()) });
@@ -243,12 +244,29 @@ impl DavFile for SynoDavFile {
             let client = self.client.clone();
             let path = self.nas_path.clone();
             let overwrite = !self.is_new;
+            // A buffer that outgrew memory is already on disk; hand the core the
+            // file so it uploads in slices instead of materializing the whole
+            // thing. Small writes still go out in one shot, as before.
+            let spilled = match buf.spilled_path() {
+                Ok(Some(p)) => Some(p.to_path_buf()),
+                Ok(None) => None,
+                Err(_) => return Box::pin(async { Err(FsError::GeneralFailure) }),
+            };
             Box::pin(async move {
                 let (parent, filename) = split_path(&path);
-                client
-                    .upload(parent, filename, data, overwrite)
-                    .await
-                    .map_err(syno_err)
+                match spilled {
+                    Some(local) => client
+                        .upload_from_path(&local, parent, filename, overwrite)
+                        .await
+                        .map_err(syno_err),
+                    None => {
+                        let data = buf.as_bytes().map_err(|_| FsError::GeneralFailure)?;
+                        client
+                            .upload(parent, filename, data, overwrite)
+                            .await
+                            .map_err(syno_err)
+                    }
+                }
             })
         } else {
             Box::pin(async { Ok(()) })
@@ -355,7 +373,7 @@ impl DavFileSystem for SynologyDavFs {
                         nas_path: nas,
                         info,
                         offset: 0,
-                        write_buf: Some(Vec::new()),
+                        write_buf: Some(SpillBuffer::new()),
                         is_new: false,
                     });
                     return Ok(file);
@@ -384,7 +402,7 @@ impl DavFileSystem for SynologyDavFs {
                     nas_path: nas,
                     info,
                     offset: 0,
-                    write_buf: Some(Vec::new()),
+                    write_buf: Some(SpillBuffer::new()),
                     is_new,
                 });
                 Ok(file)

--- a/rust/synology-filestation-fuse/src/webdav.rs
+++ b/rust/synology-filestation-fuse/src/webdav.rs
@@ -7,7 +7,7 @@ use dav_server::fs::*;
 use futures_util::stream;
 use tracing::debug;
 
-use crate::spill::SpillBuffer;
+use crate::spill::{payload_for, upload_payload, SpillBuffer};
 use synology_filestation_core::client::SynologyClient;
 use synology_filestation_core::error::SynoFsError;
 use synology_filestation_core::types::SynoFileInfo;
@@ -244,29 +244,20 @@ impl DavFile for SynoDavFile {
             let client = self.client.clone();
             let path = self.nas_path.clone();
             let overwrite = !self.is_new;
-            // A buffer that outgrew memory is already on disk; hand the core the
-            // file so it uploads in slices instead of materializing the whole
-            // thing. Small writes still go out in one shot, as before.
-            let spilled = match buf.spilled_path() {
-                Ok(Some(p)) => Some(p.to_path_buf()),
-                Ok(None) => None,
+            let payload = match payload_for(&mut buf) {
+                Ok(p) => p,
                 Err(_) => return Box::pin(async { Err(FsError::GeneralFailure) }),
             };
+            debug!("flush: uploading {} ({} bytes)", path, payload.len());
             Box::pin(async move {
+                // The buffer rides along so it outlives the upload: a spilled
+                // buffer deletes its temp file on drop, and that file is the
+                // payload being sent.
+                let _buf = buf;
                 let (parent, filename) = split_path(&path);
-                match spilled {
-                    Some(local) => client
-                        .upload_from_path(&local, parent, filename, overwrite)
-                        .await
-                        .map_err(syno_err),
-                    None => {
-                        let data = buf.as_bytes().map_err(|_| FsError::GeneralFailure)?;
-                        client
-                            .upload(parent, filename, data, overwrite)
-                            .await
-                            .map_err(syno_err)
-                    }
-                }
+                upload_payload(&client, parent, filename, payload, overwrite)
+                    .await
+                    .map_err(syno_err)
             })
         } else {
             Box::pin(async { Ok(()) })

--- a/rust/synology-filestation-fuse/src/winfs.rs
+++ b/rust/synology-filestation-fuse/src/winfs.rs
@@ -317,20 +317,34 @@ impl FileSystemContext for SynologyWinFs {
         // buffer deletes its temp file, which is exactly what we are uploading.
         let mut taken = context.write_buf.lock().unwrap().take();
         if let Some(buf) = taken.as_mut() {
-            if let Ok(payload) = payload_for(buf) {
-                tracing::debug!(
-                    "close: last-chance upload {} ({} bytes)",
-                    context.nas_path,
-                    payload.len()
-                );
-                let (parent, name) = split_path(&context.nas_path);
-                let _ = self.runtime.block_on(upload_payload(
-                    &self.client,
-                    parent,
-                    name,
-                    payload,
-                    !context.is_new,
-                ));
+            match payload_for(buf) {
+                Ok(payload) => {
+                    tracing::debug!(
+                        "close: last-chance upload {} ({} bytes)",
+                        context.nas_path,
+                        payload.len()
+                    );
+                    let (parent, name) = split_path(&context.nas_path);
+                    if let Err(e) = self.runtime.block_on(upload_payload(
+                        &self.client,
+                        parent,
+                        name,
+                        payload,
+                        !context.is_new,
+                    )) {
+                        // Nothing left to retry with — the handle is closing.
+                        tracing::error!(
+                            "close: last-chance upload of {} failed: {e}",
+                            context.nas_path
+                        );
+                    }
+                }
+                // This path exists to stop data loss when flush() never ran, so
+                // failing to even read the buffer must not pass silently.
+                Err(e) => tracing::error!(
+                    "close: cannot read write buffer for {}, data not uploaded: {e}",
+                    context.nas_path
+                ),
             }
         }
         tracing::debug!("close: removing pending {}", context.nas_path);

--- a/rust/synology-filestation-fuse/src/winfs.rs
+++ b/rust/synology-filestation-fuse/src/winfs.rs
@@ -9,6 +9,7 @@ use winfsp::filesystem::{
 };
 use winfsp::FspError;
 
+use crate::spill::{payload_for, upload_payload, SpillBuffer};
 use synology_filestation_core::client::SynologyClient;
 use synology_filestation_core::error::SynoFsError;
 use synology_filestation_core::types::SynoFileInfo;
@@ -113,7 +114,7 @@ fn now_filetime() -> u64 {
 
 /// Shared write buffer type — an Arc so multiple FileContexts for the same
 /// pending path can all point at the same buffer.
-type SharedBuf = Arc<Mutex<Option<Vec<u8>>>>;
+type SharedBuf = Arc<Mutex<Option<SpillBuffer>>>;
 
 /// Entry stored for each file that has been `create()`d but not yet uploaded.
 /// Keeping FileInfo here lets `open()` return plausible metadata without an
@@ -192,7 +193,7 @@ impl SynoFileContext {
         let write_buf = if is_dir {
             Arc::new(Mutex::new(None))
         } else {
-            Arc::new(Mutex::new(Some(Vec::new())))
+            Arc::new(Mutex::new(Some(SpillBuffer::new())))
         };
         Self {
             nas_path,
@@ -312,17 +313,25 @@ impl FileSystemContext for SynologyWinFs {
     fn close(&self, context: Self::FileContext) {
         // Last-chance upload: if flush() was never called (or was bypassed),
         // upload any remaining buffered data before dropping the context.
-        let data_opt = context.write_buf.lock().unwrap().take();
-        if let Some(data) = data_opt {
-            tracing::debug!(
-                "close: last-chance upload {} ({} bytes)",
-                context.nas_path,
-                data.len()
-            );
-            let (parent, name) = split_path(&context.nas_path);
-            let _ = self
-                .runtime
-                .block_on(self.client.upload(parent, name, data, !context.is_new));
+        // The buffer is held in `taken` across the upload: dropping a spilled
+        // buffer deletes its temp file, which is exactly what we are uploading.
+        let mut taken = context.write_buf.lock().unwrap().take();
+        if let Some(buf) = taken.as_mut() {
+            if let Ok(payload) = payload_for(buf) {
+                tracing::debug!(
+                    "close: last-chance upload {} ({} bytes)",
+                    context.nas_path,
+                    payload.len()
+                );
+                let (parent, name) = split_path(&context.nas_path);
+                let _ = self.runtime.block_on(upload_payload(
+                    &self.client,
+                    parent,
+                    name,
+                    payload,
+                    !context.is_new,
+                ));
+            }
         }
         tracing::debug!("close: removing pending {}", context.nas_path);
         self.pending_files
@@ -403,14 +412,12 @@ impl FileSystemContext for SynologyWinFs {
         file_info: &mut FileInfo,
     ) -> winfsp::Result<u32> {
         let mut wb = context.write_buf.lock().unwrap();
-        let buf = wb.get_or_insert_with(Vec::new);
-        let end = offset as usize + buffer.len();
-        if buf.len() < end {
-            buf.resize(end, 0);
-        }
-        buf[offset as usize..end].copy_from_slice(buffer);
+        let buf = wb.get_or_insert_with(SpillBuffer::new);
+        // Spills to a temp file past its threshold, so a large copy through the
+        // mount no longer pins the whole file in memory.
+        buf.write_at(offset, buffer).map_err(FspError::from)?;
         *file_info = context.file_info.clone();
-        file_info.file_size = buf.len() as u64;
+        file_info.file_size = buf.len();
         file_info.allocation_size = (file_info.file_size + 511) & !511;
         Ok(buffer.len() as u32)
     }
@@ -421,16 +428,31 @@ impl FileSystemContext for SynologyWinFs {
         file_info: &mut FileInfo,
     ) -> winfsp::Result<()> {
         if let Some(ctx) = context {
-            // Clone the data before attempting the upload so that if the upload
-            // fails, the data stays in write_buf for close() to retry.
-            let data_opt = ctx.write_buf.lock().unwrap().as_ref().map(|v| v.clone());
-            if let Some(data) = data_opt {
-                tracing::debug!("flush: uploading {} ({} bytes)", ctx.nas_path, data.len());
+            // Snapshot the buffer without consuming it, so a failed upload
+            // leaves the data in write_buf for close() to retry. For a spilled
+            // buffer the snapshot is just the temp path — no copy, and the
+            // upload streams it in slices.
+            let payload = {
+                let mut wb = ctx.write_buf.lock().unwrap();
+                match wb.as_mut() {
+                    Some(buf) => Some(payload_for(buf).map_err(FspError::from)?),
+                    None => None,
+                }
+            };
+            if let Some(payload) = payload {
+                tracing::debug!(
+                    "flush: uploading {} ({} bytes)",
+                    ctx.nas_path,
+                    payload.len()
+                );
                 let (parent, name) = split_path(&ctx.nas_path);
-                match self
-                    .runtime
-                    .block_on(self.client.upload(parent, name, data, !ctx.is_new))
-                {
+                match self.runtime.block_on(upload_payload(
+                    &self.client,
+                    parent,
+                    name,
+                    payload,
+                    !ctx.is_new,
+                )) {
                     Ok(()) => {
                         // Upload succeeded — consume the buffer, but keep the pending
                         // entry alive so that a subsequent get_security_by_name() for
@@ -466,8 +488,8 @@ impl FileSystemContext for SynologyWinFs {
         file_info: &mut FileInfo,
     ) -> winfsp::Result<()> {
         let mut wb = context.write_buf.lock().unwrap();
-        let buf = wb.get_or_insert_with(Vec::new);
-        buf.resize(new_size as usize, 0);
+        let buf = wb.get_or_insert_with(SpillBuffer::new);
+        buf.set_len(new_size).map_err(FspError::from)?;
         *file_info = context.file_info.clone();
         file_info.file_size = new_size;
         file_info.allocation_size = (new_size + 511) & !511;
@@ -562,20 +584,26 @@ impl FileSystemContext for SynologyWinFs {
         // If the file has buffered data not yet uploaded (either because this
         // is the original create() handle or a secondary handle that shares
         // the same Arc<Mutex<...>>), upload directly under the new name.
-        let data_opt = context.write_buf.lock().unwrap().take();
-        if let Some(data) = data_opt {
+        // Held across the upload for the same reason as in close(): dropping a
+        // spilled buffer would delete the temp file being uploaded.
+        let mut taken = context.write_buf.lock().unwrap().take();
+        if let Some(buf) = taken.as_mut() {
+            let payload = payload_for(buf).map_err(FspError::from)?;
             tracing::debug!(
                 "rename: uploading pending {} -> {}/{} ({} bytes)",
                 from,
                 upload_parent,
                 to_name,
-                data.len()
+                payload.len()
             );
             self.runtime
-                .block_on(
-                    self.client
-                        .upload(upload_parent, to_name, data, !context.is_new),
-                )
+                .block_on(upload_payload(
+                    &self.client,
+                    upload_parent,
+                    to_name,
+                    payload,
+                    !context.is_new,
+                ))
                 .map_err(syno_to_fsp)?;
             self.pending_files.write().unwrap().remove(from);
             return Ok(());


### PR DESCRIPTION
## Why

Every upload path held the whole file in memory. `http_upload` takes a `Vec<u8>` and `clone()`s it per retry attempt, so a 6 GB write peaked near 12 GB — the mechanism behind the mount wedging during a large copy, where FUSE callbacks queue behind the allocation and every other filesystem operation stalls with it.

## The protocol

DSM's File Station uploader already solves this by slicing. Three HAR captures of it against e4e-nas, plus its own JS (`FileUploader_T9JY.js`), pin it down exactly:

```
POST entry.cgi?api=SYNO.FileStation.Upload&method=upload&version=2
X-TYPE-NAME: SLICEUPLOAD
X-FILE-SIZE: <total bytes>
X-FILE-CHUNK-END: false        # true on the final slice (index == total-1)
X-TMP-FILE: slice.<epoch>.0.<pid>   # slice 2+, echoed from the previous response
body: overwrite | path | mtime | file   (10 MiB)
```

- **The last data slice terminates the upload** — `X-FILE-CHUNK-END: true`, no separate finalize request. Confirmed in the JS: `(1 > o.total || o.index === o.total-1) ? "true" : "false"`, and `onSuccess` calls `onFinish` on the last one.
- **`X-TMP-FILE` correlates slices**, not the session cookie. The first slice omits it, the response carries `data.tmpfile`, and every later slice echoes it back. Verified in the capture: slice 1 has no header, slices 2–3 both send `slice.1786304257.0.9224` while the `pid` in the response changes.
- **A non-final response without a `tmpfile` is fatal** — DSM's own client calls `onError` rather than continuing, so we do too.
- DSM slices only above `MAX_POST_FILESIZE` (4 GiB − 4096); `chunksize` is 10 MiB.

## What changed

**Core** — `http_slice_upload`: one reused buffer, one POST per slice, memory bounded by the slice at any file size. `upload_from_path` routes to it when a file exceeds one slice, after the SMB stream transports get their turn.

Two deliberate divergences, both commented at the code:
- **We slice above one slice, not above 4 GiB.** DSM's threshold is about its POST limit; ours is memory, and the threshold *is* the memory ceiling.
- **No per-slice retry.** A resent slice appends twice and DSM offers no way to ask how much of the partial file it holds. Failures surface and the caller restarts the file — the outer-retry contract the throttle docs already specify.

**mtime fidelity fix**, also from the captures: DSM stores the client's `mtime` verbatim — a file uploaded with `mtime=1786315083000` listed back as `mtime=1786315083`, `crtime` = upload time. We sent neither `mtime` nor `size`, so every uploaded file was stamped with the upload time. Both paths now send them.

**GUI/FFI** — `syno_upload` no longer reads the file into a `Vec`. It streams from disk and reports progress per slice through the new `ProgressSink`, so the GUI's upload bar moves instead of jumping 0 → 100%. `user_data` crosses as a `usize`, the same trick `logging.rs` already uses to stay `Send` without an `unsafe impl`.

**All three mount backends** now buffer writes in a `SpillBuffer` (`spill.rs`): in memory to 8 MiB, then a temp file, removed on drop. `payload_for` snapshots a buffer **without consuming it** — WinFsp retries a failed flush from `close()` — and yields a temp path for spilled buffers, so the snapshot is O(1) at any size. `upload_payload` picks one-shot or streaming. Both live in `spill.rs` so the backends can't drift and so the logic is compiled and tested on Linux even though two of the backends aren't.

One hazard worth knowing about, commented at both sites: in WinFsp's `close()` and `rename()` the buffer is held in a local across the upload, because dropping a spilled buffer deletes the temp file being uploaded.

## Testing

TDD throughout — every behavior below was a failing test first.

- Core (86 pass): slice count and `X-FILE-CHUNK-END` sequence; `X-TMP-FILE` handshake (`None`, then the echoed handle twice); abort when a non-final response omits `tmpfile`; stop at the failing slice without sending the rest; one-shot path untouched for small files; `mtime`/`size` fields; per-slice progress `(1024,2500) (2048,2500) (2500,2500)`.
- Fuse (31 pass): 11 `SpillBuffer`/payload tests — threshold crossing preserves content, sparse writes zero-fill, in-place overwrite after spilling, `set_len` shrinks the temp file, snapshot leaves the buffer usable, temp file removed on drop.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo fmt` applied.

**This is what the PR is for.** Only Linux compiles here. To check the macOS backend I temporarily flipped its dependency gate to `cfg(all())` and un-gated the module so it built on Linux — which caught a real bug: `SynoDavFile` derives `Debug` and `SpillBuffer` didn't implement it. Fixed with a hand-written `Debug` that prints length and spilled-state only (a derived one would dump a multi-gigabyte body into a log line). That gate change is reverted. **The WinFsp backend has never been compiled** — `winfsp-sys` needs the Windows SDK — so the Windows job here is its first real check. I did read `FspError`'s `From<std::io::Error>` impl out of the cargo registry before relying on it.

Also unverified: **nothing here has touched a real NAS.** Everything is wiremock plus DSM's own JS.

## Follow-ups, not in this PR

- The 8 MiB spill threshold and the temp-file location are hardcoded. `std::env::temp_dir()` can be a RAM-backed tmpfs, which would defeat the purpose — `--spill-dir` / `--spill-mb` should exist before this ships widely.
- Cross-directory moves still download→upload through memory; that's the read side, and a separate change.

`Cargo.lock` picks up the 0.2.1 versions it had been missing since the release — release-please doesn't regenerate the workspace lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)