### PR TITLE
fix: seven data-loss and corruption defects found in review (tier 1)

### DIFF
--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -180,6 +180,19 @@ impl<T: ?Sized> TransportEntry<T> {
 /// file in a `Vec<u8>`, so we slice anything that exceeds one slice.
 pub const DEFAULT_SLICE_SIZE: usize = 10 * 1024 * 1024;
 
+/// Entries requested per `list` / `list_share` page.
+///
+/// DSM caps what one response may carry, so a directory larger than this needs
+/// several requests. Kept modest rather than maximal: a page is parsed whole, so
+/// this trades one extra round trip on very large directories for a bounded
+/// per-response allocation.
+pub const LIST_PAGE_SIZE: usize = 1000;
+
+/// Ceiling on pages fetched for a single listing, so a server that reports an
+/// unreachable `total` (or keeps handing back full pages) cannot spin us
+/// forever. At [`LIST_PAGE_SIZE`] this covers 10M entries in one directory.
+const LIST_MAX_PAGES: usize = 10_000;
+
 /// Upload progress sink: `(bytes_done, bytes_total)`, called once per slice.
 /// Borrowed rather than boxed so callers can pass a plain closure reference.
 pub type ProgressSink<'a> = &'a (dyn Fn(u64, u64) + Send + Sync);
@@ -584,67 +597,102 @@ impl SynologyClient {
         Ok(())
     }
 
+    /// Fetch a `SYNO.FileStation.List` listing in full, following pagination.
+    ///
+    /// A single request only ever returns one page, so asking once and keeping
+    /// whatever came back silently truncates any directory bigger than the
+    /// limit — and a filesystem that omits files is worse than one that errors.
+    /// This keeps requesting at increasing offsets until the server says it is
+    /// done, which it signals either by reporting a `total` we have reached or
+    /// by handing back a partial (or empty) page.
+    async fn list_paged<T, F>(
+        &self,
+        method: &str,
+        extra_params: &[(&str, &str)],
+        additional: &str,
+        label: &str,
+        unpack: F,
+    ) -> Result<Vec<SynoFileInfo>, SynoFsError>
+    where
+        T: serde::de::DeserializeOwned,
+        F: Fn(T) -> (Vec<SynoFileInfo>, Option<u64>),
+    {
+        let url = format!("{}/entry.cgi", self.base_url);
+        let sid = self.sid();
+        let limit = LIST_PAGE_SIZE.to_string();
+        let mut collected: Vec<SynoFileInfo> = Vec::new();
+
+        for _ in 0..LIST_MAX_PAGES {
+            let offset = collected.len().to_string();
+            let mut params: Vec<(&str, &str)> = vec![
+                ("api", "SYNO.FileStation.List"),
+                ("version", "2"),
+                ("method", method),
+            ];
+            params.extend_from_slice(extra_params);
+            params.push(("additional", additional));
+            params.push(("limit", &limit));
+            params.push(("offset", &offset));
+            params.push(("_sid", &sid));
+
+            let text = self.get_text_retried(&url, &params).await?;
+            let resp: SynoResponse<T> = serde_json::from_str(&text)
+                .map_err(|e| SynoFsError::Io(format!("{label} parse error: {e}")))?;
+            if !resp.success {
+                let code = resp.error.map(|e| e.code).unwrap_or(0);
+                return Err(SynoFsError::ApiError(code));
+            }
+
+            let (page, total) = match resp.data {
+                Some(d) => unpack(d),
+                None => (Vec::new(), None),
+            };
+            let page_len = page.len();
+            collected.extend(page);
+
+            let done = page_len == 0
+                || page_len < LIST_PAGE_SIZE
+                || total.is_some_and(|t| collected.len() as u64 >= t);
+            if done {
+                debug!("{label}: {} entries", collected.len());
+                return Ok(collected);
+            }
+        }
+
+        // Only reachable from a server that keeps handing back full pages
+        // without ever satisfying its own `total`. Return what we have rather
+        // than looping, but say so — a short listing must never look normal.
+        warn!(
+            "{label}: stopped at the {LIST_MAX_PAGES}-page cap with {} entries; listing may be incomplete",
+            collected.len()
+        );
+        Ok(collected)
+    }
+
     /// List all FileStation shares the account can see.
     pub async fn list_shares(&self) -> Result<Vec<SynoFileInfo>, SynoFsError> {
-        let url = format!("{}/entry.cgi", self.base_url);
         debug!("list_shares");
-        let text = self
-            .get_text_retried(
-                &url,
-                &[
-                    ("api", "SYNO.FileStation.List"),
-                    ("version", "2"),
-                    ("method", "list_share"),
-                    ("additional", SHARE_ADDITIONAL_FIELDS),
-                    ("limit", "500"),
-                    ("offset", "0"),
-                    ("_sid", &self.sid()),
-                ],
-            )
-            .await?;
-
-        let resp: SynoResponse<ListShareData> = serde_json::from_str(&text)
-            .map_err(|e| SynoFsError::Io(format!("list_shares parse error: {e}")))?;
-
-        if resp.success {
-            let shares = resp.data.map(|d| d.shares).unwrap_or_default();
-            debug!("list_shares: {} shares returned", shares.len());
-            Ok(shares)
-        } else {
-            let code = resp.error.map(|e| e.code).unwrap_or(0);
-            Err(SynoFsError::ApiError(code))
-        }
+        self.list_paged::<ListShareData, _>(
+            "list_share",
+            &[],
+            SHARE_ADDITIONAL_FIELDS,
+            "list_shares",
+            |d| (d.shares, d.total),
+        )
+        .await
     }
 
     /// List the contents of a directory.
     pub async fn list_dir(&self, folder_path: &str) -> Result<Vec<SynoFileInfo>, SynoFsError> {
-        let url = format!("{}/entry.cgi", self.base_url);
         debug!("list_dir: {}", folder_path);
-        let text = self
-            .get_text_retried(
-                &url,
-                &[
-                    ("api", "SYNO.FileStation.List"),
-                    ("version", "2"),
-                    ("method", "list"),
-                    ("folder_path", folder_path),
-                    ("additional", ADDITIONAL_FIELDS),
-                    ("limit", "5000"),
-                    ("offset", "0"),
-                    ("_sid", &self.sid()),
-                ],
-            )
-            .await?;
-
-        let resp: SynoResponse<ListData> = serde_json::from_str(&text)
-            .map_err(|e| SynoFsError::Io(format!("list_dir parse error: {e}")))?;
-
-        if resp.success {
-            Ok(resp.data.map(|d| d.files).unwrap_or_default())
-        } else {
-            let code = resp.error.map(|e| e.code).unwrap_or(0);
-            Err(SynoFsError::ApiError(code))
-        }
+        self.list_paged::<ListData, _>(
+            "list",
+            &[("folder_path", folder_path)],
+            ADDITIONAL_FIELDS,
+            "list_dir",
+            |d| (d.files, d.total),
+        )
+        .await
     }
 
     /// Get metadata for a single file or directory.
@@ -1199,15 +1247,23 @@ impl SynologyClient {
             data.len()
         );
 
-        if overwrite {
-            self.clear_for_overwrite(folder_path, filename).await;
-        }
-
         let max_attempts = self.max_transfer_attempts();
         let mut last_err = SynoFsError::Io("no attempts".into());
         for attempt in 0..max_attempts {
             if attempt > 0 {
                 debug!("upload retry {} for {}/{}", attempt, folder_path, filename);
+            }
+
+            // Re-clear on *every* attempt, not once up front. Both upload paths
+            // always POST with `overwrite=false` (DSM's multipart overwrite
+            // times out on some versions), so an attempt only succeeds onto
+            // cleared ground. A previous attempt whose response was lost may
+            // well have landed the file — retrying without re-clearing would
+            // then get 418 and report a write that *succeeded* as
+            // AlreadyExists. Re-clearing is also what makes retrying an upload
+            // safe at all.
+            if overwrite {
+                self.clear_for_overwrite(folder_path, filename).await;
             }
 
             let file_part = multipart::Part::bytes(data.clone())
@@ -1231,6 +1287,9 @@ impl SynologyClient {
 
             // Hold a transfer slot only for the request+response read; drop it
             // before any backoff so a retrying upload doesn't hog a permit.
+            // `Ok(text)` = a 2xx body to parse; `Err(e)` = retry this attempt.
+            // A non-transient HTTP status returns immediately: the server gave
+            // a definitive refusal, and resending the same request cannot help.
             let text = {
                 let _slot = self.acquire_transfer_slot().await;
                 match self
@@ -1241,8 +1300,20 @@ impl SynologyClient {
                     .send()
                     .await
                 {
-                    Ok(r) => r.text().await.map_err(SynoFsError::from),
-                    Err(e) => Err(e.into()),
+                    Err(e) => Err(SynoFsError::from(e)),
+                    Ok(r) => {
+                        let status = r.status();
+                        if status.is_success() {
+                            r.text().await.map_err(SynoFsError::from)
+                        } else {
+                            let err = SynoFsError::Io(format!("upload HTTP {}", status));
+                            if http_status_is_transient(status) {
+                                Err(err)
+                            } else {
+                                return Err(err);
+                            }
+                        }
+                    }
                 }
             };
 
@@ -1607,6 +1678,158 @@ mod tests {
         assert!(files.is_empty());
     }
 
+    // ── list pagination ──────────────────────────────────────────────────────
+
+    /// Build a `list`/`list_share` page: `count` synthetic entries plus the
+    /// server-reported `total` for the whole directory.
+    fn page_body(
+        key: &str,
+        prefix: &str,
+        start: usize,
+        count: usize,
+        total: usize,
+    ) -> serde_json::Value {
+        let entries: Vec<serde_json::Value> = (start..start + count)
+            .map(|i| {
+                serde_json::json!({
+                    "name": format!("f{i}"),
+                    "path": format!("{prefix}/f{i}"),
+                    "isdir": false,
+                    "additional": null
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "success": true,
+            "data": { "total": total, "offset": start, key: entries }
+        })
+    }
+
+    /// Regression: `list_dir` sent a single request with a hardcoded limit and
+    /// `offset=0`, then returned whatever came back. A directory with more
+    /// entries than one page was silently listed short — through FUSE that
+    /// presents as files that simply do not exist. Every page must be fetched.
+    #[tokio::test]
+    async fn list_dir_pages_until_the_server_total_is_reached() {
+        let server = MockServer::start().await;
+        let page = LIST_PAGE_SIZE;
+        let total = page + 37;
+
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list"))
+            .and(query_param("offset", "0"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(page_body("files", "/share", 0, page, total)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list"))
+            .and(query_param("offset", page.to_string().as_str()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(page_body("files", "/share", page, 37, total)),
+            )
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let files = client.list_dir("/share").await.unwrap();
+        assert_eq!(files.len(), total, "every page must be collected");
+        assert_eq!(files[0].name, "f0");
+        assert_eq!(files[total - 1].name, format!("f{}", total - 1));
+    }
+
+    /// Same defect on the share listing, which had an even smaller cap (500).
+    #[tokio::test]
+    async fn list_shares_pages_until_the_server_total_is_reached() {
+        let server = MockServer::start().await;
+        let page = LIST_PAGE_SIZE;
+        let total = page + 5;
+
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list_share"))
+            .and(query_param("offset", "0"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(page_body("shares", "", 0, page, total)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list_share"))
+            .and(query_param("offset", page.to_string().as_str()))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(page_body("shares", "", page, 5, total)),
+            )
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let shares = client.list_shares().await.unwrap();
+        assert_eq!(shares.len(), total);
+    }
+
+    /// A directory that fits in one page must still cost exactly one request —
+    /// paging must not add a speculative second round trip to every listing.
+    #[tokio::test]
+    async fn list_dir_stops_after_a_short_page() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(page_body("files", "/share", 0, 3, 3)),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let files = client.list_dir("/share").await.unwrap();
+        assert_eq!(files.len(), 3);
+        // `expect(1)` is asserted when the server drops at end of scope.
+    }
+
+    /// A server that reports a `total` it never delivers (or keeps returning
+    /// full pages forever) must not spin the client indefinitely: paging stops
+    /// as soon as a page comes back empty.
+    #[tokio::test]
+    async fn list_dir_stops_when_a_page_comes_back_empty() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list"))
+            .and(query_param("offset", "0"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(page_body(
+                "files",
+                "/share",
+                0,
+                LIST_PAGE_SIZE,
+                999_999,
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list"))
+            .and(query_param("offset", LIST_PAGE_SIZE.to_string().as_str()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"total": 999_999, "files": []}
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let files = client.list_dir("/share").await.unwrap();
+        assert_eq!(files.len(), LIST_PAGE_SIZE);
+    }
+
     // ── get_info ─────────────────────────────────────────────────────────────
 
     #[tokio::test]
@@ -1794,6 +2017,87 @@ mod tests {
             .upload("/share", "test.txt", b"new content".to_vec(), true)
             .await
             .unwrap();
+    }
+
+    /// Regression: `clear_for_overwrite` used to run *once*, before the retry
+    /// loop. An overwrite that had to be retried therefore re-POSTed with
+    /// `overwrite=false` onto ground that was no longer clear — if the first
+    /// attempt actually landed on the NAS before the response was lost, DSM
+    /// answered 418 and a write that had *succeeded* was reported as
+    /// AlreadyExists. Each attempt must start from cleared ground.
+    #[tokio::test]
+    async fn overwrite_upload_reclears_the_destination_before_each_retry() {
+        let server = MockServer::start().await;
+
+        // The delete must happen once per upload attempt, not once per call.
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "delete"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"success": true})),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "getinfo"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"success": false, "error": {"code": 414}})),
+            )
+            .mount(&server)
+            .await;
+
+        // First attempt: the backend is degraded (the shape that leaves a write
+        // possibly-applied but unacknowledged). Second attempt: fine.
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"success": true, "data": {"blks": null}})),
+            )
+            .with_priority(2)
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        client
+            .upload("/share", "test.txt", b"new content".to_vec(), true)
+            .await
+            .expect("a retried overwrite must succeed, not report AlreadyExists");
+        // `expect(2)` on the delete mock is asserted when the server drops.
+    }
+
+    /// The retry above is only safe because each attempt re-clears; it must not
+    /// widen into retrying a *definitive* refusal. A 400 is the server telling
+    /// us the request itself is wrong — resending it cannot help.
+    #[tokio::test]
+    async fn upload_does_not_retry_a_permanent_http_status() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/webapi/entry.cgi"))
+            .respond_with(ResponseTemplate::new(400))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let err = client
+            .upload("/share", "test.txt", b"data".to_vec(), false)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, SynoFsError::Io(ref m) if m.contains("400")),
+            "expected a permanent HTTP error, got {err:?}"
+        );
     }
 
     // ── delete ───────────────────────────────────────────────────────────────

--- a/rust/synology-filestation-core/src/types.rs
+++ b/rust/synology-filestation-core/src/types.rs
@@ -69,16 +69,25 @@ pub struct AuthData {
     pub sid: String,
 }
 
-/// List response data
+/// List response data. `total` is the entry count for the *whole* directory,
+/// not this page — the paging loop uses it to know when it is done.
 #[derive(Debug, Deserialize)]
 pub struct ListData {
+    #[serde(default)]
     pub files: Vec<SynoFileInfo>,
+    /// Absent on DSM versions that omit it; paging then falls back to
+    /// "stop on the first partial page".
+    #[serde(default)]
+    pub total: Option<u64>,
 }
 
-/// ListShare response data
+/// ListShare response data. See [`ListData::total`].
 #[derive(Debug, Deserialize)]
 pub struct ListShareData {
+    #[serde(default)]
     pub shares: Vec<SynoFileInfo>,
+    #[serde(default)]
+    pub total: Option<u64>,
 }
 
 /// Sentinel path stored in the inode cache for the virtual root (the share listing).

--- a/rust/synology-filestation-fuse/src/cache.rs
+++ b/rust/synology-filestation-fuse/src/cache.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use moka::sync::Cache;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use synology_filestation_core::types::{InodeEntry, SynoFileInfo};
 
 #[cfg(test)]
@@ -155,6 +155,12 @@ impl InodeCache {
 /// Size of each cached block in bytes (256 KiB).
 pub const READ_BLOCK_SIZE: u64 = 256 * 1024;
 
+/// How long a reader waits on somebody else's in-flight block before giving up
+/// and reporting failure. Comfortably longer than a slow block download (the
+/// core's own request timeout is 30 s) but finite, so a claim that is never
+/// released cannot wedge a FUSE worker thread for the life of the mount.
+pub const BLOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// A cache of file data split into fixed-size blocks.
 ///
 /// Key: `(ino, block_index)` — `block_index = byte_offset / READ_BLOCK_SIZE`.
@@ -221,13 +227,38 @@ impl ReadCache {
     /// Spin-wait (5 ms polls) until the block appears in cache or the
     /// in-flight marker is gone (meaning the download failed).
     /// Returns the cached bytes on success, `None` on failure.
+    ///
+    /// Bounded by [`BLOCK_WAIT_TIMEOUT`]: the owner of an in-flight claim is
+    /// responsible for clearing it, but a task that dies without doing so (a
+    /// panicking prefetch, a runtime shut down mid-download) would otherwise
+    /// strand every waiter here forever — and these waiters are FUSE worker
+    /// threads, so the whole mount stops answering. Giving up returns `None`,
+    /// which the caller already handles as "that download failed".
     pub fn wait_for_block(&self, ino: u64, block_idx: u64) -> Option<Bytes> {
+        self.wait_for_block_until(ino, block_idx, BLOCK_WAIT_TIMEOUT)
+    }
+
+    /// [`wait_for_block`](Self::wait_for_block) with an explicit deadline, so
+    /// the timeout path is testable without stalling the suite.
+    fn wait_for_block_until(&self, ino: u64, block_idx: u64, timeout: Duration) -> Option<Bytes> {
+        let deadline = Instant::now() + timeout;
         loop {
             if let Some(data) = self.blocks.get(&(ino, block_idx)) {
                 return Some(data);
             }
             if !self.in_flight.lock().unwrap().contains(&(ino, block_idx)) {
                 // Download finished (or failed) without populating the cache.
+                return self.blocks.get(&(ino, block_idx));
+            }
+            if Instant::now() >= deadline {
+                // The claim owner never published a block and never released the
+                // claim. Drop the stale marker so the next reader re-downloads
+                // instead of inheriting the same dead wait.
+                self.in_flight.lock().unwrap().remove(&(ino, block_idx));
+                tracing::warn!(
+                    "read cache: abandoned in-flight block ino={ino} idx={block_idx} after {:?}",
+                    timeout
+                );
                 return self.blocks.get(&(ino, block_idx));
             }
             std::thread::sleep(Duration::from_millis(5));
@@ -456,6 +487,62 @@ mod tests {
 
         let result = handle.join().unwrap();
         assert_eq!(result, Some(Bytes::new()));
+    }
+
+    /// Regression: the claim owner can die without ever publishing the block or
+    /// releasing the claim (a panicking prefetch task, a runtime torn down
+    /// mid-download). Before this bound, every waiter looped on a 5 ms sleep
+    /// forever — and the waiters are FUSE worker threads, so the mount stopped
+    /// answering entirely. The wait must give up and report failure.
+    #[test]
+    fn wait_for_block_gives_up_on_an_abandoned_claim() {
+        let rc = ReadCache::new(1024, 16);
+        assert!(rc.claim_inflight(1, 0));
+        // Nobody will ever insert() or cancel_inflight() — the owner is gone.
+        let start = Instant::now();
+        let result = rc.wait_for_block_until(1, 0, Duration::from_millis(50));
+        assert!(result.is_none(), "an abandoned claim must not yield data");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "wait must be bounded, took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Giving up must also clear the stale marker, otherwise the next reader
+    /// inherits the same dead claim and waits out the timeout all over again
+    /// instead of just downloading the block.
+    #[test]
+    fn abandoning_a_claim_frees_it_for_the_next_reader() {
+        let rc = ReadCache::new(1024, 16);
+        assert!(rc.claim_inflight(2, 7));
+        assert!(rc
+            .wait_for_block_until(2, 7, Duration::from_millis(50))
+            .is_none());
+        assert!(
+            rc.claim_inflight(2, 7),
+            "the abandoned claim must be released so a fresh download can start"
+        );
+    }
+
+    /// The bound must not cut short a download that is merely slow: a block
+    /// published before the deadline is still returned.
+    #[test]
+    fn wait_for_block_still_returns_a_slow_but_successful_download() {
+        let rc = Arc::new(ReadCache::new(1024, 16));
+        assert!(rc.claim_inflight(3, 0));
+
+        let rc2 = rc.clone();
+        let handle =
+            std::thread::spawn(move || rc2.wait_for_block_until(3, 0, Duration::from_secs(30)));
+
+        std::thread::sleep(Duration::from_millis(30));
+        rc.insert(3, 0, Bytes::from_static(b"slow payload"));
+
+        assert_eq!(
+            handle.join().unwrap(),
+            Some(Bytes::from_static(b"slow payload"))
+        );
     }
 
     #[test]

--- a/rust/synology-filestation-fuse/src/fs.rs
+++ b/rust/synology-filestation-fuse/src/fs.rs
@@ -27,16 +27,26 @@ fn errno(raw: i32) -> Errno {
     Errno::from_i32(raw)
 }
 
+/// Split a NAS path into `(parent, filename)`. `None` for a path with no
+/// separator, which cannot name a file inside a share.
+///
+/// Previously open-coded at three call sites as `rfind('/')` followed by a
+/// second `rfind('/').unwrap()` — the `unwrap` being safe only because the
+/// preceding match had already proven the separator exists.
+fn split_nas_path(path: &str) -> Option<(&str, &str)> {
+    let idx = path.rfind('/')?;
+    Some((&path[..idx], &path[idx + 1..]))
+}
+
 struct WriteBuffer {
     nas_path: String,
     ino: u64,
     data: SpillBuffer,
     dirty: bool,
     /// True when the file was just created and has not yet been uploaded.
-    /// Allows flush to use overwrite=false, skipping the delete-before-upload round trips.
+    /// Allows the first upload to use overwrite=false, skipping the
+    /// delete-before-upload round trips. Cleared once an upload succeeds.
     new_file: bool,
-    /// In-flight background upload spawned by flush(); waited on in release().
-    upload_handle: Option<tokio::task::JoinHandle<Result<(), SynoFsError>>>,
 }
 
 pub struct SynologyFS {
@@ -153,99 +163,37 @@ impl SynologyFS {
         self.cache.get_path_for_ino(ino)
     }
 
-    /// Spawn a background upload for `fh` if the buffer is dirty.
-    /// Returns immediately; the actual upload runs on the tokio runtime.
-    /// `release` / `destroy` must call `finish_upload` to wait for completion.
-    fn queue_upload(&self, fh: u64) {
-        let mut buffers = self.write_buffers.lock().unwrap();
-        let buf = match buffers.get_mut(&fh) {
-            Some(b) if b.dirty && b.upload_handle.is_none() => b,
-            _ => return,
-        };
-
-        let nas_path = buf.nas_path.clone();
-        let ino = buf.ino;
-        let payload = match payload_for(&mut buf.data) {
-            Ok(p) => p,
-            Err(e) => {
-                error!("queue_upload: cannot read write buffer: {}", e);
-                return;
-            }
-        };
-        let overwrite = !buf.new_file;
-        buf.dirty = false;
-
-        let parent = match nas_path.rfind('/') {
-            Some(i) => nas_path[..i].to_string(),
-            None => return,
-        };
-        let filename = nas_path[nas_path.rfind('/').unwrap() + 1..].to_string();
-
-        debug!(
-            "queue_upload: fh={} parent={:?} filename={:?} size={}",
-            fh,
-            parent,
-            filename,
-            payload.len()
-        );
-
-        let client = self.client.clone();
-        let cache = self.cache.clone();
-        let read_cache = self.read_cache.clone();
-        let path_for_task = nas_path.clone();
-
-        // Spawn the upload; hold the mutex so the handle is stored before release() can run.
-        let handle = self.rt.spawn(async move {
-            let result = upload_payload(&client, &parent, &filename, payload, overwrite).await;
-            cache.invalidate_path(&path_for_task);
-            read_cache.invalidate_ino(ino);
-            result
-        });
-
-        buf.upload_handle = Some(handle);
-    }
-
-    /// Wait for any in-flight upload for `fh`, and synchronously upload any
-    /// remaining dirty data.  Called from `release` and `destroy`.
+    /// Upload `fh`'s buffered data and block until the NAS has it.
+    ///
+    /// This is what `flush` (and therefore `close(2)`) reports on, so it must
+    /// be synchronous: an upload still in flight when we return is an upload
+    /// whose failure nobody will ever hear about.
+    ///
+    /// `dirty` is cleared only *after* the upload succeeds. A failed flush
+    /// therefore leaves the data buffered for `release` to retry, matching what
+    /// the WinFsp backend already does — previously the flag was cleared before
+    /// the upload even started, so a failure silently discarded the write.
     fn finish_upload(&self, fh: u64) -> Result<(), SynoFsError> {
-        // Extract both the handle and dirty state without holding the lock while blocking.
-        let (handle, dirty, nas_path, ino, payload, overwrite) = {
+        // Snapshot under the lock; never hold it across the upload. For a
+        // spilled buffer the payload is just the temp path, and that file stays
+        // alive because the buffer itself stays in `write_buffers` until
+        // `release` removes it — after this call has returned.
+        let (nas_path, ino, payload, overwrite) = {
             let mut buffers = self.write_buffers.lock().unwrap();
             let buf = match buffers.get_mut(&fh) {
-                Some(b) => b,
-                None => return Ok(()),
+                Some(b) if b.dirty => b,
+                // Unknown handle, or nothing written since the last successful
+                // upload: there is genuinely nothing to do.
+                _ => return Ok(()),
             };
-            let handle = buf.upload_handle.take();
-            if !buf.dirty {
-                // Nothing new to upload — just wait for any in-flight task.
-                drop(buffers);
-                return if let Some(h) = handle {
-                    self.block(h)
-                        .map_err(|_| SynoFsError::Io("upload task panicked".into()))?
-                } else {
-                    Ok(())
-                };
-            }
-            let path = buf.nas_path.clone();
-            let ino = buf.ino;
             let payload = payload_for(&mut buf.data).map_err(|e| SynoFsError::Io(e.to_string()))?;
-            let overwrite = !buf.new_file;
-            buf.dirty = false;
-            (handle, true, path, ino, payload, overwrite)
+            (buf.nas_path.clone(), buf.ino, payload, !buf.new_file)
         };
-        let _ = dirty; // used implicitly — we only reach here when dirty was true
 
-        // Wait for any in-flight upload of older data before uploading the newer data.
-        if let Some(h) = handle {
-            self.block(h)
-                .map_err(|_| SynoFsError::Io("upload task panicked".into()))??;
-        }
-
-        let parent = match nas_path.rfind('/') {
-            Some(i) => &nas_path[..i],
+        let (parent, filename) = match split_nas_path(&nas_path) {
+            Some(v) => v,
             None => return Err(SynoFsError::InvalidArg),
         };
-        let filename = &nas_path[nas_path.rfind('/').unwrap() + 1..];
 
         debug!(
             "finish_upload: fh={} parent={:?} filename={:?} size={}",
@@ -261,8 +209,173 @@ impl SynologyFS {
             payload,
             overwrite,
         ))?;
+
+        // Durable now: stop advertising the buffer as dirty, and record that the
+        // file exists on the NAS so a later flush overwrites instead of racing
+        // an `overwrite=false` create against itself.
+        if let Some(buf) = self.write_buffers.lock().unwrap().get_mut(&fh) {
+            buf.dirty = false;
+            buf.new_file = false;
+        }
         self.cache.invalidate_path(&nas_path);
         self.read_cache.invalidate_ino(ino);
+        Ok(())
+    }
+
+    /// Assemble a byte range for `read`, block by block, out of the read cache.
+    ///
+    /// Split out of the `read` callback so the assembly rules are testable
+    /// without a live mount; `read` keeps the prefetch and the reply.
+    fn read_range(
+        &self,
+        ino: u64,
+        path: &str,
+        offset: u64,
+        size: u64,
+    ) -> Result<Vec<u8>, SynoFsError> {
+        let block_size = self.read_cache.block_size;
+        let first_block = offset / block_size;
+        let last_block = (offset + size - 1) / block_size;
+
+        let mut result: Vec<u8> = Vec::with_capacity(size as usize);
+
+        for block_idx in first_block..=last_block {
+            let block_start = block_idx * block_size;
+
+            let block = if let Some(cached) = self.read_cache.get(ino, block_idx) {
+                if cached.is_empty() {
+                    debug!("read: EOF sentinel hit ino={} block={}", ino, block_idx);
+                    break;
+                }
+                cached
+            } else if self.read_cache.claim_inflight(ino, block_idx) {
+                // We won the race — download synchronously.
+                debug!("read cache miss: ino={} block={}", ino, block_idx);
+                match self.block(self.client.download(path, block_start, block_size)) {
+                    Ok(b) if !b.is_empty() => {
+                        self.read_cache.insert(ino, block_idx, b.clone());
+                        b
+                    }
+                    Ok(empty) => {
+                        // EOF — cache empty sentinel so any waiters know too.
+                        self.read_cache.insert(ino, block_idx, empty);
+                        break;
+                    }
+                    Err(e) => {
+                        self.read_cache.cancel_inflight(ino, block_idx);
+                        error!("read {}: {}", path, e);
+                        return Err(e);
+                    }
+                }
+            } else {
+                // Another task is downloading this block — wait for it.
+                debug!("read waiting for inflight: ino={} block={}", ino, block_idx);
+                match self.read_cache.wait_for_block(ino, block_idx) {
+                    Some(b) if b.is_empty() => break, // EOF sentinel
+                    Some(b) => b,
+                    // Other task had a real network error.
+                    None => return Err(SynoFsError::Io("block download failed".into())),
+                }
+            };
+
+            // Slice the portion of this block that overlaps [offset, offset+size)
+            let local_start = offset.saturating_sub(block_start) as usize;
+            let local_end = (offset + size)
+                .saturating_sub(block_start)
+                .min(block_size)
+                .min(block.len() as u64) as usize;
+
+            if local_start < local_end {
+                result.extend_from_slice(&block[local_start..local_end]);
+            }
+
+            // A block shorter than the block size is the last one with data:
+            // the server had nothing beyond it to give. Stop here. Continuing
+            // would append the *next* block's bytes directly behind this one,
+            // handing the caller a buffer whose tail comes from a different file
+            // offset than it claims — silent corruption rather than a short read.
+            if (block.len() as u64) < block_size {
+                debug!(
+                    "read: short block ino={} idx={} len={} < {}; stopping",
+                    ino,
+                    block_idx,
+                    block.len(),
+                    block_size
+                );
+                break;
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Resize `path` to `new_size`, zero-extending or truncating.
+    ///
+    /// FileStation has no truncate call, so this is read-modify-write. Split out
+    /// of `setattr` so the failure behaviour is testable: a download that fails
+    /// must abort the whole operation, because the alternative — treating an
+    /// unreadable file as an empty one — uploads `new_size` zero bytes over
+    /// perfectly good data.
+    fn truncate_file(
+        &self,
+        ino: u64,
+        path: &str,
+        new_size: u64,
+    ) -> Result<SynoFileInfo, SynoFsError> {
+        // Shrinking to nothing needs no prior content, and this is the common
+        // case (O_TRUNC, `> file`). Skip the round trip entirely rather than
+        // downloading a file we are about to discard.
+        let data = if new_size == 0 {
+            Vec::new()
+        } else {
+            let current = self.block(self.client.download(path, 0, 0))?;
+            let mut data = current.to_vec();
+            data.resize(new_size as usize, 0);
+            data
+        };
+
+        let (parent, filename) = match split_nas_path(path) {
+            Some(v) => v,
+            None => return Err(SynoFsError::InvalidArg),
+        };
+        self.block(self.client.upload(parent, filename, data, true))?;
+
+        self.read_cache.invalidate_ino(ino);
+        self.cache.invalidate_path(path);
+        self.block(self.client.get_info(path))
+    }
+
+    /// Move a file between directories: download, upload to the new location,
+    /// then delete the source. FileStation's Rename API cannot move across
+    /// directories, so this is the only route.
+    ///
+    /// Split out of `rename` so the download sizing is testable — it must ask
+    /// for the *whole* file rather than a length taken from cached metadata.
+    fn move_across_dirs(
+        &self,
+        old_path: &str,
+        new_parent: &str,
+        new_name: &str,
+    ) -> Result<(), SynoFsError> {
+        // `length = 0` means "the whole file". Sizing this request from the
+        // inode cache instead would silently truncate the file whenever that
+        // cached size is stale-low — and this path deletes the source
+        // afterwards, so the missing bytes are simply gone.
+        let data = self.block(self.client.download(old_path, 0, 0))?;
+
+        self.block(
+            self.client
+                .upload(new_parent, new_name, data.to_vec(), true),
+        )?;
+
+        // Only the source deletion is best-effort: the copy is already safe on
+        // the NAS, so a failure here leaves a duplicate rather than losing data.
+        if let Err(e) = self.block(self.client.delete(old_path)) {
+            warn!(
+                "rename: uploaded {}/{} but failed to delete {}: {}",
+                new_parent, new_name, old_path, e
+            );
+        }
         Ok(())
     }
 
@@ -532,70 +645,25 @@ impl Filesystem for SynologyFS {
 
         let size = size as u64;
         let block_size = self.read_cache.block_size;
-        let first_block = offset / block_size;
         let last_block = (offset + size - 1) / block_size;
 
         debug!(
             "read: ino={} path={} offset={} size={} blocks=[{}..={}]",
-            ino, path, offset, size, first_block, last_block
+            ino,
+            path,
+            offset,
+            size,
+            offset / block_size,
+            last_block
         );
 
-        let mut result: Vec<u8> = Vec::with_capacity(size as usize);
-
-        for block_idx in first_block..=last_block {
-            let block_start = block_idx * block_size;
-
-            let block = if let Some(cached) = self.read_cache.get(ino, block_idx) {
-                if cached.is_empty() {
-                    debug!("read: EOF sentinel hit ino={} block={}", ino, block_idx);
-                    break;
-                }
-                cached
-            } else if self.read_cache.claim_inflight(ino, block_idx) {
-                // We won the race — download synchronously.
-                debug!("read cache miss: ino={} block={}", ino, block_idx);
-                match self.block(self.client.download(&path, block_start, block_size)) {
-                    Ok(b) if !b.is_empty() => {
-                        self.read_cache.insert(ino, block_idx, b.clone());
-                        b
-                    }
-                    Ok(empty) => {
-                        // EOF — cache empty sentinel so any waiters know too.
-                        self.read_cache.insert(ino, block_idx, empty);
-                        break;
-                    }
-                    Err(e) => {
-                        self.read_cache.cancel_inflight(ino, block_idx);
-                        error!("read {}: {}", path, e);
-                        reply.error(errno(e.to_errno()));
-                        return;
-                    }
-                }
-            } else {
-                // Another task is downloading this block — wait for it.
-                debug!("read waiting for inflight: ino={} block={}", ino, block_idx);
-                match self.read_cache.wait_for_block(ino, block_idx) {
-                    Some(b) if b.is_empty() => break, // EOF sentinel
-                    Some(b) => b,
-                    None => {
-                        // Other task had a real network error.
-                        reply.error(Errno::EIO);
-                        return;
-                    }
-                }
-            };
-
-            // Slice the portion of this block that overlaps [offset, offset+size)
-            let local_start = offset.saturating_sub(block_start) as usize;
-            let local_end = (offset + size)
-                .saturating_sub(block_start)
-                .min(block_size)
-                .min(block.len() as u64) as usize;
-
-            if local_start < local_end {
-                result.extend_from_slice(&block[local_start..local_end]);
+        let result = match self.read_range(ino, &path, offset, size) {
+            Ok(r) => r,
+            Err(e) => {
+                reply.error(errno(e.to_errno()));
+                return;
             }
-        }
+        };
 
         // Background prefetch of the next 16 blocks to keep VLC's read-ahead buffer full.
         for prefetch_idx in (last_block + 1)..=(last_block + 16) {
@@ -711,7 +779,6 @@ impl Filesystem for SynologyFS {
                 data: SpillBuffer::new(),
                 dirty: false,
                 new_file: false,
-                upload_handle: None,
             },
         );
         // FOPEN_KEEP_CACHE: don't invalidate the kernel page cache between opens.
@@ -740,28 +807,9 @@ impl Filesystem for SynologyFS {
             data.len()
         );
 
-        // If a background upload is in flight for this fh (started by a prior flush),
-        // wait for it before modifying the buffer — we must not hold the mutex while blocking.
-        let handle = {
-            let mut buffers = self.write_buffers.lock().unwrap();
-            buffers.get_mut(&fh).and_then(|b| b.upload_handle.take())
-        };
-        if let Some(h) = handle {
-            if let Err(e) = self
-                .block(h)
-                .map_err(|_| SynoFsError::Io("upload task panicked".into()))
-                .and_then(|r| r)
-            {
-                error!("write: prior upload failed: {}", e);
-                reply.error(errno(e.to_errno()));
-                return;
-            }
-            // The file now exists on the NAS; clear new_file so the next upload uses overwrite=true.
-            if let Some(buf) = self.write_buffers.lock().unwrap().get_mut(&fh) {
-                buf.new_file = false;
-            }
-        }
-
+        // No background upload can be in flight: flush() uploads synchronously,
+        // so by the time a write is dispatched any earlier flush has completed
+        // and already cleared `new_file`.
         let mut buffers = self.write_buffers.lock().unwrap();
         let buf = match buffers.get_mut(&fh) {
             Some(b) => b,
@@ -796,9 +844,17 @@ impl Filesystem for SynologyFS {
     ) {
         let fh = fh.0;
         debug!("flush: fh={}", fh);
-        // Kick off the upload in the background; release() will wait for completion.
-        self.queue_upload(fh);
-        reply.ok();
+        // The kernel returns *this* reply from close(2), and discards whatever
+        // release() reports. So the upload has to happen here, synchronously,
+        // and its error has to come back here — otherwise a failed upload is
+        // reported to the application as a successful close.
+        match self.finish_upload(fh) {
+            Ok(()) => reply.ok(),
+            Err(e) => {
+                error!("flush fh={}: {}", fh, e);
+                reply.error(errno(e.to_errno()));
+            }
+        }
     }
 
     fn release(
@@ -877,7 +933,6 @@ impl Filesystem for SynologyFS {
                 data: SpillBuffer::new(),
                 dirty: false,
                 new_file: true,
-                upload_handle: None,
             },
         );
 
@@ -1080,45 +1135,17 @@ impl Filesystem for SynologyFS {
             return;
         }
 
-        // Cross-directory file move: download, upload, delete
-        // Get the file size first
-        let file_size = self
-            .cache
-            .get_by_ino(self.cache.get_or_alloc_ino(&old_path))
-            .and_then(|e| e.info.additional.as_ref()?.size)
-            .unwrap_or(0);
-
-        let data = match self.block(self.client.download(&old_path, 0, file_size)) {
-            Ok(b) => b,
-            Err(e) => {
-                reply.error(errno(e.to_errno()));
-                return;
+        // Cross-directory file move: download, upload, delete.
+        match self.move_across_dirs(&old_path, &new_parent_path, new_name_str) {
+            Ok(()) => {
+                self.cache.invalidate_path(&old_path);
+                reply.ok();
             }
-        };
-
-        match self.block(
-            self.client
-                .upload(&new_parent_path, new_name_str, data.to_vec(), true),
-        ) {
-            Ok(()) => {}
             Err(e) => {
+                error!("rename {} -> {}: {}", old_path, new_path, e);
                 reply.error(errno(e.to_errno()));
-                return;
             }
         }
-
-        match self.block(self.client.delete(&old_path)) {
-            Ok(()) => {}
-            Err(e) => {
-                warn!(
-                    "rename: uploaded {} but failed to delete {}: {}",
-                    new_path, old_path, e
-                );
-            }
-        }
-
-        self.cache.invalidate_path(&old_path);
-        reply.ok();
     }
 
     fn setattr(
@@ -1154,35 +1181,16 @@ impl Filesystem for SynologyFS {
                 ino, path, new_size
             );
 
-            let new_size = new_size as usize;
-
-            // Download current content
-            let current = match self.block(self.client.download(&path, 0, 0)) {
-                Ok(b) => b.to_vec(),
-                Err(_) => Vec::new(),
-            };
-
-            let mut data = current;
-            data.resize(new_size, 0);
-
-            let parent = path.rfind('/').map(|i| &path[..i]).unwrap_or("/");
-            let filename = &path[path.rfind('/').unwrap_or(0) + 1..];
-
-            match self.block(self.client.upload(parent, filename, data, true)) {
-                Ok(()) => {
-                    self.read_cache.invalidate_ino(ino);
-                    self.cache.invalidate_path(&path);
-                    // Re-fetch attr
-                    match self.block(self.client.get_info(&path)) {
-                        Ok(info) => {
-                            let attr = self.syno_to_attr(ino, &info);
-                            self.cache.insert(ino, info);
-                            reply.attr(&TTL, &attr);
-                        }
-                        Err(e) => reply.error(errno(e.to_errno())),
-                    }
+            match self.truncate_file(ino, &path, new_size) {
+                Ok(info) => {
+                    let attr = self.syno_to_attr(ino, &info);
+                    self.cache.insert(ino, info);
+                    reply.attr(&TTL, &attr);
                 }
-                Err(e) => reply.error(errno(e.to_errno())),
+                Err(e) => {
+                    error!("setattr truncate {}: {}", path, e);
+                    reply.error(errno(e.to_errno()));
+                }
             }
         } else {
             // For other attribute changes (permissions, timestamps), return current attrs
@@ -1209,5 +1217,444 @@ impl Filesystem for SynologyFS {
             255,             // namelen
             4096,            // frsize
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap as Map;
+    use synology_filestation_core::types::SynoAdditional;
+    use wiremock::matchers::{method as http_method, path as http_path, query_param};
+    use wiremock::{Mock, MockServer, Request as WmRequest, Respond, ResponseTemplate};
+
+    /// Small blocks keep the fixtures readable; the assembly rules under test
+    /// don't depend on the real 256 KiB size.
+    const BLOCK: u64 = 1024;
+
+    fn client_for(server: &MockServer) -> SynologyClient {
+        let uri = server.uri();
+        let (host, port) = uri
+            .trim_start_matches("http://")
+            .rsplit_once(':')
+            .expect("mock server uri has a port");
+        SynologyClient::new(host, port.parse().unwrap(), false)
+    }
+
+    /// Field order matters: `rt` is declared last so it is dropped last, after
+    /// the mock server has had a runtime to shut itself down on.
+    struct Fixture {
+        fs: SynologyFS,
+        server: MockServer,
+        rt: tokio::runtime::Runtime,
+    }
+
+    fn fixture() -> Fixture {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let server = rt.block_on(MockServer::start());
+        let fs = SynologyFS::new(
+            Arc::new(client_for(&server)),
+            Arc::new(InodeCache::new(30)),
+            Arc::new(ReadCache::new(BLOCK, 64)),
+            rt.handle().clone(),
+            1000,
+            1000,
+        );
+        Fixture { fs, server, rt }
+    }
+
+    /// Serves file bytes the way DSM's Download API does: honours `Range`, and
+    /// answers 416 past EOF. `short` caps how many bytes a given range *start*
+    /// may return, which is how a test reproduces a truncated response — a
+    /// successful HTTP 200 carrying fewer bytes than the range asked for.
+    struct RangeFile {
+        body: Vec<u8>,
+        short: Map<u64, usize>,
+    }
+
+    impl Respond for RangeFile {
+        fn respond(&self, req: &WmRequest) -> ResponseTemplate {
+            if self.body.is_empty() {
+                return ResponseTemplate::new(200).set_body_bytes(Vec::new());
+            }
+            let (start, end) = match req.headers.get("range").and_then(|v| v.to_str().ok()) {
+                Some(r) => {
+                    let (s, e) = r
+                        .trim_start_matches("bytes=")
+                        .split_once('-')
+                        .expect("range header is bytes=S-E");
+                    (
+                        s.parse::<u64>().unwrap(),
+                        e.parse::<u64>().unwrap_or(u64::MAX),
+                    )
+                }
+                None => (0, self.body.len() as u64 - 1),
+            };
+            if start as usize >= self.body.len() {
+                return ResponseTemplate::new(416);
+            }
+            let end = (end as usize).min(self.body.len() - 1);
+            let mut slice = self.body[start as usize..=end].to_vec();
+            if let Some(&cap) = self.short.get(&start) {
+                slice.truncate(cap);
+            }
+            ResponseTemplate::new(206).set_body_bytes(slice)
+        }
+    }
+
+    fn mount_download(f: &Fixture, body: Vec<u8>, short: Map<u64, usize>) {
+        f.rt.block_on(
+            Mock::given(http_method("GET"))
+                .and(http_path("/webapi/entry.cgi"))
+                .and(query_param("method", "download"))
+                .respond_with(RangeFile { body, short })
+                .mount(&f.server),
+        );
+    }
+
+    fn mount_upload_ok(f: &Fixture) {
+        f.rt.block_on(
+            Mock::given(http_method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(
+                        serde_json::json!({"success": true, "data": {"blks": null}}),
+                    ),
+                )
+                .mount(&f.server),
+        );
+    }
+
+    fn mount_delete_ok(f: &Fixture) {
+        f.rt.block_on(
+            Mock::given(http_method("GET"))
+                .and(query_param("method", "delete"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({"success": true})),
+                )
+                .mount(&f.server),
+        );
+    }
+
+    /// `clear_for_overwrite` polls getinfo until the file is gone; answering
+    /// "no such file" lets the upload proceed on the first poll.
+    fn mount_getinfo_gone(f: &Fixture) {
+        f.rt.block_on(
+            Mock::given(http_method("GET"))
+                .and(query_param("method", "getinfo"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(
+                        serde_json::json!({"success": false, "error": {"code": 414}}),
+                    ),
+                )
+                .mount(&f.server),
+        );
+    }
+
+    fn ramp(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    fn posted_bodies(f: &Fixture) -> Vec<Vec<u8>> {
+        f.rt.block_on(f.server.received_requests())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|r| r.method.as_str() == "POST")
+            .map(|r| r.body)
+            .collect()
+    }
+
+    fn seed_dirty_buffer(f: &Fixture, nas_path: &str, data: &[u8]) -> u64 {
+        let ino = f.fs.cache.get_or_alloc_ino(nas_path);
+        let mut buf = SpillBuffer::new();
+        buf.write_at(0, data).unwrap();
+        let fh = 1u64;
+        f.fs.write_buffers.lock().unwrap().insert(
+            fh,
+            WriteBuffer {
+                nas_path: nas_path.to_string(),
+                ino,
+                data: buf,
+                dirty: true,
+                new_file: true,
+            },
+        );
+        fh
+    }
+
+    // ── T1.4: block assembly ──────────────────────────────────────────────────
+
+    /// Regression: the assembly loop only stopped on a *fully empty* block, so a
+    /// block that came back short was appended and then the next block's bytes
+    /// were appended directly behind it. The caller received a contiguous-looking
+    /// buffer whose tail actually came from a different file offset — silent
+    /// corruption. A short block must end the read.
+    #[test]
+    fn a_short_block_ends_the_read_instead_of_fabricating_contiguity() {
+        let f = fixture();
+        let body = ramp(4096);
+        // Block 0 is truncated to 300 bytes. This is *not* EOF: the file really
+        // is 4096 bytes, and block 1 would happily serve its full 1024.
+        mount_download(&f, body.clone(), Map::from([(0u64, 300usize)]));
+
+        let out = f.fs.read_range(7, "/share/f.bin", 0, 2 * BLOCK).unwrap();
+
+        assert_eq!(
+            out.as_slice(),
+            &body[..300],
+            "a short block must end the read, not be back-filled with block 1's bytes"
+        );
+    }
+
+    /// The stop-on-short rule must not break the ordinary case it resembles:
+    /// a final partial block at genuine EOF still contributes its bytes.
+    #[test]
+    fn a_genuinely_short_final_block_still_returns_the_whole_tail() {
+        let f = fixture();
+        let body = ramp(1500); // one full block + a 476-byte tail
+        mount_download(&f, body.clone(), Map::new());
+
+        let out = f.fs.read_range(8, "/share/f.bin", 0, 4 * BLOCK).unwrap();
+
+        assert_eq!(out, body, "the short tail block is EOF, not corruption");
+    }
+
+    /// Reads that start part-way into a block must still line up.
+    #[test]
+    fn a_mid_block_offset_read_returns_the_right_slice() {
+        let f = fixture();
+        let body = ramp(4096);
+        mount_download(&f, body.clone(), Map::new());
+
+        let out = f.fs.read_range(11, "/share/f.bin", 1500, 1000).unwrap();
+
+        assert_eq!(out.as_slice(), &body[1500..2500]);
+    }
+
+    // ── T1.2: truncate ────────────────────────────────────────────────────────
+
+    /// Regression: a failed download was mapped to `Vec::new()`, so truncate
+    /// then uploaded `new_size` zero bytes over a perfectly good file. One read
+    /// timeout during `truncate -s N` destroyed the contents. It must abort.
+    #[test]
+    fn truncate_aborts_rather_than_zeroing_the_file_when_the_download_fails() {
+        let f = fixture();
+        f.rt.block_on(
+            Mock::given(http_method("GET"))
+                .and(query_param("method", "download"))
+                .respond_with(ResponseTemplate::new(500))
+                .mount(&f.server),
+        );
+        // If truncate ever reaches the upload after a failed read, this catches it.
+        f.rt.block_on(
+            Mock::given(http_method("POST"))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(
+                        serde_json::json!({"success": true, "data": {"blks": null}}),
+                    ),
+                )
+                .expect(0)
+                .mount(&f.server),
+        );
+
+        let err =
+            f.fs.truncate_file(9, "/share/big.bin", 100)
+                .expect_err("an unreadable file must not be silently replaced with zeros");
+        assert!(matches!(err, SynoFsError::Io(_)), "got {err:?}");
+        // The `expect(0)` on the upload mock is asserted when the server drops.
+    }
+
+    /// Truncating to zero needs no prior content, and it is the common case
+    /// (`O_TRUNC`, `> file`). Downloading a file we are about to discard is pure
+    /// waste — and on a large file it is the whole file, in memory.
+    #[test]
+    fn truncate_to_zero_does_not_download_the_file_first() {
+        let f = fixture();
+        f.rt.block_on(
+            Mock::given(http_method("GET"))
+                .and(query_param("method", "download"))
+                .respond_with(ResponseTemplate::new(200))
+                .expect(0)
+                .mount(&f.server),
+        );
+        mount_delete_ok(&f);
+        mount_getinfo_gone(&f);
+        mount_upload_ok(&f);
+
+        // The trailing get_info re-read fails against these mocks (getinfo is
+        // wired to "gone" for the overwrite poll), which is irrelevant here: the
+        // assertion is the `expect(0)` on the download mock.
+        let _ = f.fs.truncate_file(10, "/share/f.bin", 0);
+    }
+
+    /// Truncation still has to do its actual job.
+    #[test]
+    fn truncate_uploads_the_resized_content() {
+        let f = fixture();
+        let body = ramp(4096);
+        mount_download(&f, body.clone(), Map::new());
+        mount_delete_ok(&f);
+        mount_getinfo_gone(&f);
+        mount_upload_ok(&f);
+
+        let _ = f.fs.truncate_file(12, "/share/f.bin", 100);
+
+        let posted = posted_bodies(&f);
+        assert_eq!(posted.len(), 1, "exactly one upload");
+        assert!(
+            posted[0].windows(100).any(|w| w == &body[..100]),
+            "the upload must carry the first 100 bytes of the original file"
+        );
+    }
+
+    // ── T1.3: cross-directory move ────────────────────────────────────────────
+
+    /// Regression: the move sized its download from the inode cache, then
+    /// deleted the source. A stale-low cached size therefore truncated the file
+    /// permanently. The download must ask for the whole file.
+    #[test]
+    fn cross_directory_move_copies_the_whole_file_not_the_cached_size() {
+        let f = fixture();
+        let body = ramp(4096);
+        mount_download(&f, body.clone(), Map::new());
+        mount_delete_ok(&f);
+        mount_getinfo_gone(&f);
+        mount_upload_ok(&f);
+
+        // Stale metadata claiming the file is 10 bytes long.
+        let ino = f.fs.cache.get_or_alloc_ino("/a/f.bin");
+        f.fs.cache.insert(
+            ino,
+            SynoFileInfo {
+                name: "f.bin".into(),
+                path: "/a/f.bin".into(),
+                isdir: false,
+                additional: Some(SynoAdditional {
+                    size: Some(10),
+                    owner: None,
+                    time: None,
+                    perm: None,
+                }),
+                code: None,
+            },
+        );
+
+        f.fs.move_across_dirs("/a/f.bin", "/b", "f.bin").unwrap();
+
+        let posted = posted_bodies(&f);
+        assert_eq!(posted.len(), 1, "exactly one upload");
+        assert!(
+            posted[0].windows(body.len()).any(|w| w == body.as_slice()),
+            "the moved file must carry all {} bytes, not the {} the cache claimed",
+            body.len(),
+            10
+        );
+    }
+
+    // ── T1.1: flush ───────────────────────────────────────────────────────────
+
+    /// Regression: `flush` spawned the upload and replied OK immediately, and
+    /// the kernel discards whatever `release` later reports — so a failed upload
+    /// reached the application as a successful `close(2)`. The call `flush`
+    /// delegates to must surface the failure.
+    #[test]
+    fn flush_reports_an_upload_failure_instead_of_swallowing_it() {
+        let f = fixture();
+        f.rt.block_on(
+            Mock::given(http_method("POST"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&f.server),
+        );
+
+        let fh = seed_dirty_buffer(&f, "/share/new.txt", b"payload");
+        let err =
+            f.fs.finish_upload(fh)
+                .expect_err("a failed upload must not look like a successful close");
+        assert!(matches!(err, SynoFsError::Io(_)), "got {err:?}");
+    }
+
+    /// `flush` must not return until the bytes are actually on the NAS — a
+    /// merely-queued upload is one whose failure nobody can report.
+    #[test]
+    fn flush_completes_the_upload_before_returning() {
+        let f = fixture();
+        mount_upload_ok(&f);
+
+        let fh = seed_dirty_buffer(&f, "/share/new.txt", b"payload");
+        f.fs.finish_upload(fh).unwrap();
+
+        assert_eq!(
+            posted_bodies(&f).len(),
+            1,
+            "the upload must have completed by the time flush returns, not merely been queued"
+        );
+    }
+
+    /// A failed flush must leave the data buffered so `release` can retry it.
+    /// Previously `dirty` was cleared *before* the upload was even started, so a
+    /// failure silently discarded the write.
+    #[test]
+    fn a_failed_flush_keeps_the_data_pending_for_a_retry() {
+        let f = fixture();
+        f.rt.block_on(
+            Mock::given(http_method("POST"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&f.server),
+        );
+
+        let fh = seed_dirty_buffer(&f, "/share/new.txt", b"payload");
+        assert!(f.fs.finish_upload(fh).is_err());
+
+        assert!(
+            f.fs.write_buffers.lock().unwrap().get(&fh).unwrap().dirty,
+            "a failed upload must leave the buffer dirty so release() retries it"
+        );
+    }
+
+    /// A successful flush clears `new_file`, so a second flush of the same
+    /// handle overwrites rather than racing an `overwrite=false` create against
+    /// the file it just created.
+    #[test]
+    fn a_successful_flush_marks_the_file_as_existing() {
+        let f = fixture();
+        mount_upload_ok(&f);
+
+        let fh = seed_dirty_buffer(&f, "/share/new.txt", b"payload");
+        f.fs.finish_upload(fh).unwrap();
+
+        let buffers = f.fs.write_buffers.lock().unwrap();
+        let buf = buffers.get(&fh).unwrap();
+        assert!(!buf.dirty, "a successful upload clears dirty");
+        assert!(!buf.new_file, "the file now exists on the NAS");
+    }
+
+    #[test]
+    fn flush_of_a_clean_buffer_is_a_no_op() {
+        let f = fixture();
+        f.rt.block_on(
+            Mock::given(http_method("POST"))
+                .respond_with(ResponseTemplate::new(500))
+                .expect(0)
+                .mount(&f.server),
+        );
+
+        let fh = seed_dirty_buffer(&f, "/share/new.txt", b"payload");
+        f.fs.write_buffers
+            .lock()
+            .unwrap()
+            .get_mut(&fh)
+            .unwrap()
+            .dirty = false;
+
+        f.fs.finish_upload(fh).unwrap();
+    }
+
+    #[test]
+    fn split_nas_path_splits_on_the_last_separator() {
+        assert_eq!(
+            split_nas_path("/share/dir/f.txt"),
+            Some(("/share/dir", "f.txt"))
+        );
+        assert_eq!(split_nas_path("/f.txt"), Some(("", "f.txt")));
+        assert_eq!(split_nas_path("f.txt"), None);
     }
 }


### PR DESCRIPTION
Stacked on #151 — the upload-retry fix touches `clear_for_overwrite`, which only exists on that branch. Review after #151 merges, or review the three commits directly.

These came out of a code review of the driver. Every item here either loses data, corrupts data, or reports success for an operation that failed. Each fix has a regression test.

## What was wrong

| | Defect | Symptom |
|---|---|---|
| 1 | `flush()` replied OK before the upload ran; the error surfaced only from `release()`, which the kernel discards | `cp bigfile /mnt/nas/` exits 0 with the upload failed |
| 2 | `truncate` mapped a failed download to `Vec::new()`, then uploaded `new_size` zero bytes | one read timeout during `truncate -s N` destroys the file |
| 3 | cross-directory move sized its download from the inode cache, then deleted the source | stale-low cached size permanently truncates the moved file |
| 4 | read assembly only stopped on a *fully empty* block | a short block is back-filled with the next block's bytes — a contiguous-looking buffer whose tail is from a different file offset |
| 5 | listings were one request, hardcoded limit, `offset=0`, `total` never read | a directory over 5000 entries (shares over 500) is silently listed short — files that "don't exist" |
| 6 | `clear_for_overwrite` ran once, *before* the retry loop | attempt 1 lands but its response is lost → attempt 2 gets DSM 418 → a write that succeeded is reported as `AlreadyExists` |
| 7 | `wait_for_block` looped with no deadline | a prefetch task that dies without releasing its claim strands every waiter forever — and those are FUSE worker threads, so the mount stops answering |

## Notes for review

- **#1 also converges the backends.** WinFsp already returned the upload error from `flush` and retried from `close`; Linux did neither. `dirty` is now cleared only *after* a successful upload, so a failed flush leaves the data buffered for `release` to retry. `queue_upload` and the background-upload handle are deleted.
- **#6 pulled in a small consistency fix.** `http_upload` now classifies HTTP status the way `http_download` already did (502/503/504/407 retry, everything else fails fast). It previously fed non-2xx bodies to the JSON parser, so a 400 surfaced as `upload parse error: EOF while parsing a value`. Retrying an upload is only safe *because* each attempt now re-clears.
- **#5 keeps single-page listings at one request** — no speculative second round trip. A 10,000-page cap logs rather than truncating quietly.
- The four `fs.rs` behaviours are extracted into `read_range`, `truncate_file` and `move_across_dirs` so they're testable without a live mount.

## Testing

141 → 163 tests. `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, `cargo fmt` clean.

New tests drive a Range-honouring mock NAS that can serve a deliberately truncated response. All four `fs.rs` fixes were verified to go red when reverted — the corruption test's failure output shows the byte ramp restarting mid-buffer, and the truncate test's request log shows the DELETE+UPLOAD proceeding after a `500`.

Two caveats on rigour, stated plainly: #7's test was not observed red (the old loop had no exit condition, so it would hang rather than fail), and the flush-specific tests were not run against the old code — `a_failed_flush_keeps_the_data_pending_for_a_retry` would have failed it, but I didn't produce that run.

## Not included

Tier 2 (TLS verification disabled unconditionally, password in the URL query string, world-readable spill temp files) follows as a separate PR stacked on this one. Tier 3 is structural cleanup — duplication, unbounded caches, unbounded prefetch fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)