### PR TITLE
feat(smb): let SMB take new files, not just replacements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "synology-filestation-fuse"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "synology_filestation"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "pyo3",
  "pyo3-async-runtimes",

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -1335,17 +1335,33 @@ impl SynologyClient {
         overwrite: bool,
         progress: Option<ProgressSink<'_>>,
     ) -> Result<(), SynoFsError> {
-        if overwrite && !self.stream_write_transports.is_empty() {
+        if !self.stream_write_transports.is_empty() {
             let full_path = format!("{}/{}", folder_path.trim_end_matches('/'), filename);
             for entry in &self.stream_write_transports {
                 let allowed = entry.breaker.lock().unwrap().allows(Instant::now());
                 if !allowed {
                     continue;
                 }
-                match entry.transport.write_from_path(&full_path, local).await {
+                // Creating and replacing are different promises, so they are
+                // different calls. A new file used to skip the backends
+                // entirely — which exempted the case a mount spends its
+                // bandwidth on, since a large copy is a *new* file.
+                let attempt = if overwrite {
+                    entry.transport.write_from_path(&full_path, local).await
+                } else {
+                    entry.transport.write_new_from_path(&full_path, local).await
+                };
+                match attempt {
                     Ok(()) => {
                         entry.breaker.lock().unwrap().on_success();
                         return Ok(());
+                    }
+                    // Declining a case it cannot promise is not a failure:
+                    // leave the breaker shut so this backend still gets the
+                    // writes it can serve.
+                    Err(e) if e.category() == ErrorCategory::NotSupported => {
+                        debug!("stream write backend cannot create new files, using HTTP: {e}");
+                        continue;
                     }
                     Err(e) if e.category() == ErrorCategory::Transport => {
                         warn!("stream write backend failed (transient), falling back: {e}");
@@ -4035,13 +4051,17 @@ mod tests {
 
     enum Behave {
         Ok(&'static [u8]),
-        Transient, // category Transport → fall back
-        NotFound,  // definitive → propagate, no fallback
+        Transient,       // category Transport → fall back
+        NotFound,        // definitive → propagate, no fallback
+        Exists,          // the create-new case: the name is taken
+        CannotCreateNew, // capability gap, not a failure
     }
 
     struct FakeBackend {
         behave: Behave,
         calls: AtomicUsize,
+        /// Calls that asked for create-new semantics specifically.
+        new_calls: AtomicUsize,
     }
 
     impl FakeBackend {
@@ -4049,10 +4069,14 @@ mod tests {
             Arc::new(Self {
                 behave,
                 calls: AtomicUsize::new(0),
+                new_calls: AtomicUsize::new(0),
             })
         }
         fn call_count(&self) -> usize {
             self.calls.load(Ordering::SeqCst)
+        }
+        fn new_call_count(&self) -> usize {
+            self.new_calls.load(Ordering::SeqCst)
         }
         fn outcome_bytes(&self) -> Result<Bytes, SynoFsError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
@@ -4060,6 +4084,8 @@ mod tests {
                 Behave::Ok(b) => Ok(Bytes::from_static(b)),
                 Behave::Transient => Err(SynoFsError::Io("backend down".into())),
                 Behave::NotFound => Err(SynoFsError::NotFound),
+                Behave::Exists => Err(SynoFsError::AlreadyExists),
+                Behave::CannotCreateNew => Err(SynoFsError::NotSupported),
             }
         }
         fn outcome_unit(&self) -> Result<(), SynoFsError> {
@@ -4083,6 +4109,10 @@ mod tests {
 
     #[async_trait::async_trait]
     impl StreamWriteTransport for FakeBackend {
+        async fn write_new_from_path(&self, _p: &str, _local: &Path) -> Result<(), SynoFsError> {
+            self.new_calls.fetch_add(1, Ordering::SeqCst);
+            self.outcome_unit()
+        }
         async fn write_from_path(&self, _p: &str, _local: &Path) -> Result<(), SynoFsError> {
             self.outcome_unit()
         }
@@ -4101,6 +4131,8 @@ mod tests {
                 }
                 Behave::Transient => Err(SynoFsError::Io("backend down".into())),
                 Behave::NotFound => Err(SynoFsError::NotFound),
+                // Write-side behaviours; a read never sees them.
+                Behave::Exists | Behave::CannotCreateNew => Err(SynoFsError::NotSupported),
             }
         }
     }
@@ -4275,7 +4307,59 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upload_from_path_overwrite_false_bypasses_stream_backend() {
+    async fn a_new_file_is_streamed_through_the_backend() {
+        // Creating a file is the case large copies are made of, so it must not
+        // be the one case that skips the fast path. The backend is asked for
+        // create-new semantics rather than the replacing write, so the "don't
+        // clobber" contract survives the change of transport.
+        let src = write_scratch_file(b"streamed payload");
+        let server = MockServer::start().await;
+        let backend = FakeBackend::new(Behave::Ok(b""));
+        let client = client_for(&server).with_stream_write_transport(backend.clone());
+        client
+            .upload_from_path(&src, "/share", "f.bin", false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            backend.new_call_count(),
+            1,
+            "asked to create, not to replace"
+        );
+        assert!(
+            server.received_requests().await.unwrap().is_empty(),
+            "the NAS's HTTP API is not touched when the backend took the write"
+        );
+        std::fs::remove_file(&src).ok();
+    }
+
+    #[tokio::test]
+    async fn a_new_file_whose_name_is_taken_is_refused_rather_than_retried() {
+        // The name being taken is an answer, not a transport hiccup: HTTP would
+        // only reach the same conclusion, and re-uploading to find out costs
+        // the whole file.
+        let src = write_scratch_file(b"streamed payload");
+        let server = MockServer::start().await;
+        let backend = FakeBackend::new(Behave::Exists);
+        let client = client_for(&server).with_stream_write_transport(backend.clone());
+        let err = client
+            .upload_from_path(&src, "/share", "f.bin", false)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SynoFsError::AlreadyExists), "got {err:?}");
+        assert!(
+            server.received_requests().await.unwrap().is_empty(),
+            "no second opinion over HTTP"
+        );
+        std::fs::remove_file(&src).ok();
+    }
+
+    #[tokio::test]
+    async fn a_backend_that_cannot_create_new_defers_to_http() {
+        // Declining is not failing. A backend without create-new semantics
+        // simply doesn't get the new-file case, and its breaker stays shut so
+        // it still serves the writes it can.
         let src = write_scratch_file(b"streamed payload");
         let server = MockServer::start().await;
         Mock::given(method("POST"))
@@ -4285,16 +4369,24 @@ mod tests {
             })))
             .mount(&server)
             .await;
-        let backend = FakeBackend::new(Behave::Ok(b""));
+        let backend = FakeBackend::new(Behave::CannotCreateNew);
         let client = client_for(&server).with_stream_write_transport(backend.clone());
         client
             .upload_from_path(&src, "/share", "f.bin", false)
             .await
             .unwrap();
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+
+        // Same client, a replacing write: the breaker must not have been
+        // tripped by the decline.
+        client
+            .upload_from_path(&src, "/share", "f.bin", true)
+            .await
+            .unwrap();
         assert_eq!(
             backend.call_count(),
-            0,
-            "overwrite=false must skip the streaming backend"
+            2,
+            "the decline cost the backend nothing"
         );
         std::fs::remove_file(&src).ok();
     }

--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -3615,13 +3615,19 @@ mod tests {
     // rename. The fishsense regression is the central case here.
 
     fn unique_tmp_path(name: &str) -> std::path::PathBuf {
+        // A counter, not just the clock. `SystemTime` is only nanosecond-*typed*
+        // — macOS and Windows tick it in microseconds — so two tests starting in
+        // the same tick got the same "unique" path, and whichever finished first
+        // deleted the other's file out from under it.
+        static SEQ: AtomicUsize = AtomicUsize::new(0);
         let mut p = std::env::temp_dir();
         let pid = std::process::id();
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        p.push(format!("synofs-test-{pid}-{nanos}-{name}"));
+        let seq = SEQ.fetch_add(1, Ordering::SeqCst);
+        p.push(format!("synofs-test-{pid}-{nanos}-{seq}-{name}"));
         p
     }
 

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -83,6 +83,28 @@ pub trait StreamWriteTransport: Send + Sync {
     /// Stream the contents of local file `local` into `remote_path`, replacing
     /// it (old-or-new).
     async fn write_from_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError>;
+
+    /// Stream `local` into `remote_path`, which **must not already exist**.
+    ///
+    /// Creating a file is where the volume is — a mount's large copies are new
+    /// files, not replacements — so a backend that cannot serve this case
+    /// doesn't get the traffic that matters. But "create" carries a promise
+    /// [`write_from_path`](Self::write_from_path) does not: an existing name is
+    /// [`SynoFsError::AlreadyExists`], never a silent clobber. Only a backend
+    /// that can make that atomic (SMB's `FILE_CREATE` disposition, say) should
+    /// implement it.
+    ///
+    /// The default declines with [`SynoFsError::NotSupported`], which the
+    /// selection layer reads as "not for you" rather than "you failed" — the
+    /// backend keeps its breaker shut and still serves replacing writes.
+    async fn write_new_from_path(
+        &self,
+        remote_path: &str,
+        local: &Path,
+    ) -> Result<(), SynoFsError> {
+        let _ = (remote_path, local);
+        Err(SynoFsError::NotSupported)
+    }
 }
 
 /// Tuning for a backend's [`CircuitBreaker`].

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -563,6 +563,73 @@ impl SmbTransport {
     /// the target with the same move-aside guarantee as [`write_atomic`].
     ///
     /// [`write_atomic`]: Self::write_atomic
+    /// Stream a local file to `logical`, which must not already exist.
+    ///
+    /// Unlike [`Self::write_from_path`] this writes the destination directly
+    /// instead of staging a `.part` and renaming. That is the whole point: the
+    /// server's `FILE_CREATE` disposition is what makes "fail if it exists"
+    /// atomic, and a rename would either clobber the winner of a race or need a
+    /// check-then-act that cannot be made safe from here. The cost is that a
+    /// failed transfer leaves a short file at the real name, so a failure
+    /// removes it.
+    pub async fn write_new_from_path(
+        &self,
+        logical: &str,
+        local: &Path,
+    ) -> Result<(), SynoFsError> {
+        let loc = SmbPath::from_logical(logical)?;
+
+        let mut file = tokio::fs::File::open(local)
+            .await
+            .map_err(|e| local_fs_error(&format!("open {}", local.display()), &e))?;
+
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        self.ensure_ready(client, trees, &loc.share).await?;
+
+        // Exclusive create: an existing name comes back as
+        // STATUS_OBJECT_NAME_COLLISION, which maps to AlreadyExists — the
+        // caller's cue that this is an answer, not a transport failure.
+        let mut writer = {
+            let tree = trees.get(&loc.share).expect("tree just ensured");
+            match client.create_file_writer_exclusive(tree, &loc.path).await {
+                Ok(w) => w,
+                Err(e) => return Err(self.mark_and_map(&e)),
+            }
+        };
+
+        let mut buf = vec![0u8; 1 << 20];
+        let mut stream_err: Option<SynoFsError> = None;
+        loop {
+            match file.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    if let Err(e) = writer.write_chunk(&buf[..n]).await {
+                        stream_err = Some(self.mark_and_map(&e));
+                        break;
+                    }
+                }
+                Err(e) => {
+                    stream_err = Some(SynoFsError::Io(format!("read {}: {e}", local.display())));
+                    break;
+                }
+            }
+        }
+        if let Err(e) = writer.finish().await {
+            stream_err.get_or_insert_with(|| self.mark_and_map(&e));
+        }
+
+        if let Some(e) = stream_err {
+            // We created this name, so removing it is ours to do — leaving a
+            // truncated file where the caller asked for a whole one is worse
+            // than leaving nothing.
+            let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+            self.note_cleanup(client.delete_file(tree, &loc.path).await);
+            return Err(e);
+        }
+        Ok(())
+    }
+
     pub async fn write_from_path(&self, logical: &str, local: &Path) -> Result<(), SynoFsError> {
         let loc = SmbPath::from_logical(logical)?;
         let seq = PART_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -646,6 +713,14 @@ impl WriteTransport for SmbTransport {
 impl StreamWriteTransport for SmbTransport {
     async fn write_from_path(&self, remote_path: &str, local: &Path) -> Result<(), SynoFsError> {
         SmbTransport::write_from_path(self, remote_path, local).await
+    }
+
+    async fn write_new_from_path(
+        &self,
+        remote_path: &str,
+        local: &Path,
+    ) -> Result<(), SynoFsError> {
+        SmbTransport::write_new_from_path(self, remote_path, local).await
     }
 }
 


### PR DESCRIPTION
First piece of the SMB-first work. Everything in the SMB → VPN → HTTPS chain rests on SMB actually being used, and today it isn't for the case that matters.

## The gap

`upload_from_path` consulted the streaming backends only when `overwrite` was true:

```rust
if overwrite && !self.stream_write_transports.is_empty() {
```

and the FUSE layer passes `overwrite = !buf.new_file`. So **creating** a file always went over HTTP — which exempts exactly the case a mount spends its bandwidth on, because a large copy is a *new* file. On campus, with SMB up and healthy, a 6 GB copy still went through `synoscgi` and inherited every limitation of the Upload API: no resume, the opaque tmpfile, the 401-on-reconnect from #160.

## Why the gate existed, and what replaces it

It wasn't arbitrary. HTTP's `overwrite=false` refuses to clobber an existing file; `write_from_path` stages a `.part` and renames over whatever is in the way. Routing new files to it would have turned "don't clobber" into "silently replace".

So this adds the missing promise instead of removing the check:

- **`StreamWriteTransport::write_new_from_path`** — stream a local file to a name that must not already exist.
- **SMB gets that atomically from the server**, via `create_file_writer_exclusive` (FILE_CREATE disposition). `STATUS_OBJECT_NAME_COLLISION → ErrorKind::AlreadyExists → SynoFsError::AlreadyExists`, end to end.
- **An existing name is an answer, not a failure.** It propagates instead of falling back — HTTP would only reach the same conclusion, and re-uploading gigabytes to find out is the expensive way to learn it.
- **It writes the destination directly** rather than staging a `.part`. Exclusive create at the real name *is* the atomicity here; a rename would clobber the winner of a race, and check-then-act can't be made safe from the client. The cost is that a failed transfer leaves a short file at the real name, so a failure removes it.
- **The default implementation declines** with `NotSupported`, which the selection layer reads as "not for you" rather than "you failed": the backend keeps its breaker shut, still serves replacing writes, and HTTP takes the new-file case exactly as before.

## Tests

Three new, red first (they failed with `upload HTTP 404` — the backend wasn't consulted at all):

- `a_new_file_is_streamed_through_the_backend` — create-new is used, and the HTTP API is never touched.
- `a_new_file_whose_name_is_taken_is_refused_rather_than_retried` — `AlreadyExists` propagates, no second opinion over HTTP.
- `a_backend_that_cannot_create_new_defers_to_http` — the decline falls back *and* leaves the breaker shut, proven by a subsequent replacing write still reaching the backend.

`upload_from_path_overwrite_false_bypasses_stream_backend` encoded the old contract and is inverted rather than deleted.

Workspace green (132 core + the rest), `cargo fmt` and `cargo clippy --workspace --all-targets` clean.

## Not in this PR

The SMB path still can't serve metadata (`readdir`, `mkdir`, `rename`, `truncate`) or offset writes, so `fs.rs` remains HTTP-first for everything but bulk transfer. That's the next piece, and it's what lets the write path stop buffering to a spill file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
