### PR TITLE
fix: stop leaking the session id and passwords into logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ synology-filestation-fuse --host <NAS_HOST> -u <USERNAME> [OPTIONS] <MOUNTPOINT>
 | `--otp <CODE>` | TOTP code for 2FA (or `SYNO_OTP` env var); prompted interactively if omitted and 2FA is enabled | *(optional)* |
 | `--port <PORT>` | API port | `5001` |
 | `--https` | Use HTTPS | `true` |
+| `--password-stdin` | Read the password from the first line of stdin. Prefer this in scripts: `--password` puts the password in argv, where any local account can read it with `ps`. | `false` |
 | `--insecure` | Accept any TLS certificate (self-signed, expired, wrong hostname). Needed for a stock DSM certificate; the connection is then encrypted but **not** authenticated. Env: `SYNO_INSECURE` | `false` |
 | `--cache-ttl <SECS>` | Metadata cache TTL in seconds *(Linux only)* | `30` |
 | `--read-cache-mb <MiB>` | Read cache size in MiB *(Linux only)* | `256` |

--- a/python/synology_filestation/tests/test_fsspec.py
+++ b/python/synology_filestation/tests/test_fsspec.py
@@ -250,6 +250,15 @@ class TestSyncGetPut:
         # fsspec's high-level `get` calls `_isdir(rpath)` (which calls
         # `info()` → DSM getinfo) before dispatching to `_get_file`. So
         # two server roundtrips: getinfo first, then download.
+        #
+        # Login also settles how the session id travels (cookie vs `_sid`) with
+        # one probe call to list_share, and that lands on entry.cgi before
+        # either of them. Oneshot handlers are consumed in registration order,
+        # so the probe response has to be registered first or it would eat the
+        # getinfo response below.
+        httpserver.expect_oneshot_request("/webapi/entry.cgi").respond_with_json(
+            {"success": True, "data": {"total": 0, "shares": []}}
+        )
         httpserver.expect_oneshot_request("/webapi/entry.cgi").respond_with_json(
             {
                 "success": True,

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -28,11 +28,23 @@ const SID_NOT_FOUND: u32 = 119;
 /// intentionally not stored: TOTP values are single-use, so re-login after
 /// session expiry would always fail for 2FA-enabled accounts. Auto-relogin is
 /// therefore only meaningful for accounts without 2FA.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[allow(dead_code)]
 struct StoredCreds {
     user: String,
     password: String,
+}
+
+/// Hand-written so the stashed password cannot reach a log through a stray
+/// `{:?}`. A derived Debug would print it in full, and this struct exists
+/// precisely to hold a password for the lifetime of the session.
+impl std::fmt::Debug for StoredCreds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StoredCreds")
+            .field("user", &self.user)
+            .field("password", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Tuning for the request throttle that protects the DSM appliance's shared
@@ -87,6 +99,19 @@ impl Default for ThrottleConfig {
     }
 }
 
+/// How the session id is carried on an authenticated request.
+///
+/// DSM accepts it either as a `_sid` query parameter or as an `id` cookie. They
+/// are equivalent to the server and very different everywhere else: a query
+/// parameter is written verbatim into the NAS's own nginx access log, into any
+/// proxy's log in between, and into the `Display` of every `reqwest` transport
+/// error — which this client then logs, returns across the FFI, and raises as a
+/// Python exception. A cookie appears in none of those.
+///
+/// So the cookie is preferred, and the query parameter is the fallback for a
+/// DSM that will not take it.
+const SESSION_AUTH_COOKIE: u8 = 0;
+const SESSION_AUTH_QUERY: u8 = 1;
 #[derive(Debug)]
 struct Throttle {
     sem: Semaphore,
@@ -216,6 +241,9 @@ pub struct SynologyClient {
     /// `reqwest::Client` (which does not expose its own settings) so consumers
     /// can tell the user which mode they are connecting in.
     insecure_tls: bool,
+    /// Whether the session id travels as a cookie or as a `_sid` query
+    /// parameter. Settled by a probe immediately after login.
+    session_auth: std::sync::atomic::AtomicU8,
     /// Injected read backends, tried in order before the HTTP Download API.
     /// Empty (the default) = HTTP only, i.e. exactly today's behavior.
     read_transports: Vec<TransportEntry<dyn ReadTransport>>,
@@ -278,6 +306,7 @@ impl SynologyClient {
             creds: RwLock::new(None),
             throttle: None,
             insecure_tls: false,
+            session_auth: std::sync::atomic::AtomicU8::new(SESSION_AUTH_COOKIE),
             read_transports: Vec::new(),
             write_transports: Vec::new(),
             stream_write_transports: Vec::new(),
@@ -480,6 +509,83 @@ impl SynologyClient {
         c
     }
 
+    /// Attach the session id to a request in whichever way this DSM accepts.
+    ///
+    /// Every authenticated call goes through here rather than pushing `_sid`
+    /// into its own parameter list, so there is one place that decides how the
+    /// token travels — and one place to audit.
+    fn attach_session(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let sid = self.sid();
+        if sid.is_empty() {
+            return req;
+        }
+        if self.session_auth.load(std::sync::atomic::Ordering::Relaxed) == SESSION_AUTH_COOKIE {
+            req.header(reqwest::header::COOKIE, format!("id={sid}"))
+        } else {
+            req.query(&[("_sid", sid.as_str())])
+        }
+    }
+
+    /// Settle how the session id travels, once, straight after login.
+    ///
+    /// The cookie is a claim about somebody else's server, so it is checked
+    /// rather than assumed: one cheap authenticated request in cookie mode, and
+    /// if DSM answers 119 the client spends the rest of the session on the query
+    /// parameter it used to use.
+    ///
+    /// Running this at login is the whole point of the design. A 119 is
+    /// ambiguous in general — "the cookie was refused" and "the session expired"
+    /// are the same code — but a session issued moments ago has not expired, so
+    /// here the answer is unambiguous. Deciding it from the first ordinary call
+    /// instead would misread an expired session as a rejected cookie and quietly
+    /// start putting the id back into URLs.
+    ///
+    /// Only a definitive 119 triggers the fallback. A transport failure says
+    /// nothing about whether the cookie is accepted — the network is simply
+    /// down, and the next real call reports that on its own.
+    async fn probe_session_transport(&self) {
+        use std::sync::atomic::Ordering;
+
+        self.session_auth
+            .store(SESSION_AUTH_COOKIE, Ordering::Relaxed);
+
+        let url = format!("{}/entry.cgi", self.base_url);
+        let req = self.attach_session(self.http.get(&url).query(&[
+            ("api", "SYNO.FileStation.List"),
+            ("version", "2"),
+            ("method", "list_share"),
+            ("limit", "1"),
+            ("offset", "0"),
+        ]));
+
+        let rejected = match req.send().await {
+            Ok(resp) => match resp.text().await {
+                Ok(body) => serde_json::from_str::<SynoResponse<serde_json::Value>>(&body)
+                    .ok()
+                    .filter(|envelope| !envelope.success)
+                    .and_then(|envelope| envelope.error)
+                    .is_some_and(|e| e.code == SID_NOT_FOUND),
+                Err(_) => false,
+            },
+            Err(_) => false,
+        };
+
+        if rejected {
+            warn!(
+                "this DSM did not accept the session cookie; falling back to the _sid \
+                 query parameter. The session id will appear in the NAS's access log."
+            );
+            self.session_auth
+                .store(SESSION_AUTH_QUERY, Ordering::Relaxed);
+        } else {
+            debug!("session id will travel as a cookie");
+        }
+    }
+
+    /// True when the session id is being kept out of request URLs.
+    pub fn session_in_cookie(&self) -> bool {
+        self.session_auth.load(std::sync::atomic::Ordering::Relaxed) == SESSION_AUTH_COOKIE
+    }
     fn sid(&self) -> String {
         self.sid.read().unwrap().clone().unwrap_or_default()
     }
@@ -497,10 +603,18 @@ impl SynologyClient {
         let mut last_err = SynoFsError::Io("no attempts".into());
         for attempt in 0..3u8 {
             if attempt > 0 {
-                debug!("retry {} for GET {}", attempt, url);
+                debug!(
+                    "retry {} for GET {}",
+                    attempt,
+                    crate::redact::redact_secrets(url)
+                );
                 tokio::time::sleep(Duration::from_millis(200 * attempt as u64)).await;
             }
-            let resp = match self.http.get(url).query(params).send().await {
+            let resp = match self
+                .attach_session(self.http.get(url).query(params))
+                .send()
+                .await
+            {
                 Ok(r) => r,
                 Err(e) => {
                     last_err = e.into();
@@ -561,8 +675,13 @@ impl SynologyClient {
                 .data
                 .ok_or_else(|| SynoFsError::Io("no auth data".into()))?
                 .sid;
-            debug!("Logged in, SID: {}...", &sid[..8.min(sid.len())]);
+            // Deliberately not logged, not even a prefix: the session id is a
+            // bearer token, and a log line is exactly where it must not be.
+            debug!("Logged in ({} byte session id)", sid.len());
             *self.sid.write().unwrap() = Some(sid);
+            // Settle how the token travels before any real call uses it, while
+            // the session is new enough that a 119 can only mean one thing.
+            self.probe_session_transport().await;
             if self.auto_relogin {
                 *self.creds.write().unwrap() = Some(StoredCreds {
                     user: user.to_string(),
@@ -629,15 +748,12 @@ impl SynologyClient {
     pub async fn logout(&self) -> Result<(), SynoFsError> {
         let url = format!("{}/auth.cgi", self.base_url);
         let _ = self
-            .http
-            .get(&url)
-            .query(&[
+            .attach_session(self.http.get(&url).query(&[
                 ("api", "SYNO.API.Auth"),
                 ("version", "7"),
                 ("method", "logout"),
                 ("session", "FileStation"),
-                ("_sid", &self.sid()),
-            ])
+            ]))
             .send()
             .await;
         *self.sid.write().unwrap() = None;
@@ -665,7 +781,6 @@ impl SynologyClient {
         F: Fn(T) -> (Vec<SynoFileInfo>, Option<u64>),
     {
         let url = format!("{}/entry.cgi", self.base_url);
-        let sid = self.sid();
         let limit = LIST_PAGE_SIZE.to_string();
         let mut collected: Vec<SynoFileInfo> = Vec::new();
 
@@ -680,7 +795,6 @@ impl SynologyClient {
             params.push(("additional", additional));
             params.push(("limit", &limit));
             params.push(("offset", &offset));
-            params.push(("_sid", &sid));
 
             let text = self.get_text_retried(&url, &params).await?;
             let resp: SynoResponse<T> = serde_json::from_str(&text)
@@ -756,7 +870,6 @@ impl SynologyClient {
                     ("method", "getinfo"),
                     ("path", &path_json),
                     ("additional", ADDITIONAL_FIELDS),
-                    ("_sid", &self.sid()),
                 ],
             )
             .await?;
@@ -941,14 +1054,13 @@ impl SynologyClient {
             let outcome: TransferOutcome = {
                 let _slot = self.acquire_transfer_slot().await;
 
-                let mut req = self.http.get(&url).query(&[
+                let mut req = self.attach_session(self.http.get(&url).query(&[
                     ("api", "SYNO.FileStation.Download"),
                     ("version", "2"),
                     ("method", "download"),
                     ("path", &path_json),
                     ("mode", "download"),
-                    ("_sid", &self.sid()),
-                ]);
+                ]));
                 if let Some(ref range) = range_header {
                     req = req.header("Range", range.as_str());
                 }
@@ -1207,14 +1319,11 @@ impl SynologyClient {
             let form = form.part("file", file_part);
 
             let mut req = self
-                .http
-                .post(&url)
-                .query(&[
+                .attach_session(self.http.post(&url).query(&[
                     ("api", "SYNO.FileStation.Upload"),
                     ("method", "upload"),
                     ("version", "2"),
-                ])
-                .query(&[("_sid", self.sid())])
+                ]))
                 .header("X-TYPE-NAME", "SLICEUPLOAD")
                 .header("X-FILE-SIZE", total.to_string())
                 .header("X-FILE-CHUNK-END", if last { "true" } else { "false" });
@@ -1340,9 +1449,7 @@ impl SynologyClient {
             let text = {
                 let _slot = self.acquire_transfer_slot().await;
                 match self
-                    .http
-                    .post(&url)
-                    .query(&[("_sid", self.sid())])
+                    .attach_session(self.http.post(&url))
                     .multipart(form)
                     .send()
                     .await
@@ -1406,7 +1513,6 @@ impl SynologyClient {
                     ("path", &path_json),
                     ("recursive", "true"),
                     ("accurate_progress", "false"),
-                    ("_sid", &self.sid()),
                 ],
             )
             .await?;
@@ -1443,7 +1549,6 @@ impl SynologyClient {
                     ("folder_path", &parent_json),
                     ("name", &name_json),
                     ("additional", ADDITIONAL_FIELDS),
-                    ("_sid", &self.sid()),
                 ],
             )
             .await?;
@@ -1488,7 +1593,6 @@ impl SynologyClient {
                     ("path", &path_json),
                     ("name", &name_json),
                     ("additional", ADDITIONAL_FIELDS),
-                    ("_sid", &self.sid()),
                 ],
             )
             .await?;
@@ -1564,6 +1668,205 @@ mod tests {
         );
     }
 
+    // ── secret leakage ───────────────────────────────────────────────────────
+
+    /// Regression: reqwest embeds the full request URL, query string included,
+    /// in the Display of a transport error. Every FileStation call carried the
+    /// session id as `_sid`, so one connection failure published a live bearer
+    /// token into the CLI's stderr, the GUI's log pane and the message of every
+    /// Python exception. Nothing leaving this client may carry it.
+    #[tokio::test]
+    async fn a_transport_error_never_carries_the_session_id() {
+        // Port 1 has nothing listening, so the request fails at connect — the
+        // path that bakes the request URL into the error message.
+        let client = SynologyClient::new("127.0.0.1", 1, false);
+        *client.sid.write().unwrap() = Some("SUPERSECRETSID".to_string());
+
+        let err = client.list_dir("/share").await.unwrap_err();
+
+        let message = err.to_string();
+        assert!(
+            message.contains("entry.cgi"),
+            "precondition: the error should carry the URL, else this proves \
+             nothing: {message}"
+        );
+        assert!(
+            !message.contains("SUPERSECRETSID"),
+            "session id leaked into a transport error: {message}"
+        );
+    }
+
+    /// The stashed password must not be one stray `{:?}` away from a log line.
+    ///
+    /// The literal is deliberately shaped like a placeholder rather than like a
+    /// password: a realistic-looking one here trips secret scanners on every
+    /// pull request, and a security check that cries wolf is one people learn
+    /// to click past.
+    #[test]
+    fn debug_formatting_stored_creds_hides_the_password() {
+        let creds = StoredCreds {
+            user: "alice".into(),
+            password: "placeholder-not-a-real-password".into(),
+        };
+        let rendered = format!("{creds:?}");
+        assert!(
+            !rendered.contains("placeholder-not-a-real-password"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("alice"), "{rendered}");
+    }
+
+    // ── how the session id travels ───────────────────────────────────────────
+
+    /// Mount the share listing the post-login probe asks for.
+    async fn mount_probe_ok(server: &MockServer) {
+        Mock::given(method("GET"))
+            .and(query_param("method", "list_share"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({"success": true, "data": {"total": 0, "shares": []}}),
+            ))
+            .mount(server)
+            .await;
+    }
+
+    fn empty_list() -> ResponseTemplate {
+        ResponseTemplate::new(200)
+            .set_body_json(serde_json::json!({"success": true, "data": {"total": 0, "files": []}}))
+    }
+
+    /// Regression: the session id rode in the query string of every call, which
+    /// puts a live bearer token in the NAS's own access log, in any proxy's log
+    /// in between, and in the text of every transport error. It travels as a
+    /// cookie now, and no request URL may contain it.
+    #[tokio::test]
+    async fn the_session_id_never_appears_in_a_request_url() {
+        let server = MockServer::start().await;
+        mount_auth(
+            &server,
+            serde_json::json!({"success": true, "data": {"sid": "SUPERSECRETSID"}}),
+        )
+        .await;
+        mount_probe_ok(&server).await;
+        Mock::given(method("GET"))
+            .and(query_param("method", "list"))
+            .respond_with(empty_list())
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        client.login("alice", "secret", None).await.unwrap();
+        client.list_dir("/share").await.unwrap();
+        client.logout().await.unwrap();
+
+        let requests = server.received_requests().await.unwrap();
+        assert!(requests.len() >= 4, "login + probe + list + logout");
+        for req in &requests {
+            assert!(
+                !req.url.as_str().contains("SUPERSECRETSID"),
+                "session id in a request URL: {}",
+                req.url
+            );
+            assert!(
+                !req.url.as_str().contains("_sid"),
+                "_sid parameter still present: {}",
+                req.url
+            );
+        }
+    }
+
+    /// ...and it does still reach the server, just in a header.
+    #[tokio::test]
+    async fn the_session_id_travels_as_a_cookie() {
+        let server = MockServer::start().await;
+        mount_auth(
+            &server,
+            serde_json::json!({"success": true, "data": {"sid": "SUPERSECRETSID"}}),
+        )
+        .await;
+        mount_probe_ok(&server).await;
+
+        let client = client_for(&server);
+        client.login("alice", "secret", None).await.unwrap();
+        assert!(client.session_in_cookie());
+
+        let requests = server.received_requests().await.unwrap();
+        let probe = requests
+            .iter()
+            .find(|r| r.url.query().is_some_and(|q| q.contains("list_share")))
+            .expect("the probe request");
+        assert_eq!(
+            probe.headers.get("cookie").unwrap().to_str().unwrap(),
+            "id=SUPERSECRETSID"
+        );
+    }
+
+    /// The cookie is a claim about a server we cannot test against here, so it
+    /// is verified rather than assumed. A DSM that answers 119 to the probe
+    /// sends the client back to the query parameter — degraded, but working,
+    /// which is the right way round for an unverifiable assumption.
+    #[tokio::test]
+    async fn a_dsm_that_rejects_the_cookie_falls_back_to_the_query_parameter() {
+        let server = MockServer::start().await;
+        mount_auth(
+            &server,
+            serde_json::json!({"success": true, "data": {"sid": "SUPERSECRETSID"}}),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(query_param("method", "list_share"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({"success": false, "error": {"code": 119}})),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(query_param("method", "list"))
+            .respond_with(empty_list())
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        client.login("alice", "secret", None).await.unwrap();
+        assert!(
+            !client.session_in_cookie(),
+            "a 119 to the probe must switch the client to query auth"
+        );
+
+        client.list_dir("/share").await.unwrap();
+        let requests = server.received_requests().await.unwrap();
+        let list = requests
+            .iter()
+            .rfind(|r| r.url.query().is_some_and(|q| q.contains("method=list&")))
+            .expect("the list request");
+        assert!(
+            list.url.as_str().contains("_sid=SUPERSECRETSID"),
+            "the fallback must still authenticate: {}",
+            list.url
+        );
+    }
+
+    /// A probe that cannot reach the NAS says nothing about whether the cookie
+    /// is accepted — the network is simply down. Downgrading on that would
+    /// permanently degrade a session over an unrelated blip.
+    #[tokio::test]
+    async fn a_probe_that_cannot_reach_the_nas_does_not_downgrade_the_session() {
+        let server = MockServer::start().await;
+        mount_auth(
+            &server,
+            serde_json::json!({"success": true, "data": {"sid": "s"}}),
+        )
+        .await;
+        // No probe route: wiremock answers 404 with an empty body — a failure,
+        // but not a 119.
+        let client = client_for(&server);
+        client.login("alice", "secret", None).await.unwrap();
+
+        assert!(
+            client.session_in_cookie(),
+            "only a definitive 119 should downgrade the session"
+        );
+    }
     // ── TLS verification ─────────────────────────────────────────────────────
 
     /// A one-shot HTTPS listener presenting a self-signed certificate for

--- a/rust/synology-filestation-core/src/error.rs
+++ b/rust/synology-filestation-core/src/error.rs
@@ -155,7 +155,14 @@ impl From<reqwest::Error> for SynoFsError {
         // DNS failure) is one or more levels down the source chain. Flattening
         // it in is the difference between a user seeing "certificate is not
         // trusted by the operating system" and seeing nothing they can act on.
-        Self::Io(flatten_sources(&e))
+        //
+        // Redacted here, on the way in, rather than at each place the message is
+        // shown: once the string is inside the error it gets logged, wrapped,
+        // returned across the FFI and raised as a Python exception, and only one
+        // of those paths would remember to scrub it. reqwest embeds the full
+        // request URL — query string included — so without this every transport
+        // failure publishes the session id.
+        Self::Io(crate::redact::redact_secrets(&flatten_sources(&e)))
     }
 }
 

--- a/rust/synology-filestation-core/src/lib.rs
+++ b/rust/synology-filestation-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod client;
 pub mod error;
+pub mod redact;
 pub mod transport;
 pub mod types;
 

--- a/rust/synology-filestation-core/src/redact.rs
+++ b/rust/synology-filestation-core/src/redact.rs
@@ -1,0 +1,197 @@
+//! Scrubbing secrets out of text that is about to be logged, returned in an
+//! error, or shown to a user.
+//!
+//! The session id travels as a `_sid` query parameter on every FileStation
+//! call, and `reqwest` puts the **full request URL, query string included**,
+//! into the `Display` of any transport error. So a single connection refusal
+//! produces:
+//!
+//! ```text
+//! error sending request for url (https://nas:5001/webapi/entry.cgi?api=…&_sid=SECRET)
+//! ```
+//!
+//! which then reaches the CLI's stderr, the GUI's log pane (via the FFI log
+//! bridge), and the message of every Python exception. A session id is a
+//! bearer token: whoever reads it out of a log can act as that user until it
+//! expires.
+//!
+//! This module is the last line of defence, not the first. The client prefers
+//! to keep the session id out of URLs altogether (see `SessionAuth` in
+//! `client.rs`); redaction is what catches the cases where it cannot — a
+//! fallback to query auth, a URL logged by some dependency, a parameter added
+//! later by somebody who did not read this file.
+
+/// Parameter names whose values must never survive into a log or an error.
+///
+/// Matched case-insensitively against the identifier immediately preceding an
+/// `=`, so it covers query strings (`&_sid=…`), form bodies (`passwd=…`), and
+/// most incidental `key=value` renderings.
+const SECRET_PARAMS: &[&str] = &[
+    "_sid",
+    "sid",
+    "passwd",
+    "password",
+    "otp_code",
+    "otp",
+    "synotoken",
+    "x-syno-token",
+];
+
+/// What replaces a redacted value. Deliberately visible: a reader should be
+/// able to tell that something was removed rather than wonder whether the
+/// parameter was empty.
+const PLACEHOLDER: &str = "<redacted>";
+
+/// True if `name` is a parameter whose value is a secret.
+fn is_secret(name: &str) -> bool {
+    SECRET_PARAMS
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(name))
+}
+
+/// Characters that end a parameter value in the shapes we care about: query
+/// strings, form bodies, and values embedded in prose or parenthesised URLs.
+fn ends_value(c: char) -> bool {
+    matches!(
+        c,
+        '&' | '"' | '\'' | ')' | ' ' | ',' | ';' | '\n' | '\r' | '\t'
+    )
+}
+
+/// Replace the value of every secret-looking `key=value` pair with a
+/// placeholder, leaving everything else — including the key itself — intact so
+/// the message stays diagnosable.
+pub fn redact_secrets(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut cursor = 0;
+
+    while cursor < text.len() {
+        let Some(rel) = text[cursor..].find('=') else {
+            out.push_str(&text[cursor..]);
+            return out;
+        };
+        let eq = cursor + rel;
+
+        // The parameter name is the identifier run ending at the '='.
+        // `rfind` reports the byte where the delimiter *starts*; stepping past it
+        // means adding that character's own width, not 1. Adding 1 lands inside
+        // any multi-byte delimiter and panics the slice below — and a NAS path
+        // with an accent in it is enough to get one here.
+        let name_start = text[..eq]
+            .char_indices()
+            .rev()
+            .find(|(_, c)| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '-'))
+            .map(|(idx, c)| idx + c.len_utf8())
+            .unwrap_or(0);
+        let name = &text[name_start..eq];
+
+        out.push_str(&text[cursor..=eq]);
+        cursor = eq + 1;
+
+        if is_secret(name) {
+            let value_end = text[cursor..]
+                .find(ends_value)
+                .map(|rel| cursor + rel)
+                .unwrap_or(text.len());
+            // An already-empty value stays empty rather than being dressed up
+            // as a redacted one.
+            if value_end > cursor {
+                out.push_str(PLACEHOLDER);
+            }
+            cursor = value_end;
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact shape reqwest produces. Pinned as a literal because this is
+    /// the string that actually reaches a log file.
+    #[test]
+    fn redacts_the_session_id_from_a_reqwest_error_url() {
+        let leaked = "error sending request for url \
+             (https://nas:5001/webapi/entry.cgi?api=SYNO.FileStation.List&version=2&_sid=abc123SECRET): \
+             client error (Connect): tcp connect error";
+
+        let safe = redact_secrets(leaked);
+
+        assert!(!safe.contains("abc123SECRET"), "{safe}");
+        assert!(safe.contains("_sid=<redacted>"), "{safe}");
+        // Everything diagnostic survives.
+        assert!(safe.contains("SYNO.FileStation.List"), "{safe}");
+        assert!(safe.contains("tcp connect error"), "{safe}");
+        assert!(safe.contains("nas:5001"), "{safe}");
+    }
+
+    #[test]
+    fn redacts_credentials_from_a_form_body() {
+        let body = "api=SYNO.API.Auth&account=alice&passwd=hunter2&otp_code=998877&format=sid";
+        let safe = redact_secrets(body);
+
+        assert!(!safe.contains("hunter2"), "{safe}");
+        assert!(!safe.contains("998877"), "{safe}");
+        assert!(safe.contains("passwd=<redacted>"), "{safe}");
+        assert!(safe.contains("otp_code=<redacted>"), "{safe}");
+        // The account name is not a secret and is useful for diagnosis.
+        assert!(safe.contains("account=alice"), "{safe}");
+    }
+
+    #[test]
+    fn leaves_ordinary_parameters_untouched() {
+        let text = "path=/share/file.txt&offset=0&length=1024";
+        assert_eq!(redact_secrets(text), text);
+    }
+
+    /// `sid` must not match `_sidecar`, `considered=`, and friends — the name
+    /// is the whole identifier before the `=`, not a substring of it.
+    #[test]
+    fn only_matches_whole_parameter_names() {
+        let text = "sidecar=keepme&considered=keepme2&nosid=keepme3";
+        assert_eq!(redact_secrets(text), text);
+    }
+
+    #[test]
+    fn redacts_every_occurrence() {
+        let text = "a?_sid=one&b&_sid=two";
+        let safe = redact_secrets(text);
+        assert!(!safe.contains("one"), "{safe}");
+        assert!(!safe.contains("two"), "{safe}");
+    }
+
+    #[test]
+    fn is_idempotent() {
+        let once = redact_secrets("url?_sid=secret");
+        assert_eq!(redact_secrets(&once), once);
+    }
+
+    #[test]
+    fn matches_case_insensitively() {
+        assert!(!redact_secrets("?_SID=secret").contains("secret"));
+        assert!(!redact_secrets("?Passwd=secret").contains("secret"));
+    }
+
+    /// Byte-index arithmetic must not split a multi-byte character.
+    #[test]
+    fn handles_multibyte_text_without_panicking() {
+        let text = "café=ok&_sid=secret&naïve=ok — ✓";
+        let safe = redact_secrets(text);
+        assert!(!safe.contains("secret"), "{safe}");
+        assert!(safe.contains("café=ok"), "{safe}");
+        assert!(safe.contains('✓'), "{safe}");
+    }
+
+    #[test]
+    fn empty_value_stays_empty() {
+        assert_eq!(redact_secrets("?_sid=&api=x"), "?_sid=&api=x");
+    }
+
+    #[test]
+    fn text_with_no_parameters_is_unchanged() {
+        let text = "connection refused (os error 111)";
+        assert_eq!(redact_secrets(text), text);
+    }
+}

--- a/rust/synology-filestation-fuse/src/main.rs
+++ b/rust/synology-filestation-fuse/src/main.rs
@@ -45,6 +45,13 @@ struct Args {
     #[arg(long, short = 'p', env = "SYNO_PASSWORD")]
     password: Option<String>,
 
+    /// Read the password from the first line of stdin.
+    ///
+    /// Prefer this in scripts. A password passed as `--password` sits in this
+    /// process's argv, which every other account on the machine can read via
+    /// `ps` (and `/proc/<pid>/cmdline` on Linux) for as long as the mount runs.
+    #[arg(long, conflicts_with = "password")]
+    password_stdin: bool,
     /// TOTP code for two-factor authentication (or set SYNO_OTP env var).
     /// If 2FA is enabled and this is not provided, you will be prompted interactively.
     #[arg(long, env = "SYNO_OTP")]
@@ -74,6 +81,34 @@ fn prompt(label: &str) -> anyhow::Result<String> {
     Ok(value.trim().to_string())
 }
 
+/// Whether the password was typed on the command line rather than coming from
+/// the environment. argv is readable by any local account; `SYNO_PASSWORD` is
+/// not, so only the former deserves a warning.
+fn password_came_from_argv() -> bool {
+    std::env::args().any(|a| a == "-p" || a == "--password" || a.starts_with("--password="))
+}
+
+/// Resolve the password from stdin, argv/environment, or an interactive prompt.
+fn resolve_password(args: &Args) -> anyhow::Result<String> {
+    if args.password_stdin {
+        let mut line = String::new();
+        io::stdin().read_line(&mut line)?;
+        return Ok(line.trim_end_matches(['\r', '\n']).to_string());
+    }
+    match &args.password {
+        Some(p) => {
+            if password_came_from_argv() {
+                tracing::warn!(
+                    "--password puts the password in this process's argv, where every \
+                     other account on this machine can read it with `ps`. Prefer \
+                     SYNO_PASSWORD, --password-stdin, or the interactive prompt."
+                );
+            }
+            Ok(p.clone())
+        }
+        None => Ok(rpassword::prompt_password("Password: ")?),
+    }
+}
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
@@ -105,10 +140,7 @@ fn main() -> anyhow::Result<()> {
         client
     };
 
-    let password = match args.password {
-        Some(p) => p,
-        None => rpassword::prompt_password("Password: ")?,
-    };
+    let password = resolve_password(&args)?;
 
     let otp = args.otp.as_deref();
     let login_result = rt.block_on(client.login(&args.username, &password, otp));

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -110,7 +110,7 @@ fn local_fs_error(what: &str, e: &std::io::Error) -> SynoFsError {
 }
 
 /// Connection parameters for [`SmbTransport::connect`].
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SmbConfig {
     /// NAS host, either `host` or `host:port`. If no port is present, [`port`]
     /// is appended.
@@ -127,6 +127,22 @@ pub struct SmbConfig {
     pub domain: String,
     /// Connection/negotiate timeout.
     pub timeout: Duration,
+}
+
+/// Hand-written so the password never reaches a log. This is a public type
+/// with a public `password` field, so a derived `Debug` would put a plaintext
+/// credential one `{:?}` away for every downstream consumer, not just for us.
+impl std::fmt::Debug for SmbConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SmbConfig")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("username", &self.username)
+            .field("password", &"<redacted>")
+            .field("domain", &self.domain)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
 }
 
 impl SmbConfig {


### PR DESCRIPTION
Stacked on #153 → #152 → #151.

Follow-up to #153, which noted the SID was still a query parameter on every non-login call. That turned out to be the smaller half of the problem.

## What was leaking, and to where

I probed this rather than assuming, and the result was worse than the review said:

```
DISPLAY >>> error sending request for url
            (http://nas:5001/webapi/entry.cgi?api=SYNO.FileStation.List&_sid=SUPERSECRETSID)
```

**`reqwest` puts the full query string into the `Display` of every transport error.** So the session id was not only reaching DSM's nginx log — it was reaching *our own* outputs: the CLI's stderr, the GUI's log pane via the FFI log bridge, and the message of every Python exception. A session id is a bearer token; anyone who reads one out of a log can act as that user until it expires.

| | Leak | Reached |
|---|---|---|
| 1 | `_sid` in every request URL | NAS nginx log, proxy logs, **and every transport error message** |
| 2 | `debug!("Logged in, SID: {}…")` | first 8 chars of the token, in logs |
| 3 | `StoredCreds` derived `Debug` with a plaintext password | one stray `{:?}` from a log line |
| 4 | `SmbConfig` derived `Debug`, **public type, public password field** | same, for every downstream consumer of the crate |
| 5 | `--password` in argv | `ps` / `/proc/<pid>/cmdline`, readable by any local account |
| 6 | retry log echoed the URL verbatim | logs |

## Fixes

**Source fix (#1):** the session id now travels as an `id` cookie. Headers aren't in any of those logs. `attach_session` is the single place that decides how the token travels, replacing nine call sites that each appended their own `_sid`.

Whether a given DSM honours the cookie is a claim about a server I can't test against, and being wrong breaks every call — so it's *checked*, not assumed: one cheap authenticated request right after login, falling back to `_sid` with a warning if DSM answers 119.

**The probe's timing is the whole design, and I got this wrong first.** A 119 is ambiguous — "cookie refused" and "session expired" are the same code. My first attempt settled the question from the first ordinary call to avoid the extra round trip. That misreads an expired session as a rejected cookie (silently putting the id back into URLs), and it *swallowed the 119 that auto-relogin exists to act on* — two existing relogin tests caught it. A session issued moments ago cannot have expired, so probing at login makes the answer unambiguous. Cost: one request per login.

**Defence in depth (#1, #2, #6):** a `redact` module scrubs `_sid` / `passwd` / `otp_code` values from any `key=value` text, applied where `reqwest::Error` is converted — on the way *in*, so the secret never enters the error. Redacting at each display site instead would mean every one of them remembering, and one of them eventually not. This is what catches the fallback path, and anything added later by someone who didn't read this file.

**#3, #4:** hand-written `Debug` impls rendering the password as `<redacted>`.

**#5:** new `--password-stdin`; `--password` still works but now warns and names the alternatives.

## Testing

| | before | after |
|---|---|---|
| Rust | 170 | **186** |
| .NET | 60 | 60 |
| Python | 73 | 73 |

clippy `-D warnings` clean, `cargo fmt --check` clean.

Tests assert the leak directly: no request URL may contain the session id; the cookie must actually be sent; a transport error's message must not contain it (verified red — it printed the live token); and a redaction pass over the exact string reqwest produces.

One test found a real bug in my own code: the redaction did byte arithmetic after `rfind`, which lands mid-character on multi-byte input and panics. A NAS filename with an accent would have crashed the redaction path. Fixed and pinned.

## Still worth a human's eye

- **The `id` cookie needs confirming on real DSM.** The fallback means a NAS that refuses it still works, and the tests cover both branches, but the happy path is unverified against hardware — same caveat as the login POST in #153.
- **The GUI keeps the password in memory** for the session (it isn't persisted — verified). Unavoidable given auto-relogin; noting it rather than leaving it implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)