### PR TITLE
build(smb): take smb2 from our fork, for the two SET_INFO ops it adds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,9 +2247,8 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smb2"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f68d69984762b69f4825a8d97b321e2831ad10449c4535a6f326abeaa11b0c9"
+version = "0.18.1"
+source = "git+https://github.com/UCSD-E4E/smb2?rev=b33283c9963cbef74c2b4a17faae4664980a0f9d#b33283c9963cbef74c2b4a17faae4664980a0f9d"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,18 @@ members = [
     "rust/synology-filestation-smb",
     "python/synology_filestation",
 ]
+
+# Our fork of `smb2`, pinned by revision.
+#
+# It carries two SET_INFO operations upstream does not have yet: a rename that
+# tells the server to replace the destination (so a published file is never
+# briefly absent, instead of the delete-then-rename dance that leaves a gap),
+# and `set_end_of_file`, which truncates in one round trip rather than making
+# the caller download a file, cut the tail off and write it all back.
+#
+# A `patch` rather than a `git` dependency so the crates named in each manifest
+# stay honest: when the changes land upstream, this block goes away and nothing
+# else moves. Pinned to a revision, never a branch — a build that can change
+# under you is not a build.
+[patch.crates-io]
+smb2 = { git = "https://github.com/UCSD-E4E/smb2", rev = "b33283c9963cbef74c2b4a17faae4664980a0f9d" }

--- a/rust/synology-filestation-smb/Cargo.toml
+++ b/rust/synology-filestation-smb/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 [dependencies]
 # Pure-Rust SMB2/3 client (no C deps): SMB3 + signing + AES encryption + NTLMv2,
 # validated against the AD-joined, SMB3-only e4e-nas.
-smb2 = "0.16"
+smb2 = "0.18"
 bytes = "1"
 tokio = { version = "1", features = ["rt", "sync", "macros", "time", "io-util", "fs"] }
 tracing = "0.1"


### PR DESCRIPTION
Points the workspace at [UCSD-E4E/smb2](https://github.com/UCSD-E4E/smb2), pinned to `b33283c9` (the merge of UCSD-E4E/smb2#2), for the two SET_INFO operations upstream doesn't have.

## Why

Upstream's SET_INFO can say exactly one thing — rename, with `ReplaceIfExists` hardcoded to `false` — and two things we need follow from that:

- **`commit_temp` can't publish a file under its final name in one step.** It moves the old file aside, renames the new one in, then deletes the backup: a sequence with a window where the name resolves to nothing, and a half-finished state to unwind if the process dies mid-swap. `RenameOptions { replace_if_exists }` hands the swap to the server.
- **Truncate has no class to use**, so `fs.rs` downloads the file, cuts the tail off locally and writes it all back — 11 GB of traffic to take a 6 GB file to 5 GB. `set_end_of_file` is one round trip regardless of size.

## Shape of the change

`[patch.crates-io]` rather than a `git` dependency, so each manifest keeps naming `smb2` honestly and the patch block simply disappears when the changes land upstream — no call sites move either way. Pinned to a **revision, not a branch**: a build that can change under you is not a build.

## What was verified

- `cargo build --workspace` — the **0.16 → 0.18 jump needed no code changes** on our side
- `cargo test --workspace` — green, unchanged (133 core + the rest)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -D warnings` — clean
- `nix build .#synology-filestation-fuse` — **crane vendors the git source with no extra hashes**, which was the real risk here; `Cargo.lock` records `git+https://github.com/UCSD-E4E/smb2?rev=b33283c9…`

## Supersedes #163

Dependabot's 0.16.1 → 0.18.1 bump is included here, since the fork is based on 0.18.1. #163 can be closed.

## Nothing uses it yet

Deliberately. Both call sites live in `rust/synology-filestation-smb/src/transport.rs`, which the SMB stack in review (#165 → #167 → #168) is already rewriting — landing them here would guarantee conflicts. Once that stack merges, two small follow-ups:

1. `commit_temp` becomes a single replacing rename, deleting the move-aside dance and its name-absent window.
2. `MetadataTransport::truncate` over `set_end_of_file`, so `fs.rs` stops moving two full file transfers to shrink a file by one byte.

Neither operation has a live-server test yet — worth doing against the NAS before the FUSE write path leans on them, especially since your notes record that the existing `write_atomic`/backup-rename path has never run against real DSM either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
