### PR TITLE
feat(smb): open a file for writing, at an offset

### DIFF
--- a/rust/synology-filestation-core/src/client.rs
+++ b/rust/synology-filestation-core/src/client.rs
@@ -5859,4 +5859,21 @@ mod tests {
         let entries = client.list_dir("/share").await.unwrap();
         assert_eq!(entries[0].name, "from-backend");
     }
+
+    #[tokio::test]
+    async fn a_backend_without_offset_writes_declines_to_open_one() {
+        // The trait default is what every non-SMB backend gets: opening a file
+        // for writing is refused outright, so a caller keeps buffering rather
+        // than discovering the gap halfway through a file.
+        use crate::transport::{OpenWriteTransport, WriteOpen};
+        struct Bulk;
+        impl OpenWriteTransport for Bulk {}
+
+        // `Box<dyn WriteHandle>` has no Debug, so unwrap_err is out.
+        match Bulk.open_write("/share/f.bin", WriteOpen::CreateNew).await {
+            Err(SynoFsError::NotSupported) => {}
+            Err(e) => panic!("expected a decline, got {e:?}"),
+            Ok(_) => panic!("a backend with no offset writes must not hand one out"),
+        }
+    }
 }

--- a/rust/synology-filestation-core/src/lib.rs
+++ b/rust/synology-filestation-core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod types;
 pub use client::{SynologyClient, ThrottleConfig};
 pub use error::SynoFsError;
 pub use transport::{
-    BreakerConfig, CircuitBreaker, MetadataTransport, ReadTransport, StreamReadTransport,
-    StreamWriteTransport, WriteTransport,
+    BreakerConfig, CircuitBreaker, MetadataTransport, OpenWriteTransport, ReadTransport,
+    StreamReadTransport, StreamWriteTransport, WriteHandle, WriteOpen, WriteTransport,
 };
 pub use types::{SynoAdditional, SynoFileInfo, SynoOwner, SynoPerm, SynoTime};

--- a/rust/synology-filestation-core/src/transport.rs
+++ b/rust/synology-filestation-core/src/transport.rs
@@ -160,6 +160,57 @@ pub trait MetadataTransport: Send + Sync {
     }
 }
 
+/// What opening a file for writing may create, and what it promises about a
+/// name that is already taken.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteOpen {
+    /// The file must not exist. An existing name is
+    /// [`SynoFsError::AlreadyExists`], never a silent replacement.
+    CreateNew,
+    /// Open what is there and keep it, creating the file only if it is absent.
+    /// Writes land at the offsets given; bytes outside them are untouched.
+    Existing,
+}
+
+/// A backend that can write **into an open file at arbitrary offsets**.
+///
+/// This is the difference between a mount that spools a 6 GB copy to a local
+/// spill file and ships it on `close(2)`, and one where each `write(2)` goes to
+/// the server as it arrives — bounded memory, back-pressure at network speed,
+/// and a write that fails when it fails rather than minutes later at close.
+///
+/// The HTTP FileStation API cannot do this at all: its upload takes a whole
+/// file, so the buffering is not a design choice there but a consequence. A
+/// backend that can address offsets implements this; the default declines and
+/// the caller keeps buffering.
+#[async_trait]
+pub trait OpenWriteTransport: Send + Sync {
+    async fn open_write(
+        &self,
+        path: &str,
+        mode: WriteOpen,
+    ) -> Result<Box<dyn WriteHandle>, SynoFsError> {
+        let _ = (path, mode);
+        Err(SynoFsError::NotSupported)
+    }
+}
+
+/// An open file being written. Dropping one without [`close`](Self::close)
+/// abandons whatever the server already has, so callers must close and check.
+///
+/// `Send` but not `Sync`: a handle is owned by whoever is writing to it, one
+/// task at a time. Requiring `Sync` would rule out backends whose writer holds
+/// an in-flight request — which is most of them.
+#[async_trait]
+pub trait WriteHandle: Send {
+    /// Place `data` at `offset`. Offsets need not be contiguous; a backend that
+    /// streams may pay a reopen when they jump.
+    async fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<(), SynoFsError>;
+
+    /// Finish. The server holds every byte written when this returns `Ok`.
+    async fn close(&mut self) -> Result<(), SynoFsError>;
+}
+
 /// Tuning for a backend's [`CircuitBreaker`].
 #[derive(Debug, Clone, Copy)]
 pub struct BreakerConfig {

--- a/rust/synology-filestation-smb/src/transport.rs
+++ b/rust/synology-filestation-smb/src/transport.rs
@@ -20,8 +20,9 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use smb2::{ClientConfig, SmbClient, Tree};
 use synology_filestation_core::{
-    MetadataTransport, ReadTransport, StreamReadTransport, StreamWriteTransport, SynoAdditional,
-    SynoFileInfo, SynoFsError, SynoTime, SynologyClient, WriteTransport,
+    MetadataTransport, OpenWriteTransport, ReadTransport, StreamReadTransport,
+    StreamWriteTransport, SynoAdditional, SynoFileInfo, SynoFsError, SynoTime, SynologyClient,
+    WriteHandle, WriteOpen, WriteTransport,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
@@ -276,11 +277,11 @@ struct Inner {
 
 /// An authenticated SMB connection that reads NAS files.
 pub struct SmbTransport {
-    inner: Mutex<Inner>,
+    inner: Arc<Mutex<Inner>>,
     /// Tracks whether the SMB link needs re-establishing. `smb2` doesn't
     /// auto-reconnect, so without this a mount would degrade to HTTP permanently
     /// after one network flap.
-    reconnect: ReconnectState,
+    reconnect: Arc<ReconnectState>,
 }
 
 impl SmbTransport {
@@ -300,11 +301,11 @@ impl SmbTransport {
         .await
         .map_err(|e| to_syno_error(&e))?;
         Ok(Self {
-            inner: Mutex::new(Inner {
+            inner: Arc::new(Mutex::new(Inner {
                 client,
                 trees: HashMap::new(),
-            }),
-            reconnect: ReconnectState::default(),
+            })),
+            reconnect: Arc::new(ReconnectState::default()),
         })
     }
 
@@ -1106,5 +1107,187 @@ mod metadata_tests {
             unix_secs(smb2::pack::FileTime::from_system_time(when)),
             1_786_315_083
         );
+    }
+}
+
+/// One open file being written over SMB.
+///
+/// The server has no notion of a "file position we hold": every write carries
+/// its own offset. What the handle carries instead is a writer *positioned* at
+/// the next offset it expects, because sequential appends — what a copy is —
+/// then cost one round trip each. A write that lands somewhere else closes that
+/// writer and opens another at the offset asked for, which is a reopen a
+/// sequential copy never pays.
+pub struct SmbWriteHandle {
+    inner: Arc<Mutex<Inner>>,
+    reconnect: Arc<ReconnectState>,
+    loc: SmbPath,
+    writer: Option<smb2::FileWriter>,
+    /// Where the open writer will put the next chunk.
+    next: u64,
+}
+
+impl SmbWriteHandle {
+    /// Open a writer at `offset`, replacing whatever this handle had.
+    ///
+    /// `FileOpenIf` is what makes this safe for an existing file: it opens what
+    /// is there and creates only when absent, so bytes outside the ones written
+    /// survive. An overwrite disposition here would quietly truncate a file the
+    /// caller only meant to patch.
+    async fn reopen_at(&mut self, offset: u64) -> Result<(), SynoFsError> {
+        self.finish_writer().await?;
+        let mut guard = self.inner.lock().await;
+        let Inner { client, trees } = &mut *guard;
+        ensure_share(client, trees, &self.reconnect, &self.loc.share).await?;
+        let tree = trees.get(&self.loc.share).expect("share just ensured");
+        let writer = client
+            .create_file_writer_at(tree, &self.loc.path, offset)
+            .await
+            .map_err(|e| map_smb_error(&self.reconnect, &e))?;
+        self.writer = Some(writer);
+        self.next = offset;
+        Ok(())
+    }
+
+    /// Close the open writer, if any, surfacing what the server said.
+    async fn finish_writer(&mut self) -> Result<(), SynoFsError> {
+        match self.writer.take() {
+            // `finish` reports the bytes it wrote; the caller tracks its own
+            // offsets, so only the failure matters here.
+            Some(w) => w
+                .finish()
+                .await
+                .map(|_| ())
+                .map_err(|e| map_smb_error(&self.reconnect, &e)),
+            None => Ok(()),
+        }
+    }
+}
+
+#[async_trait]
+impl WriteHandle for SmbWriteHandle {
+    async fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<(), SynoFsError> {
+        if needs_reopen(self.writer.is_some(), self.next, offset) {
+            self.reopen_at(offset).await?;
+        }
+        let writer = self.writer.as_mut().expect("writer just opened");
+        writer
+            .write_chunk(data)
+            .await
+            .map_err(|e| map_smb_error(&self.reconnect, &e))?;
+        self.next = offset + data.len() as u64;
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), SynoFsError> {
+        self.finish_writer().await
+    }
+}
+
+#[async_trait]
+impl OpenWriteTransport for SmbTransport {
+    async fn open_write(
+        &self,
+        path: &str,
+        mode: WriteOpen,
+    ) -> Result<Box<dyn WriteHandle>, SynoFsError> {
+        let loc = SmbPath::from_logical(path)?;
+        let mut handle = SmbWriteHandle {
+            inner: Arc::clone(&self.inner),
+            reconnect: Arc::clone(&self.reconnect),
+            loc: loc.clone(),
+            writer: None,
+            next: 0,
+        };
+
+        match mode {
+            // Create eagerly, so a name already taken is an error the caller
+            // gets from `open` — where `create(2)` can still report it — rather
+            // than from the first write.
+            WriteOpen::CreateNew => {
+                let mut guard = self.inner.lock().await;
+                let Inner { client, trees } = &mut *guard;
+                self.ensure_ready(client, trees, &loc.share).await?;
+                let tree = trees.get(&loc.share).expect("tree just ensured");
+                let writer = client
+                    .create_file_writer_exclusive(tree, &loc.path)
+                    .await
+                    .map_err(|e| self.mark_and_map(&e))?;
+                handle.writer = Some(writer);
+            }
+            // Nothing to do until the first write says where it goes: opening
+            // now would guess an offset and pay a reopen for guessing wrong.
+            WriteOpen::Existing => {}
+        }
+        Ok(Box::new(handle))
+    }
+}
+
+/// Whether the next write has to open a new writer.
+///
+/// Sequential appends — what copying a file into the mount is — keep the writer
+/// they have and cost one round trip per chunk. Anything that lands away from
+/// where the open writer sits has to reopen there, because SMB writes carry
+/// their own offset and the writer's is set when it opens.
+fn needs_reopen(has_writer: bool, next_offset: u64, write_offset: u64) -> bool {
+    !has_writer || write_offset != next_offset
+}
+
+/// `SmbTransport::ensure_ready` without a `&self`, for the write handle — which
+/// owns the pieces rather than the transport.
+async fn ensure_share(
+    client: &mut SmbClient,
+    trees: &mut HashMap<String, Tree>,
+    reconnect: &ReconnectState,
+    share: &str,
+) -> Result<(), SynoFsError> {
+    if reconnect
+        .reconnect_if_needed(|| client.reconnect())
+        .await
+        .map_err(|e| map_smb_error(reconnect, &e))?
+    {
+        trees.clear();
+    }
+    if !trees.contains_key(share) {
+        let tree = client
+            .connect_share(share)
+            .await
+            .map_err(|e| map_smb_error(reconnect, &e))?;
+        trees.insert(share.to_string(), tree);
+    }
+    Ok(())
+}
+
+/// `SmbTransport::mark_and_map` without a `&self`, for the same reason.
+fn map_smb_error(reconnect: &ReconnectState, e: &smb2::Error) -> SynoFsError {
+    reconnect.flag_if_lost(e.kind());
+    to_syno_error(e)
+}
+
+#[cfg(test)]
+mod write_handle_tests {
+    use super::*;
+
+    #[test]
+    fn a_sequential_copy_never_reopens() {
+        // The case that matters: chunk after chunk, each starting where the
+        // last ended. One open writer serves the whole file.
+        let mut next = 0u64;
+        for _ in 0..4 {
+            assert!(!needs_reopen(true, next, next), "offset {next} continued");
+            next += 1 << 20;
+        }
+    }
+
+    #[test]
+    fn the_first_write_opens_a_writer() {
+        assert!(needs_reopen(false, 0, 0));
+    }
+
+    #[test]
+    fn a_write_that_lands_elsewhere_reopens_there() {
+        // Seeking back to patch a header, and skipping forward past a hole.
+        assert!(needs_reopen(true, 4096, 0));
+        assert!(needs_reopen(true, 4096, 8192));
     }
 }


### PR DESCRIPTION
**Stacked on #167** (which is stacked on #165). Base is `feat/smb-metadata`; this PR's diff is the top commit.

## Why

The mount buffers every write to a local spill file and ships the whole thing on `close(2)`. That isn't really a design choice — it's a consequence of the HTTP Upload API taking a *file* rather than a *range*. There's nowhere to put a write until you have all of them. The cost:

- a 6 GB temp file for every 6 GB copy
- `write(2)` returns instantly whether or not the NAS can keep up, so the file manager's progress bar is fiction
- a failure surfaces minutes later, at close, when the user has moved on

SMB addresses ranges, so it can do better.

## The seam

`OpenWriteTransport::open_write(path, mode)` hands back a `WriteHandle`:

```rust
async fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<(), SynoFsError>;
async fn close(&mut self) -> Result<(), SynoFsError>;   // server has the bytes when this returns Ok
```

The default declines with `NotSupported`, so a backend that can only move whole files says so and the caller keeps buffering — same "declining isn't failing" rule as #165 and #167.

`WriteOpen::CreateNew` creates eagerly, so a name already taken is an error `create(2)` can still report; `WriteOpen::Existing` waits for the first write rather than guessing an offset and paying to be wrong.

## The SMB handle

It keeps a writer *positioned* where it expects the next chunk. Sequential appends — what a copy is — then cost one round trip each with no reopen. A write landing elsewhere closes that writer and opens another at the offset asked for.

Two details worth review attention:

- **`FileOpenIf`, not an overwrite disposition.** It opens what's there and creates only when absent, so bytes outside the write survive. An overwrite disposition would quietly truncate a file the caller only meant to patch.
- **`WriteHandle: Send`, not `Send + Sync`.** A handle belongs to whoever is writing to it, one task at a time. I had `Sync` at first and the compiler was right to object: `smb2::FileWriter` holds an in-flight request, so requiring `Sync` would exclude most real backends, including this one.

## Tests

The reopen rule is extracted as a pure function rather than left buried in a network call:

- `a_sequential_copy_never_reopens` — the case that matters, four chunks, one writer
- `the_first_write_opens_a_writer`
- `a_write_that_lands_elsewhere_reopens_there` — seeking back to patch a header, skipping forward past a hole
- `a_backend_without_offset_writes_declines_to_open_one` — the trait default

Workspace green (137 core, 22 SMB), fmt and clippy clean. The network-touching paths need a live server; they're exercised by the next PR's mount rather than mocked here.

## Not in this PR

`fs.rs` doesn't use it yet — that's the rewiring that lets `spill.rs` and the upload-on-close path come out, and it deserves its own review.

## Related finding: truncate can't be fixed the same way

`fs.rs` implements truncate as download-whole-file → resize → upload-whole-file, so shrinking a 6 GB file to 5 GB moves 11 GB. I went looking for the SMB equivalent and **`smb2 0.16.1` has no SetInfo/set-EOF call** — `EndOfFile` appears only in its directory-listing parser. It's a third-party crate (`github.com/vdavid/smb2`), so the options are an upstream PR adding SetInfo, or a workaround (truncate-to-zero via an overwriting create; grow by writing one byte at `new_size - 1`; shrink by rewriting the first `new_size` bytes). None of the workarounds is a real truncate, so I've left it alone rather than shipping an imitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
