### PR TITLE
fix(fuse): present mounted entries under local ownership, not DSM's

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,7 @@ MVVM pattern (Avalonia). The GUI calls the Rust core **directly via the FFI cdyl
 - Write buffers are held entirely in memory until file close
 - No symlinks, hard links, or special files
 - Linux: inode numbers are not stable; permissions/timestamps are read-only
+- Linux: ownership and mode are **synthetic** — every entry is reported as owned by the mounting user (`--uid`/`--gid`) with a `--umask`-derived mode, because DSM's uids and POSIX bits describe accounts on the appliance, not on this machine. Exporting them verbatim made GIO report `access::can-delete: FALSE` (see `fs::Ownership`). What the account may actually do is still enforced by DSM per call
 
 ## Release Process
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ synology-filestation-fuse --host <NAS_HOST> -u <USERNAME> [OPTIONS] <MOUNTPOINT>
 | `--insecure` | Accept any TLS certificate (self-signed, expired, wrong hostname). Needed for a stock DSM certificate; the connection is then encrypted but **not** authenticated. Env: `SYNO_INSECURE` | `false` |
 | `--cache-ttl <SECS>` | Metadata cache TTL in seconds *(Linux only)* | `30` |
 | `--read-cache-mb <MiB>` | Read cache size in MiB *(Linux only)* | `256` |
+| `--uid <UID>` | Owner reported for every mounted entry. DSM's own uids name accounts on the appliance, not on this machine, so they are never used *(Linux only)* | *(mounting user)* |
+| `--gid <GID>` | Group reported for every mounted entry *(Linux only)* | *(mounting user's group)* |
+| `--umask <MASK>` | Octal umask for the permissions the mount reports; `022` gives `0755` directories and `0644` files *(Linux only)* | `022` |
 | `--log-level <LEVEL>` | Log level (`error`, `warn`, `info`, `debug`, `trace`) | `info` |
 
 ### Examples

--- a/rust/synology-filestation-fuse/src/fs.rs
+++ b/rust/synology-filestation-fuse/src/fs.rs
@@ -49,25 +49,54 @@ struct WriteBuffer {
     new_file: bool,
 }
 
-/// Translate FileStation metadata into a `FileAttr`, falling back to
-/// `fallback_uid`/`fallback_gid` when the NAS reports no owner.
+/// How the mount presents ownership and permissions to the kernel.
+///
+/// DSM's identifiers describe the *appliance*, not this machine, so they are
+/// deliberately dropped rather than mapped: shares arrive owned by root as
+/// `dr----x--t` (mode 0o1411, sticky) and their contents owned by
+/// directory-service ids like 1161823311 with mode 000. Exporting that verbatim
+/// made glib apply the sticky-directory rule — a file is deletable only by its
+/// own owner or its parent directory's owner — and report
+/// `access::can-delete: FALSE` for everything inside a share, so GNOME Files
+/// hid Delete, Move to Trash and Rename. (The kernel never enforced those bits:
+/// the mount carries no `default_permissions`. The damage was entirely in what
+/// userspace concluded from the metadata.)
+///
+/// So every entry is presented as owned by the mounting user with a synthetic
+/// mode, the way sshfs and rclone do it. What the account may actually do is
+/// still decided by DSM on each call, and surfaces as an error from that call.
+#[derive(Debug, Clone, Copy)]
+pub struct Ownership {
+    /// Owner reported for every entry — the mounting user unless overridden.
+    pub uid: u32,
+    /// Group reported for every entry.
+    pub gid: u32,
+    /// Masked out of the synthetic mode, as a process umask would be.
+    pub umask: u16,
+}
+
+impl Ownership {
+    /// The synthetic mode for an entry: `0o777`/`0o666` less the umask.
+    pub fn perm(&self, isdir: bool) -> u16 {
+        let base = if isdir { 0o777 } else { 0o666 };
+        base & !self.umask
+    }
+}
+
+/// Translate FileStation metadata into a `FileAttr`, presenting it under
+/// `owner` rather than under whatever identifiers DSM reported.
 ///
 /// A free function rather than a method: a spawned transfer replies to the
 /// kernel from the runtime, where there is no `&self` left to borrow — only
-/// the two ids it copied out of the filesystem.
-fn file_attr(fallback_uid: u32, fallback_gid: u32, ino: u64, info: &SynoFileInfo) -> FileAttr {
+/// the `Ownership` it copied out of the filesystem.
+fn file_attr(owner: Ownership, ino: u64, info: &SynoFileInfo) -> FileAttr {
     let kind = if info.isdir {
         FileType::Directory
     } else {
         FileType::RegularFile
     };
     let size = info.additional.as_ref().and_then(|a| a.size).unwrap_or(0);
-    let perm = info
-        .additional
-        .as_ref()
-        .and_then(|a| a.perm.as_ref())
-        .map(|p| p.posix as u16)
-        .unwrap_or(if info.isdir { 0o755 } else { 0o644 });
+    let perm = owner.perm(info.isdir);
 
     let ts_to_system = |ts: i64| {
         if ts >= 0 {
@@ -94,19 +123,6 @@ fn file_attr(fallback_uid: u32, fallback_gid: u32, ino: u64, info: &SynoFileInfo
             (now, now, now, now)
         });
 
-    let uid = info
-        .additional
-        .as_ref()
-        .and_then(|a| a.owner.as_ref())
-        .map(|o| o.uid)
-        .unwrap_or(fallback_uid);
-    let gid = info
-        .additional
-        .as_ref()
-        .and_then(|a| a.owner.as_ref())
-        .map(|o| o.gid)
-        .unwrap_or(fallback_gid);
-
     FileAttr {
         ino: INodeNo(ino),
         size,
@@ -118,8 +134,8 @@ fn file_attr(fallback_uid: u32, fallback_gid: u32, ino: u64, info: &SynoFileInfo
         kind,
         perm,
         nlink: if info.isdir { 2 } else { 1 },
-        uid,
-        gid,
+        uid: owner.uid,
+        gid: owner.gid,
         rdev: 0,
         blksize: 4096,
         flags: 0,
@@ -315,8 +331,7 @@ pub struct SynologyFS {
     /// longer implicitly serialised by the event loop.
     transfer_limit: Arc<tokio::sync::Semaphore>,
     next_fh: AtomicU64,
-    uid: u32,
-    gid: u32,
+    owner: Ownership,
 }
 
 impl SynologyFS {
@@ -325,8 +340,7 @@ impl SynologyFS {
         cache: Arc<InodeCache>,
         read_cache: Arc<ReadCache>,
         rt: tokio::runtime::Handle,
-        uid: u32,
-        gid: u32,
+        owner: Ownership,
     ) -> Self {
         Self {
             client,
@@ -336,8 +350,7 @@ impl SynologyFS {
             write_buffers: Arc::new(Mutex::new(HashMap::new())),
             transfer_limit: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_TRANSFERS)),
             next_fh: AtomicU64::new(1),
-            uid,
-            gid,
+            owner,
         }
     }
 
@@ -360,7 +373,7 @@ impl SynologyFS {
     }
 
     fn syno_to_attr(&self, ino: u64, info: &SynoFileInfo) -> FileAttr {
-        file_attr(self.uid, self.gid, ino, info)
+        file_attr(self.owner, ino, info)
     }
 
     fn get_path_for_ino(&self, ino: u64) -> Option<String> {
@@ -572,10 +585,10 @@ impl SynologyFS {
             ctime: UNIX_EPOCH,
             crtime: UNIX_EPOCH,
             kind: FileType::Directory,
-            perm: 0o755,
+            perm: self.owner.perm(true),
             nlink: 2,
-            uid: self.uid,
-            gid: self.gid,
+            uid: self.owner.uid,
+            gid: self.owner.gid,
             rdev: 0,
             blksize: 4096,
             flags: 0,
@@ -1371,11 +1384,11 @@ impl Filesystem for SynologyFS {
             // Read-modify-write over the whole file, so it too runs on the
             // runtime and replies from there.
             let cache = self.cache.clone();
-            let (uid, gid) = (self.uid, self.gid);
+            let owner = self.owner;
             let failed_path = path.clone();
             self.start_truncate(ino, path, new_size, move |r| match r {
                 Ok(info) => {
-                    let attr = file_attr(uid, gid, ino, &info);
+                    let attr = file_attr(owner, ino, &info);
                     cache.insert(ino, info);
                     reply.attr(&TTL, &attr);
                 }
@@ -1416,7 +1429,7 @@ impl Filesystem for SynologyFS {
 mod tests {
     use super::*;
     use std::collections::HashMap as Map;
-    use synology_filestation_core::types::SynoAdditional;
+    use synology_filestation_core::types::{SynoAdditional, SynoOwner, SynoPerm};
     use wiremock::matchers::{method as http_method, path as http_path, query_param};
     use wiremock::{Mock, MockServer, Request as WmRequest, Respond, ResponseTemplate};
 
@@ -1449,8 +1462,11 @@ mod tests {
             Arc::new(InodeCache::new(30)),
             Arc::new(ReadCache::new(BLOCK, 64)),
             rt.handle().clone(),
-            1000,
-            1000,
+            Ownership {
+                uid: 1000,
+                gid: 1000,
+                umask: 0o022,
+            },
         );
         Fixture { fs, server, rt }
     }
@@ -2123,5 +2139,115 @@ mod tests {
         );
         assert_eq!(split_nas_path("/f.txt"), Some(("", "f.txt")));
         assert_eq!(split_nas_path("f.txt"), None);
+    }
+
+    // ── T1.4: ownership and mode presented to the kernel ──────────────────────
+
+    /// The identity a mount presents by default: the local user, umask 0o022.
+    fn mounting_user() -> Ownership {
+        Ownership {
+            uid: 1000,
+            gid: 100,
+            umask: 0o022,
+        }
+    }
+
+    /// A `SynoFileInfo` carrying whatever DSM said about owner and POSIX mode.
+    fn info_with(isdir: bool, owner: Option<(u32, u32)>, posix: Option<u32>) -> SynoFileInfo {
+        SynoFileInfo {
+            name: "entry".into(),
+            path: "/share/entry".into(),
+            isdir,
+            additional: Some(SynoAdditional {
+                size: Some(0),
+                owner: owner.map(|(uid, gid)| SynoOwner {
+                    uid,
+                    gid,
+                    user: "dsm-user".into(),
+                    group: "dsm-group".into(),
+                }),
+                time: None,
+                perm: posix.map(|posix| SynoPerm { posix }),
+            }),
+            code: None,
+        }
+    }
+
+    /// Regression: DSM's uid/gid space has nothing to do with the local one —
+    /// shares come back owned by root and their contents by directory-service
+    /// ids like 1161823311. Exporting those verbatim left every entry owned by
+    /// a stranger, which is half of what made GIO report
+    /// `access::can-delete: FALSE` for anything inside a share.
+    #[test]
+    fn nas_owner_is_never_exported_to_the_kernel() {
+        let attr = file_attr(
+            mounting_user(),
+            42,
+            &info_with(false, Some((1161823311, 1161822721)), None),
+        );
+
+        assert_eq!(attr.uid, 1000, "entries must be owned by the mounting user");
+        assert_eq!(
+            attr.gid, 100,
+            "entries must carry the mounting user's group"
+        );
+    }
+
+    /// Regression: every DSM share is reported as `dr----x--t` — mode 0o1411,
+    /// sticky bit set, owned by root. Passing that through made glib apply the
+    /// sticky-directory rule (deletable only by the owner of the file or of its
+    /// parent), so GNOME Files hid Delete, Move to Trash and Rename on
+    /// everything inside a share. The sticky bit must never reach the kernel.
+    #[test]
+    fn nas_posix_mode_is_never_exported_to_the_kernel() {
+        let share = file_attr(
+            mounting_user(),
+            42,
+            &info_with(true, Some((0, 0)), Some(0o1411)),
+        );
+
+        assert_eq!(
+            share.perm & 0o1000,
+            0,
+            "the sticky bit must not survive into the mount"
+        );
+        assert_eq!(share.perm, 0o755, "directories get a synthetic 0o755");
+
+        // A share's contents come back as mode 000 owned by a directory-service
+        // id; that must not make them unusable locally either.
+        let child = file_attr(
+            mounting_user(),
+            43,
+            &info_with(false, Some((1161823311, 1161822721)), Some(0o000)),
+        );
+        assert_eq!(child.perm, 0o644, "files get a synthetic 0o644");
+    }
+
+    /// The synthetic mode is `0o777`/`0o666` less the umask, so a private mount
+    /// is still expressible.
+    #[test]
+    fn umask_narrows_the_synthetic_mode() {
+        let default = mounting_user();
+        assert_eq!(default.perm(true), 0o755, "0o022 is the usual umask");
+        assert_eq!(default.perm(false), 0o644);
+
+        let private = Ownership {
+            umask: 0o077,
+            ..default
+        };
+        assert_eq!(private.perm(true), 0o700);
+        assert_eq!(private.perm(false), 0o600);
+    }
+
+    /// The virtual root is the one entry with no NAS metadata behind it; it
+    /// must still follow the same ownership rules as everything else.
+    #[test]
+    fn virtual_root_is_owned_by_the_mounting_user() {
+        let f = fixture();
+        let attr = f.fs.virtual_root_attr();
+
+        assert_eq!(attr.uid, 1000);
+        assert_eq!(attr.gid, 1000);
+        assert_eq!(attr.perm, 0o755);
     }
 }

--- a/rust/synology-filestation-fuse/src/lib.rs
+++ b/rust/synology-filestation-fuse/src/lib.rs
@@ -19,6 +19,10 @@ use std::sync::Arc;
 use synology_filestation_core::client::SynologyClient;
 use synology_filestation_core::error::SynoFsError;
 
+/// Default umask for the synthetic mode the Linux backend reports, matching the
+/// 0o755 directories / 0o644 files a process with the usual umask creates.
+pub const DEFAULT_UMASK: u16 = 0o022;
+
 #[cfg(target_os = "linux")]
 mod cache;
 #[cfg(target_os = "linux")]
@@ -49,6 +53,16 @@ pub struct MountOptions {
     /// kernel receive buffer, which is why this is a small number rather than
     /// "as many as possible".
     pub io_threads: usize,
+    /// Owner reported for every entry (Linux only). `None` means the mounting
+    /// user. DSM's own uids are deliberately never used: they name accounts on
+    /// the appliance, not on this machine.
+    pub uid: Option<u32>,
+    /// Group reported for every entry (Linux only). `None` means the mounting
+    /// user's group.
+    pub gid: Option<u32>,
+    /// Masked out of the synthetic mode (Linux only), as a process umask would
+    /// be: the default 0o022 yields 0o755 directories and 0o644 files.
+    pub umask: u16,
 }
 
 impl Default for MountOptions {
@@ -57,6 +71,9 @@ impl Default for MountOptions {
             cache_ttl: 30,
             read_cache_mb: 256,
             io_threads: 0,
+            uid: None,
+            gid: None,
+            umask: DEFAULT_UMASK,
         }
     }
 }
@@ -205,6 +222,13 @@ pub fn spawn_mount(
     let read_cache = Arc::new(ReadCache::new(READ_BLOCK_SIZE, max_blocks.max(1)));
     let uid = unsafe { libc::getuid() };
     let gid = unsafe { libc::getgid() };
+    // DSM's uids and POSIX bits describe the appliance, not this machine, so
+    // the mount presents everything under local identifiers instead.
+    let owner = fs::Ownership {
+        uid: opts.uid.unwrap_or(uid),
+        gid: opts.gid.unwrap_or(gid),
+        umask: opts.umask,
+    };
 
     info!(
         "Read cache: {} MiB ({} blocks × {} MiB)",
@@ -213,7 +237,7 @@ pub fn spawn_mount(
         READ_BLOCK_SIZE / (1024 * 1024)
     );
 
-    let fs = SynologyFS::new(client.clone(), cache, read_cache, rt, uid, gid);
+    let fs = SynologyFS::new(client.clone(), cache, read_cache, rt, owner);
 
     // As a non-root user, allow_other requires `user_allow_other` in
     // /etc/fuse.conf; running as root always permits it.

--- a/rust/synology-filestation-fuse/src/main.rs
+++ b/rust/synology-filestation-fuse/src/main.rs
@@ -75,9 +75,37 @@ struct Args {
     #[arg(long, default_value_t = 0)]
     fuse_threads: usize,
 
+    /// Owner reported for every mounted entry; defaults to the mounting user.
+    /// DSM's own uids name accounts on the appliance and are never used
+    /// (Linux/FUSE only)
+    #[arg(long)]
+    uid: Option<u32>,
+
+    /// Group reported for every mounted entry; defaults to the mounting user's
+    /// group (Linux/FUSE only)
+    #[arg(long)]
+    gid: Option<u32>,
+
+    /// Umask for the synthetic permissions the mount reports. The default 0o022
+    /// gives 0755 directories and 0644 files (Linux/FUSE only)
+    #[arg(long, value_parser = parse_umask, default_value = "022")]
+    umask: u16,
+
     /// Log level (error, warn, info, debug, trace)
     #[arg(long, default_value = "info")]
     log_level: String,
+}
+
+/// Parse a umask the way `umask(1)` and every mount helper do: octal, with no
+/// `0o` prefix required. Base 10 would silently turn the near-universal `022`
+/// into 0o026.
+fn parse_umask(raw: &str) -> Result<u16, String> {
+    let value = u16::from_str_radix(raw.trim_start_matches("0o"), 8)
+        .map_err(|_| format!("`{raw}` is not an octal umask"))?;
+    if value > 0o777 {
+        return Err(format!("umask `{raw}` is out of range (max 777)"));
+    }
+    Ok(value)
 }
 
 fn prompt(label: &str) -> anyhow::Result<String> {
@@ -190,6 +218,9 @@ fn main() -> anyhow::Result<()> {
         cache_ttl: args.cache_ttl,
         read_cache_mb: args.read_cache_mb,
         io_threads: args.fuse_threads,
+        uid: args.uid,
+        gid: args.gid,
+        umask: args.umask,
     };
     let handle = spawn_mount(client.clone(), rt.handle().clone(), args.mountpoint, opts)?;
 
@@ -203,4 +234,26 @@ fn main() -> anyhow::Result<()> {
     rt.block_on(client.logout())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_umask;
+
+    /// `--umask 022` must mean 0o022. Parsed as decimal it would be 0o026,
+    /// quietly stripping group/other permissions the user never asked to drop.
+    #[test]
+    fn umask_is_parsed_as_octal() {
+        assert_eq!(parse_umask("022"), Ok(0o022));
+        assert_eq!(parse_umask("077"), Ok(0o077));
+        assert_eq!(parse_umask("0o027"), Ok(0o027));
+        assert_eq!(parse_umask("0"), Ok(0));
+    }
+
+    #[test]
+    fn a_umask_outside_the_permission_bits_is_rejected() {
+        assert!(parse_umask("1777").is_err());
+        assert!(parse_umask("088").is_err(), "8 is not an octal digit");
+        assert!(parse_umask("rwx").is_err());
+    }
 }


### PR DESCRIPTION
## The symptom

GNOME Files shows **no Delete, Move to Trash, or Rename** entry for anything inside a share on a Linux mount.

## The cause

Nautilus decides those menu items purely from GIO's `access::can-delete`, and GIO said `FALSE`:

```
$ gio info /home/chris/mnt/2026_kastner_ml_dump/share
  access::can-write:  TRUE
  access::can-delete: FALSE
  access::can-trash:  FALSE
  access::can-rename: FALSE
  unix::uid: 1161823311
```

The mount was passing DSM's own owner and POSIX mode straight through to the kernel. Those describe accounts on the *appliance*, not on this machine:

```
dr----x--t 2 root       root      2026_kastner_ml_dump   <- mode 0o1411, sticky, owned by root
d--------- 2 1161823311 1161822721  share                <- mode 000, directory-service uid
```

glib's `get_access_rights()` then applies the sticky-directory rule — a file is deletable only by its own owner or by its parent directory's owner — matched neither against the local euid (1000), and concluded nothing inside a share was deletable. `can-trash` and `can-rename` fall out of the same check.

Nothing in the kernel was enforcing those bits: the mount carries no `default_permissions`, and the FS implements no `access` callback. `rm` from a terminal worked all along, and the `unlink` path was never at fault. The damage was entirely in what userspace *concluded* from the metadata.

## The fix

Report every entry as owned by the mounting user with a synthetic mode, the way sshfs and rclone do. A new `fs::Ownership { uid, gid, umask }` replaces the two fallback ids that `file_attr` used only when the NAS reported no owner; `additional.owner` and `perm.posix` are no longer read at all. Mode is `0o777`/`0o666` less the umask, and `virtual_root_attr` follows the same rule instead of hardcoding `0o755`.

What the account may actually do is unchanged — it was never these bits. DSM decides per call, and a refusal surfaces as an error from that call.

New `--uid` / `--gid` / `--umask` flags override the defaults. The umask parser is octal, since `022` read as decimal would silently become `0o026`.

The GUI picks this up for free: the FFI mount path builds its options with `..MountOptions::default()`.

## Tests

Written first, and confirmed failing for the right reasons before the implementation landed:

```
nas_owner_is_never_exported_to_the_kernel      ... FAILED   left: 1161823311  right: 1000
nas_posix_mode_is_never_exported_to_the_kernel ... FAILED   left: 512 (sticky)  right: 0
```

Five new tests in total, covering the two regressions above plus umask narrowing, the virtual root, and octal umask parsing.

- `cargo test --workspace` — 10 test binaries, all green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Not covered

- **Not remount-verified.** The mechanism was confirmed against a live mount and the attributes are pinned by unit tests, but confirming GIO flips to `can-delete: TRUE` means tearing down the running mount and re-authenticating. After remounting, `gio info <file-in-a-share>` is the check.
- **Linux only.** The WebDAV (macOS) and WinFsp (Windows) backends have their own metadata translation and are untouched; the bug was in the FUSE path.
- **Unrelated:** during diagnosis, `ls -la` on the mount root took over two minutes to return with 4 requests queued on the FUSE connection. Deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)