### PR TITLE
feat(smb): serve listings and namespace changes over SMB

### DIFF
--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -8,9 +8,44 @@ use tracing::{debug, error, warn};
 
 use crate::error::{dsm_code_to_category, ErrorCategory, SynoFsError};
 use crate::transport::{
-    BreakerConfig, CircuitBreaker, ReadTransport, StreamReadTransport, StreamWriteTransport,
-    WriteTransport,
+    BreakerConfig, CircuitBreaker, MetadataTransport, ReadTransport, StreamReadTransport,
+    StreamWriteTransport, WriteTransport,
 };
+/// Offer an operation to each metadata backend in turn before falling back to
+/// HTTP, expanding at the head of the method it belongs to.
+///
+/// A macro rather than a function because the six operations differ in
+/// signature and return type, and an `async` closure over `&dyn Trait` buys
+/// lifetime grief for no gain. The `return` is the point: a backend that
+/// answers *is* the answer.
+macro_rules! via_metadata {
+    ($self:ident, $method:ident ( $($arg:expr),* )) => {
+        for entry in &$self.metadata_transports {
+            if !entry.breaker.lock().unwrap().allows(Instant::now()) {
+                continue;
+            }
+            match entry.transport.$method($($arg),*).await {
+                Ok(v) => {
+                    entry.breaker.lock().unwrap().on_success();
+                    return Ok(v);
+                }
+                // Declining an operation it cannot promise is not a failure.
+                Err(e) if e.category() == ErrorCategory::NotSupported => continue,
+                Err(e) if e.category() == ErrorCategory::Transport => {
+                    warn!("metadata backend failed (transient), falling back: {e}");
+                    entry.breaker.lock().unwrap().on_failure(Instant::now());
+                    continue;
+                }
+                // A reachable backend gave a definitive answer; trust it.
+                Err(e) => {
+                    entry.breaker.lock().unwrap().on_success();
+                    return Err(e);
+                }
+            }
+        }
+    };
+}
+
 use crate::types::{
     AuthData, CreateFolderData, GetInfoData, ListData, ListShareData, Md5StartData, Md5StatusData,
     RenameData, SynoFileInfo, SynoResponse, UploadData, ADDITIONAL_FIELDS, SHARE_ADDITIONAL_FIELDS,
@@ -386,6 +421,9 @@ pub struct SynologyClient {
     /// Injected streaming read backends, tried in order by `download_to_path`
     /// before falling back to the buffering HTTP download.
     stream_read_transports: Vec<TransportEntry<dyn StreamReadTransport>>,
+    /// Injected metadata backends, tried in order before the HTTP List/Delete/
+    /// CreateFolder/Rename APIs.
+    metadata_transports: Vec<TransportEntry<dyn MetadataTransport>>,
     /// Bytes per slice for the chunked upload path. A file larger than this is
     /// uploaded slice-by-slice so it is never held in memory whole; anything
     /// smaller takes the one-shot path. Default [`DEFAULT_SLICE_SIZE`].
@@ -444,6 +482,7 @@ impl SynologyClient {
             write_transports: Vec::new(),
             stream_write_transports: Vec::new(),
             stream_read_transports: Vec::new(),
+            metadata_transports: Vec::new(),
             slice_size: DEFAULT_SLICE_SIZE,
         }
     }
@@ -575,6 +614,15 @@ impl SynologyClient {
     /// HTTP download on transport failures.
     pub fn with_stream_read_transport(mut self, transport: Arc<dyn StreamReadTransport>) -> Self {
         self.stream_read_transports
+            .push(TransportEntry::new(transport));
+        self
+    }
+
+    /// Inject a [`MetadataTransport`] backend. Listings, `get_info`, and the
+    /// namespace mutations prefer it over the HTTP FileStation APIs, falling
+    /// back to HTTP when it is unhealthy or declines an operation.
+    pub fn with_metadata_transport(mut self, transport: Arc<dyn MetadataTransport>) -> Self {
+        self.metadata_transports
             .push(TransportEntry::new(transport));
         self
     }
@@ -1004,6 +1052,7 @@ impl SynologyClient {
     /// List all FileStation shares the account can see.
     pub async fn list_shares(&self) -> Result<Vec<SynoFileInfo>, SynoFsError> {
         debug!("list_shares");
+        via_metadata!(self, list_shares());
         self.list_paged::<ListShareData, _>(
             "list_share",
             &[],
@@ -1017,6 +1066,7 @@ impl SynologyClient {
     /// List the contents of a directory.
     pub async fn list_dir(&self, folder_path: &str) -> Result<Vec<SynoFileInfo>, SynoFsError> {
         debug!("list_dir: {}", folder_path);
+        via_metadata!(self, list_dir(folder_path));
         self.list_paged::<ListData, _>(
             "list",
             &[("folder_path", folder_path)],
@@ -1032,6 +1082,7 @@ impl SynologyClient {
         let url = format!("{}/entry.cgi", self.base_url);
         let path_json = serde_json::to_string(&[path]).unwrap();
         debug!("get_info: {}", path);
+        via_metadata!(self, get_info(path));
         let text = self
             .get_text_retried(
                 &url,
@@ -2073,6 +2124,7 @@ impl SynologyClient {
         let url = format!("{}/entry.cgi", self.base_url);
         let path_json = serde_json::to_string(&[path]).unwrap();
         debug!("delete: {}", path);
+        via_metadata!(self, delete(path));
 
         let text = self
             .get_text_retried(
@@ -2109,6 +2161,7 @@ impl SynologyClient {
         let parent_json = serde_json::to_string(&[parent]).unwrap();
         let name_json = serde_json::to_string(&[name]).unwrap();
         debug!("create_folder: {}/{}", parent, name);
+        via_metadata!(self, create_folder(parent, name));
 
         let text = self
             .get_text_retried(
@@ -2153,6 +2206,7 @@ impl SynologyClient {
         let path_json = serde_json::to_string(&[old_path]).unwrap();
         let name_json = serde_json::to_string(&[new_name]).unwrap();
         debug!("rename: {} -> {}", old_path, new_name);
+        via_metadata!(self, rename(old_path, new_name));
 
         let text = self
             .get_text_retried(
@@ -5678,5 +5732,131 @@ mod tests {
             "it landed via a resend, so its contents are checked"
         );
         std::fs::remove_file(&local).ok();
+    }
+
+    // ── metadata backends ────────────────────────────────────────────────────
+    //
+    // Listings and namespace changes follow the same selection rules as bytes:
+    // a healthy backend answers, a transport failure falls back to HTTP, a
+    // definitive answer is the answer, and an operation the backend cannot
+    // promise is declined without counting against it.
+
+    struct FakeMeta {
+        behave: Behave,
+        calls: AtomicUsize,
+    }
+
+    impl FakeMeta {
+        fn new(behave: Behave) -> Arc<Self> {
+            Arc::new(Self {
+                behave,
+                calls: AtomicUsize::new(0),
+            })
+        }
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+        fn entry(&self, name: &str) -> Result<SynoFileInfo, SynoFsError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.behave {
+                Behave::Ok(_) => Ok(SynoFileInfo {
+                    name: name.to_string(),
+                    path: format!("/share/{name}"),
+                    isdir: false,
+                    additional: None,
+                    code: None,
+                }),
+                Behave::Transient => Err(SynoFsError::Io("backend down".into())),
+                Behave::NotFound => Err(SynoFsError::NotFound),
+                Behave::Exists => Err(SynoFsError::AlreadyExists),
+                Behave::CannotCreateNew => Err(SynoFsError::NotSupported),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MetadataTransport for FakeMeta {
+        async fn list_dir(&self, _folder: &str) -> Result<Vec<SynoFileInfo>, SynoFsError> {
+            self.entry("from-backend").map(|e| vec![e])
+        }
+        async fn get_info(&self, _path: &str) -> Result<SynoFileInfo, SynoFsError> {
+            self.entry("from-backend")
+        }
+        async fn delete(&self, _path: &str) -> Result<(), SynoFsError> {
+            self.entry("deleted").map(|_| ())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_listing_prefers_the_metadata_backend() {
+        let backend = FakeMeta::new(Behave::Ok(b""));
+        // No HTTP server at all: if the backend didn't answer, this would fail.
+        let client = offline_client().with_metadata_transport(backend.clone());
+        let entries = client.list_dir("/share").await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "from-backend");
+        assert_eq!(backend.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_listing_falls_back_to_http_when_the_backend_is_down() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "list"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"files": [{
+                    "name": "from-http", "path": "/share/from-http", "isdir": false,
+                    "additional": {"size": 1, "owner": null, "time": null, "perm": null}
+                }], "total": 1, "offset": 0}
+            })))
+            .mount(&server)
+            .await;
+        let backend = FakeMeta::new(Behave::Transient);
+        let client = client_for(&server).with_metadata_transport(backend.clone());
+        let entries = client.list_dir("/share").await.unwrap();
+        assert_eq!(entries[0].name, "from-http", "HTTP served the listing");
+        assert_eq!(backend.call_count(), 1, "the backend was tried first");
+    }
+
+    #[tokio::test]
+    async fn a_definitive_answer_from_the_backend_is_not_second_guessed() {
+        // NotFound from a reachable backend is the truth about the namespace.
+        // Asking HTTP for a second opinion would be slower and no more correct.
+        let server = MockServer::start().await;
+        let backend = FakeMeta::new(Behave::NotFound);
+        let client = client_for(&server).with_metadata_transport(backend.clone());
+        let err = client.get_info("/share/gone").await.unwrap_err();
+        assert!(matches!(err, SynoFsError::NotFound), "got {err:?}");
+        assert!(
+            server.received_requests().await.unwrap().is_empty(),
+            "no HTTP second opinion"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_operation_the_backend_declines_goes_to_http() {
+        // FakeMeta implements only listings, stat and delete; `create_folder`
+        // falls through to the trait default, which declines.
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/webapi/entry.cgi"))
+            .and(query_param("method", "create"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "data": {"folders": [{"name": "new", "path": "/share/new", "isdir": true}]}
+            })))
+            .mount(&server)
+            .await;
+        let backend = FakeMeta::new(Behave::Ok(b""));
+        let client = client_for(&server).with_metadata_transport(backend.clone());
+        let made = client.create_folder("/share", "new").await.unwrap();
+        assert_eq!(made.name, "new");
+        assert_eq!(backend.call_count(), 0, "declined without being charged");
+
+        // And the decline left the breaker shut: a listing still prefers it.
+        let entries = client.list_dir("/share").await.unwrap();
+        assert_eq!(entries[0].name, "from-backend");
     }
 }

--- a/rust/synology-filestation-core/src/lib.rs
+++ b/rust/synology-filestation-core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod types;
 pub use client::{SynologyClient, ThrottleConfig};
 pub use error::SynoFsError;
 pub use transport::{
-    BreakerConfig, CircuitBreaker, ReadTransport, StreamReadTransport, StreamWriteTransport,
-    WriteTransport,
+    BreakerConfig, CircuitBreaker, MetadataTransport, ReadTransport, StreamReadTransport,
+    StreamWriteTransport, WriteTransport,
 };
 pub use types::{SynoAdditional, SynoFileInfo, SynoOwner, SynoPerm, SynoTime};

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -38,6 +38,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 
 use crate::error::SynoFsError;
+use crate::types::SynoFileInfo;
 
 /// A read backend serving file bytes as an alternative to the HTTP Download API.
 #[async_trait]
@@ -103,6 +104,58 @@ pub trait StreamWriteTransport: Send + Sync {
         local: &Path,
     ) -> Result<(), SynoFsError> {
         let _ = (remote_path, local);
+        Err(SynoFsError::NotSupported)
+    }
+}
+
+/// A backend that can answer questions about the *namespace* — what is here,
+/// how big is it — and change it: create a directory, rename, delete.
+///
+/// Kept apart from the byte-moving traits because the capabilities are
+/// genuinely separate. SMB can serve all of it; a bulk object store might only
+/// carry contents. Every method defaults to [`SynoFsError::NotSupported`], so a
+/// backend implements the operations it can actually promise and the selection
+/// layer quietly uses HTTP for the rest — a decline is not a failure and does
+/// not count against the backend's breaker.
+///
+/// Paths are FileStation logical paths (`/share/dir/file`), so a backend that
+/// addresses storage differently translates on its own side. Return types match
+/// the HTTP client's, because callers must not be able to tell which backend
+/// answered.
+#[async_trait]
+pub trait MetadataTransport: Send + Sync {
+    /// The shares available to this session, as directory entries.
+    async fn list_shares(&self) -> Result<Vec<SynoFileInfo>, SynoFsError> {
+        Err(SynoFsError::NotSupported)
+    }
+
+    /// Entries directly under `folder_path`.
+    async fn list_dir(&self, folder_path: &str) -> Result<Vec<SynoFileInfo>, SynoFsError> {
+        let _ = folder_path;
+        Err(SynoFsError::NotSupported)
+    }
+
+    /// Metadata for a single entry.
+    async fn get_info(&self, path: &str) -> Result<SynoFileInfo, SynoFsError> {
+        let _ = path;
+        Err(SynoFsError::NotSupported)
+    }
+
+    /// Create directory `name` under `parent`.
+    async fn create_folder(&self, parent: &str, name: &str) -> Result<SynoFileInfo, SynoFsError> {
+        let _ = (parent, name);
+        Err(SynoFsError::NotSupported)
+    }
+
+    /// Rename within the same directory — `new_name` is a bare name, not a path.
+    async fn rename(&self, old_path: &str, new_name: &str) -> Result<SynoFileInfo, SynoFsError> {
+        let _ = (old_path, new_name);
+        Err(SynoFsError::NotSupported)
+    }
+
+    /// Remove a file or an empty directory.
+    async fn delete(&self, path: &str) -> Result<(), SynoFsError> {
+        let _ = path;
         Err(SynoFsError::NotSupported)
     }
 }

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -20,8 +20,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use smb2::{ClientConfig, SmbClient, Tree};
 use synology_filestation_core::{
-    ReadTransport, StreamReadTransport, StreamWriteTransport, SynoFsError, SynologyClient,
-    WriteTransport,
+    MetadataTransport, ReadTransport, StreamReadTransport, StreamWriteTransport, SynoAdditional,
+    SynoFileInfo, SynoFsError, SynoTime, SynologyClient, WriteTransport,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
@@ -254,7 +254,8 @@ pub async fn auto_attach(
             .with_read_transport(smb.clone())
             .with_write_transport(smb.clone())
             .with_stream_write_transport(smb.clone())
-            .with_stream_read_transport(smb),
+            .with_stream_read_transport(smb.clone())
+            .with_metadata_transport(smb),
         None => client,
     }
 }
@@ -845,6 +846,265 @@ mod tests {
             cfg2.addr(),
             "nas.example.com:1445",
             "explicit port preserved"
+        );
+    }
+}
+
+/// Whether a share the server advertised is one a user would browse.
+///
+/// `NetShareEnumAll` also reports the administrative plumbing — `IPC$`, the
+/// per-volume admin shares — which are not places to put files. The special
+/// bit (`0x8000_0000`) marks them, and the `$` suffix catches servers that
+/// don't set it; anything that isn't a disk tree (low bits non-zero) is a
+/// printer or a pipe.
+fn is_user_share(share_type: u32, name: &str) -> bool {
+    const SPECIAL: u32 = 0x8000_0000;
+    const TYPE_MASK: u32 = 0x0000_000F;
+    share_type & SPECIAL == 0 && share_type & TYPE_MASK == 0 && !name.ends_with('$')
+}
+
+/// The logical path a rename produces: `new_name` replaces the last component
+/// of `old_path`, which is what the FileStation `rename` contract means by a
+/// name rather than a path.
+fn sibling_path(old_path: &str, new_name: &str) -> String {
+    let trimmed = old_path.trim_end_matches('/');
+    match trimmed.rsplit_once('/') {
+        Some((parent, _)) if !parent.is_empty() => format!("{parent}/{new_name}"),
+        _ => format!("/{new_name}"),
+    }
+}
+
+/// Windows FILETIME → unix seconds, for the timestamps FileStation reports.
+fn unix_secs(t: smb2::pack::FileTime) -> i64 {
+    t.to_system_time()
+        .and_then(|st| st.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Build the `SynoFileInfo` a caller expects, so nothing downstream can tell
+/// whether SMB or the HTTP API answered.
+fn file_info(
+    name: &str,
+    path: &str,
+    isdir: bool,
+    size: u64,
+    mtime: i64,
+    crtime: i64,
+) -> SynoFileInfo {
+    SynoFileInfo {
+        name: name.to_string(),
+        path: path.to_string(),
+        isdir,
+        additional: Some(SynoAdditional {
+            size: Some(size),
+            owner: None,
+            time: Some(SynoTime {
+                atime: mtime,
+                mtime,
+                ctime: mtime,
+                crtime,
+            }),
+            perm: None,
+        }),
+        code: None,
+    }
+}
+
+#[async_trait]
+impl MetadataTransport for SmbTransport {
+    async fn list_shares(&self) -> Result<Vec<SynoFileInfo>, SynoFsError> {
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        // No share to attach for an enumeration, so reconnect handling is done
+        // by hand rather than through `ensure_ready`.
+        if self
+            .reconnect
+            .reconnect_if_needed(|| client.reconnect())
+            .await
+            .map_err(|e| self.mark_and_map(&e))?
+        {
+            trees.clear();
+        }
+        let shares = client
+            .list_shares()
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+        Ok(shares
+            .into_iter()
+            .filter(|s| is_user_share(s.share_type, &s.name))
+            .map(|s| {
+                let path = format!("/{}", s.name);
+                file_info(&s.name, &path, true, 0, 0, 0)
+            })
+            .collect())
+    }
+
+    async fn list_dir(&self, folder_path: &str) -> Result<Vec<SynoFileInfo>, SynoFsError> {
+        let loc = SmbPath::from_logical(folder_path)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        self.ensure_ready(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        let entries = client
+            .list_directory(tree, &loc.path)
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+
+        let base = folder_path.trim_end_matches('/');
+        Ok(entries
+            .into_iter()
+            // The dot entries are an SMB directory's own bookkeeping; a
+            // FileStation listing has never had them and readdir synthesises
+            // its own.
+            .filter(|e| e.name != "." && e.name != "..")
+            .map(|e| {
+                let path = format!("{base}/{}", e.name);
+                file_info(
+                    &e.name,
+                    &path,
+                    e.is_directory,
+                    e.size,
+                    unix_secs(e.modified),
+                    unix_secs(e.created),
+                )
+            })
+            .collect())
+    }
+
+    async fn get_info(&self, path: &str) -> Result<SynoFileInfo, SynoFsError> {
+        let loc = SmbPath::from_logical(path)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        self.ensure_ready(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        let info = client
+            .stat(tree, &loc.path)
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+        let name = path
+            .trim_end_matches('/')
+            .rsplit('/')
+            .next()
+            .unwrap_or(path);
+        Ok(file_info(
+            name,
+            path,
+            info.is_directory,
+            info.size,
+            unix_secs(info.modified),
+            unix_secs(info.created),
+        ))
+    }
+
+    async fn create_folder(&self, parent: &str, name: &str) -> Result<SynoFileInfo, SynoFsError> {
+        let full = format!("{}/{}", parent.trim_end_matches('/'), name);
+        let loc = SmbPath::from_logical(&full)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        self.ensure_ready(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        client
+            .create_directory(tree, &loc.path)
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+        Ok(file_info(name, &full, true, 0, 0, 0))
+    }
+
+    async fn rename(&self, old_path: &str, new_name: &str) -> Result<SynoFileInfo, SynoFsError> {
+        let from = SmbPath::from_logical(old_path)?;
+        let new_logical = sibling_path(old_path, new_name);
+        let to = SmbPath::from_logical(&new_logical)?;
+        // A rename is a tree-local operation; crossing shares would be a copy,
+        // which this is not.
+        if from.share != to.share {
+            return Err(SynoFsError::InvalidArg);
+        }
+
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        self.ensure_ready(client, trees, &from.share).await?;
+        let tree = trees.get_mut(&from.share).expect("tree just ensured");
+        client
+            .rename(tree, &from.path, &to.path)
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+
+        let info = client
+            .stat(tree, &to.path)
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+        Ok(file_info(
+            new_name,
+            &new_logical,
+            info.is_directory,
+            info.size,
+            unix_secs(info.modified),
+            unix_secs(info.created),
+        ))
+    }
+
+    async fn delete(&self, path: &str) -> Result<(), SynoFsError> {
+        let loc = SmbPath::from_logical(path)?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        self.ensure_ready(client, trees, &loc.share).await?;
+        let tree = trees.get_mut(&loc.share).expect("tree just ensured");
+        // SMB deletes files and directories through different calls, so ask
+        // first. FileStation's delete takes either.
+        let info = client
+            .stat(tree, &loc.path)
+            .await
+            .map_err(|e| self.mark_and_map(&e))?;
+        let done = if info.is_directory {
+            client.delete_directory(tree, &loc.path).await
+        } else {
+            client.delete_file(tree, &loc.path).await
+        };
+        done.map_err(|e| self.mark_and_map(&e))
+    }
+}
+
+#[cfg(test)]
+mod metadata_tests {
+    use super::*;
+
+    #[test]
+    fn administrative_shares_are_not_places_to_put_files() {
+        const DISK: u32 = 0;
+        const IPC: u32 = 3;
+        const SPECIAL: u32 = 0x8000_0000;
+
+        assert!(is_user_share(DISK, "fishsense_data"));
+        // IPC$ is the named-pipe endpoint the share enumeration itself rides on.
+        assert!(!is_user_share(IPC | SPECIAL, "IPC$"));
+        // Per-volume admin shares: flagged special, and named with a $.
+        assert!(!is_user_share(DISK | SPECIAL, "C$"));
+        // A server that forgets the special bit is still caught by the suffix.
+        assert!(!is_user_share(DISK, "ADMIN$"));
+        // Printers and pipes are not directories.
+        assert!(!is_user_share(1, "LaserJet"));
+    }
+
+    #[test]
+    fn rename_replaces_the_last_component_only() {
+        assert_eq!(
+            sibling_path("/share/dir/old.orf", "new.orf"),
+            "/share/dir/new.orf"
+        );
+        // A trailing slash is a directory being renamed, not a different path.
+        assert_eq!(sibling_path("/share/dir/", "renamed"), "/share/renamed");
+        // Renaming a share-level entry keeps it share-level.
+        assert_eq!(sibling_path("/share/file", "other"), "/share/other");
+    }
+
+    #[test]
+    fn a_windows_epoch_timestamp_becomes_unix_seconds() {
+        use std::time::{Duration, UNIX_EPOCH};
+        let when = UNIX_EPOCH + Duration::from_secs(1_786_315_083);
+        assert_eq!(
+            unix_secs(smb2::pack::FileTime::from_system_time(when)),
+            1_786_315_083
         );
     }
 }


### PR DESCRIPTION
**Stacked on #165** — base is `feat/smb-create-new`, so review that one first; this PR's diff is the second commit.

## The gap

`fs.rs` calls `list_dir`, `get_info`, `list_shares`, `create_folder`, `rename` and `delete`, and none of them had anywhere to go but FileStation — even with SMB connected and healthy. Every readdir and stat on the mount therefore went through `synoscgi`: the slower path, and the one that falls over under load.

#165 gave SMB the new-file write. This gives it the namespace.

## `MetadataTransport`

A third trait beside the byte-moving ones, because the capabilities really are separate — SMB serves all of it, while a bulk object store might only carry contents. **Every method defaults to `NotSupported`**, so a backend implements what it can promise and the selection layer quietly uses HTTP for the rest.

Selection reuses the rules the read/write paths already follow:

| outcome | behaviour |
|---|---|
| backend answers | that's the answer |
| transport failure | fall back to HTTP, count against the breaker |
| definitive answer (e.g. `NotFound` from a reachable backend) | propagate — no HTTP second opinion |
| declined (`NotSupported`) | fall back, breaker untouched |

It expands from a macro at the head of each method. The six operations differ in signature and return type, and an `async` closure over `&dyn Trait` buys lifetime grief for no gain.

## The SMB side

Returns the same `SynoFileInfo` the HTTP client does, so nothing downstream can tell which backend answered. Three decisions worth flagging:

- **Administrative shares are filtered from enumeration.** `NetShareEnumAll` reports `IPC$` and the per-volume `$` shares; they aren't places to put files. Matched on the special bit *and* the `$` suffix, since not every server sets the bit.
- **`.` and `..` are dropped from listings** — an SMB directory's own bookkeeping, which a FileStation listing has never carried and `readdir` synthesises anyway.
- **A rename that would cross shares is refused** rather than silently becoming a copy. SMB rename is tree-local.

`auto_attach` now registers the metadata transport alongside the others, so anything already using SMB picks this up with no call-site change.

## Tests

Four in core, red first (all four failed with the backend never consulted):

- `a_listing_prefers_the_metadata_backend` — served from an **offline** client, so only the backend could have answered.
- `a_listing_falls_back_to_http_when_the_backend_is_down`
- `a_definitive_answer_from_the_backend_is_not_second_guessed` — `NotFound` propagates and HTTP is never called.
- `an_operation_the_backend_declines_goes_to_http` — and the decline leaves the breaker shut, proven by a following listing still preferring the backend.

Three in the SMB crate for the pure helpers: admin-share filtering, rename replacing only the last component, and the FILETIME → unix-seconds conversion.

Workspace green (136 core, 19 SMB), fmt and clippy clean.

## Still to come

`fs.rs` doesn't know any of this yet — it talks to `SynologyClient`, which now prefers SMB automatically, so the mount gets the benefit without changes. What's left for SMB-first is the write path: offset writes (`create_file_writer_at`) so `write(2)` streams through with back-pressure instead of buffering to a spill file, and truncate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
